### PR TITLE
release: auto-update UI — install button + left-nav badge

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -189,7 +189,7 @@ export function App() {
   // Initialize SSE for real-time updates
   useEventStream();
   useTimezoneSync();
-  const { install: installUpdate } = useAutoUpdate();
+  const { install: installUpdate, updateReady } = useAutoUpdate();
 
   // Initialize diagnostics ring buffers for feedback
   useEffect(() => {
@@ -979,6 +979,7 @@ export function App() {
             onArchiveList={handleArchiveList}
             onUnarchiveList={(id) => unarchiveList.mutate(id)}
             hasBrokenConnections={(brokenConnections?.count ?? 0) > 0}
+            hasPendingUpdate={updateReady}
             onOpenSpotlight={() => {
               setSpotlightInitialAction("search");
               omnibar.open("spotlight");

--- a/packages/business/src/__tests__/business.test.ts
+++ b/packages/business/src/__tests__/business.test.ts
@@ -468,6 +468,21 @@ describe("itemToThing", () => {
   it("dueDate is undefined when null", () => {
     expect(itemToThing(makeItem(), NOW).dueDate).toBeUndefined();
   });
+
+  it("passes through sourceId for system:update tasks (drives the Install & Restart button)", () => {
+    const item = makeItem({ sourceId: "system:update" });
+    expect(itemToThing(item, NOW).sourceId).toBe("system:update");
+  });
+
+  it("passes through sourceId for relink:* tasks (drives the Reconnect button)", () => {
+    const item = makeItem({ sourceId: "relink:google_calendar" });
+    expect(itemToThing(item, NOW).sourceId).toBe("relink:google_calendar");
+  });
+
+  it("strips sourceId for non-whitelisted sources (avoids leaking internal ids to the UI)", () => {
+    const item = makeItem({ sourceId: "internal:some-pipeline-id" });
+    expect(itemToThing(item, NOW).sourceId).toBeUndefined();
+  });
 });
 
 // ── validateCreateItem ──

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -261,7 +261,13 @@ export function itemToThing(
       scoutId: item.sourceId,
       scoutName: item.scoutName ?? undefined,
     }),
-    ...(item.source === "system" && item.sourceId?.startsWith("relink:") && {
+    // sourceId is passed through to the frontend only for system items the UI
+    // branches on: "relink:*" (reconnect broken integrations) and "system:update"
+    // (show "Install & Restart" button on the auto-update task).
+    ...(item.sourceId && (
+      item.sourceId.startsWith("relink:") ||
+      item.sourceId === "system:update"
+    ) && {
       sourceId: item.sourceId,
     }),
     ...(item.type === "content" && {

--- a/packages/ui/src/LeftNav.tsx
+++ b/packages/ui/src/LeftNav.tsx
@@ -43,6 +43,8 @@ interface LeftNavProps {
   onOpenSpotlight?: () => void;
   /** Show amber dot on settings when integrations are broken */
   hasBrokenConnections?: boolean;
+  /** Show amber dot on settings when an auto-update is downloaded and ready to install */
+  hasPendingUpdate?: boolean;
   assistantName?: string;
   isAIWorking?: boolean;
 }
@@ -65,6 +67,7 @@ export function LeftNav({
   archivedLists,
   onOpenSpotlight,
   hasBrokenConnections,
+  hasPendingUpdate,
   assistantName,
   isAIWorking,
 }: LeftNavProps) {
@@ -265,7 +268,7 @@ export function LeftNav({
                     </span>
                   </div>
                 )}
-                {hasBrokenConnections && (
+                {(hasBrokenConnections || hasPendingUpdate) && (
                   <div className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-amber-400 border-2 border-black/50" />
                 )}
               </div>


### PR DESCRIPTION
## Summary
Two follow-ups to the auto-updater 404 fix that just deployed:

- **Install & Restart button never rendered on the update task.** \`itemToThing()\` was whitelisting only \`relink:*\` sourceIds for passthrough to the frontend, so the \"system:update\" sourceId was silently stripped and the button in \`ThingCard\`/\`InboxItemRow\` — which keys off \`thing.sourceId === \"system:update\"\` — always evaluated to false. Extended the whitelist in \`packages/business/src/index.ts\`. Locked in with 3 new tests in \`business.test.ts\`.
- **Left-nav Settings button wasn't badged for pending updates.** The Updates tab inside Settings got an amber dot (via \`SettingsLayout.tsx:154\`), but the top-level Settings icon in \`LeftNav\` only considered broken integrations — so users had to already be inside Settings to know there was anything to see. Added \`hasPendingUpdate\` prop to \`LeftNav\`; combined with \`hasBrokenConnections\` for the existing amber dot.

Separately, one lingering issue this doesn't address: \`electron-updater\` refuses to install unsigned macOS builds (\`Could not get code signature for running application\`). So after this PR, you'll see the button and it'll fail silently on click — a reminder to wire up signing/notarization in CI. Out of scope here.

## Test plan
- [x] \`pnpm --filter @brett/business exec vitest\` — 135/135 pass (3 new sourceId tests)
- [x] Typecheck clean for \`@brett/api\`, \`@brett/desktop\`, \`@brett/ui\`, \`@brett/business\`, \`@brett/api-core\`
- [ ] After deploy: launch Brett with a pending update and confirm (a) left-nav avatar has amber dot, (b) Today task shows \"Install &amp; Restart\" button, (c) button clicks through to install attempt (will fail silently until signing is fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)