### PR TITLE
release: fix auto-updater 404 + chore commit

### DIFF
--- a/apps/api/src/__tests__/download.test.ts
+++ b/apps/api/src/__tests__/download.test.ts
@@ -13,7 +13,7 @@ vi.mock("../lib/storage-urls.js", () => ({
       "https://api.example.com/public/videos/login-bg-2.mp4",
     ],
   }),
-  getLatestVersion: vi.fn().mockResolvedValue({ version: "1.2.3", artifact: "releases/Brett-1.2.3.zip" }),
+  getLatestVersion: vi.fn().mockResolvedValue({ version: "1.2.3", artifact: "releases/Brett-1.2.3-mac.zip" }),
 }));
 
 describe("GET /download", () => {
@@ -39,8 +39,23 @@ describe("GET /download", () => {
   it("contains a download link pointing to the release proxy", async () => {
     const res = await app.request("/download");
     const html = await res.text();
-    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3.zip");
+    // electron-builder produces "Brett-{version}-mac.zip"; latest-mac.yml references
+    // that exact name, so the download link MUST match it or the auto-updater 404s.
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-mac.zip");
     expect(html).toContain("Download for macOS");
+  });
+
+  it("rejects poisoned artifact keys and falls back to a safe default", async () => {
+    const { getLatestVersion } = await import("../lib/storage-urls.js");
+    (getLatestVersion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      version: "1.2.3",
+      artifact: "releases/../../etc/passwd",
+    });
+
+    const res = await app.request("/download");
+    const html = await res.text();
+    expect(html).not.toContain("etc/passwd");
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-mac.zip");
   });
 
   it("contains video URLs in the script", async () => {

--- a/apps/api/src/routes/download.ts
+++ b/apps/api/src/routes/download.ts
@@ -17,11 +17,14 @@ download.get("/", async (c) => {
   const latest = await getLatestVersion();
   const version = latest.version;
   // artifact key from latest.json includes "releases/" prefix — strip it for the proxy URL
-  const rawKey = latest.artifact || latest.dmg || `releases/Brett-${version}.zip`;
+  const rawKey = latest.artifact || latest.dmg || `releases/Brett-${version}-mac.zip`;
   let filename = rawKey.replace(/^releases\//, "");
-  // Validate filename to prevent open redirect via poisoned latest.json
-  if (!/^Brett-[\d.]+\.(zip|dmg)$/.test(filename)) {
-    filename = `Brett-${version}.zip`;
+  // Validate filename to prevent open redirect via poisoned latest.json.
+  // Pattern matches electron-builder outputs: "Brett-X.Y.Z.zip", "Brett-X.Y.Z-mac.zip",
+  // "Brett-X.Y.Z-arm64-mac.dmg", etc. Must stay in sync with ALLOWED_RELEASE_PATTERNS
+  // in release-proxy.ts.
+  if (!/^Brett-[\d.]+(?:-[\w.]+)?\.(zip|dmg)$/.test(filename)) {
+    filename = `Brett-${version}-mac.zip`;
   }
 
   // Escape all interpolated values for safe HTML embedding

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,0 +1,1 @@
+expo-env.d.ts

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "setup": "pnpm install"
+  }
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -37,8 +37,9 @@ async function release() {
     throw new Error("latest-mac.yml not found in dist/. electron-builder may not have generated it.");
   }
 
-  // 4. Upload .dmg
-  const dmgKey = `releases/Brett-${version}.dmg`;
+  // 4. Upload artifact under its native electron-builder filename (e.g. "Brett-0.1.950-mac.zip").
+  // latest-mac.yml references this exact name + SHA512, so renaming on upload breaks the updater.
+  const dmgKey = `releases/${dmgFile}`;
   const dmgBody = fs.readFileSync(dmgPath);
   console.log(`\nUploading ${dmgFile} (${(dmgBody.length / 1024 / 1024).toFixed(1)} MB) → ${dmgKey}`);
   await s3.send(

--- a/scripts/upload-release.ts
+++ b/scripts/upload-release.ts
@@ -28,7 +28,6 @@ async function uploadRelease() {
     throw new Error(`Artifact "${artifactFile}" does not contain expected version "${version}". Stale build artifact?`);
   }
   const artifactPath = path.join(distDir, artifactFile);
-  const ext = path.extname(artifactFile);
 
   // Find latest-mac.yml (contains SHA512 hash — do not modify)
   const ymlPath = path.join(distDir, "latest-mac.yml");
@@ -36,8 +35,9 @@ async function uploadRelease() {
     throw new Error("latest-mac.yml not found in dist/.");
   }
 
-  // Upload artifact
-  const artifactKey = `releases/Brett-${version}${ext}`;
+  // Upload artifact under its native electron-builder filename (e.g. "Brett-0.1.950-mac.zip").
+  // latest-mac.yml references this exact name + SHA512, so renaming on upload breaks the updater.
+  const artifactKey = `releases/${artifactFile}`;
   const artifactBody = fs.readFileSync(artifactPath);
   console.log(`Uploading ${artifactFile} (${(artifactBody.length / 1024 / 1024).toFixed(1)} MB) → ${artifactKey}`);
   await releaseS3.send(
@@ -49,7 +49,7 @@ async function uploadRelease() {
       ACL: "public-read",
     })
   );
-  console.log(`  ✓ ${ext.slice(1).toUpperCase()} uploaded`);
+  console.log(`  ✓ ${path.extname(artifactFile).slice(1).toUpperCase()} uploaded`);
 
   // Upload latest-mac.yml
   const ymlKey = "releases/latest-mac.yml";


### PR DESCRIPTION
## Summary
- **fix(release): upload artifact under electron-builder's native filename** — the `latest-mac.yml` published by every release references `Brett-X.Y.Z-mac.zip` with an exact SHA512 hash, but the upload script was renaming the artifact to `Brett-X.Y.Z.zip` on S3 upload. Every auto-update download hit 404, the `update-downloaded` IPC never fired, and the in-app "update available" UI never surfaced. Fix: upload under the native filename so the yml and S3 key stay aligned. Applies to `scripts/upload-release.ts` (CI) and `scripts/release.ts` (local).
- Loosens the `/download` filename validator to accept the `-mac` suffix (kept in sync with `ALLOWED_RELEASE_PATTERNS` in `release-proxy.ts`) and adds a test that locks in the behavior.
- Also included: `chore: add Conductor config and gitignore Expo auto-generated file` (no-op on prod).

## Test plan
- [x] `pnpm --filter @brett/api typecheck` — clean
- [x] `pnpm --filter @brett/api exec vitest run src/__tests__/download.test.ts` — 12/12 pass (incl. new poisoned-key rejection test)
- [ ] After deploy: `curl https://api.brett.brentbarkman.com/releases/latest-mac.yml` should reference the new `-mac.zip` filename and `curl -I` on that URL should return 200
- [ ] Installed desktop app (current v0.1.950) should detect and download the new release on next startup, and show the update notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)