### PR TITLE
Release: drop drive.metadata.readonly scope

### DIFF
--- a/apps/api/prisma/migrations/20260414120000_rename_has_drive_scope_and_drop_drive_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20260414120000_rename_has_drive_scope_and_drop_drive_metadata/migration.sql
@@ -1,0 +1,6 @@
+-- Rename GoogleAccount.hasDriveScope → hasMeetingNotesScope.
+-- The column previously tracked whether both drive.metadata.readonly and documents.readonly
+-- scopes were granted. We're dropping the restricted drive.metadata.readonly scope (it blocks
+-- publishing without CASA audit). The column now tracks only documents.readonly — which is
+-- all we need since Calendar event.attachments[] provides the fileId directly.
+ALTER TABLE "GoogleAccount" RENAME COLUMN "hasDriveScope" TO "hasMeetingNotesScope";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -287,8 +287,8 @@ model GoogleAccount {
   tokenExpiresAt  DateTime
   connectedAt     DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
-  hasDriveScope       Boolean   @default(false)
-  meetingNotesEnabled Boolean   @default(true)
+  hasMeetingNotesScope Boolean   @default(false)
+  meetingNotesEnabled  Boolean   @default(true)
 
   calendars       CalendarList[]
   events          CalendarEvent[]

--- a/apps/api/src/__tests__/google-drive.test.ts
+++ b/apps/api/src/__tests__/google-drive.test.ts
@@ -1,25 +1,50 @@
 import { describe, it, expect } from "vitest";
-import { escapeDriveQuery, parseTranscriptDoc, parseMeetingNotesDoc } from "../lib/google-drive.js";
+import { pickMeetArtifacts, parseTranscriptDoc, parseMeetingNotesDoc } from "../lib/google-drive.js";
 
-describe("escapeDriveQuery", () => {
-  it("escapes single quotes", () => {
-    expect(escapeDriveQuery("Alice's 1:1")).toBe("Alice\\'s 1:1");
+describe("pickMeetArtifacts", () => {
+  it("returns nulls when attachments is null", () => {
+    expect(pickMeetArtifacts(null)).toEqual({ transcriptFileId: null, notesFileId: null });
   });
 
-  it("handles multiple quotes", () => {
-    expect(escapeDriveQuery("it's Bob's meeting")).toBe("it\\'s Bob\\'s meeting");
+  it("returns nulls when attachments is empty", () => {
+    expect(pickMeetArtifacts([])).toEqual({ transcriptFileId: null, notesFileId: null });
   });
 
-  it("passes through clean strings", () => {
-    expect(escapeDriveQuery("Weekly Standup")).toBe("Weekly Standup");
+  it("picks transcript by title prefix and notes as the other Doc", () => {
+    const attachments = [
+      { fileId: "1AaBbCcDdEeFfGgHhIiJjKkLlMmNn", title: "Meeting notes", mimeType: "application/vnd.google-apps.document" },
+      { fileId: "2ZzYyXxWwVvUuTtSsRrQqPpOoNnMm", title: "Transcript — Weekly Sync", mimeType: "application/vnd.google-apps.document" },
+    ];
+    expect(pickMeetArtifacts(attachments)).toEqual({
+      transcriptFileId: "2ZzYyXxWwVvUuTtSsRrQqPpOoNnMm",
+      notesFileId: "1AaBbCcDdEeFfGgHhIiJjKkLlMmNn",
+    });
   });
 
-  it("escapes backslashes", () => {
-    expect(escapeDriveQuery("path\\to\\file")).toBe("path\\\\to\\\\file");
+  it("ignores non-Doc mime types", () => {
+    const attachments = [
+      { fileId: "1AaBbCcDdEeFfGgHhIiJjKkLlMmNn", title: "Slides", mimeType: "application/vnd.google-apps.presentation" },
+    ];
+    expect(pickMeetArtifacts(attachments)).toEqual({ transcriptFileId: null, notesFileId: null });
   });
 
-  it("escapes both backslashes and single quotes", () => {
-    expect(escapeDriveQuery("Alice\\'s file")).toBe("Alice\\\\\\'s file");
+  it("rejects malformed file IDs", () => {
+    const attachments = [
+      { fileId: "short", title: "Meeting notes", mimeType: "application/vnd.google-apps.document" },
+      { fileId: "contains/slash/bad", title: "Transcript", mimeType: "application/vnd.google-apps.document" },
+    ];
+    expect(pickMeetArtifacts(attachments)).toEqual({ transcriptFileId: null, notesFileId: null });
+  });
+
+  it("keeps the first notes doc if multiple non-transcript Docs are attached", () => {
+    const attachments = [
+      { fileId: "1AaBbCcDdEeFfGgHhIiJjKkLlMmNn", title: "Meeting notes", mimeType: "application/vnd.google-apps.document" },
+      { fileId: "3QqRrSsTtUuVvWwXxYyZzAaBbCcDd", title: "Agenda", mimeType: "application/vnd.google-apps.document" },
+    ];
+    expect(pickMeetArtifacts(attachments)).toEqual({
+      transcriptFileId: null,
+      notesFileId: "1AaBbCcDdEeFfGgHhIiJjKkLlMmNn",
+    });
   });
 });
 
@@ -69,12 +94,6 @@ describe("parseMeetingNotesDoc", () => {
 
   it("returns empty string for empty content", () => {
     expect(parseMeetingNotesDoc([])).toBe("");
-  });
-});
-
-describe("escapeDriveQuery (extended)", () => {
-  it("escapes backslashes before single quotes", () => {
-    expect(escapeDriveQuery("path\\to\\'file")).toBe("path\\\\to\\\\\\'file");
   });
 });
 

--- a/apps/api/src/jobs/cron.ts
+++ b/apps/api/src/jobs/cron.ts
@@ -172,7 +172,7 @@ export function startCronJobs(): void {
 
       const [granolaUsers, googleUsers] = await Promise.all([
         prisma.granolaAccount.findMany({ select: { userId: true } }),
-        prisma.googleAccount.findMany({ where: { hasDriveScope: true }, select: { userId: true } }),
+        prisma.googleAccount.findMany({ where: { hasMeetingNotesScope: true }, select: { userId: true } }),
       ]);
 
       const userIds = [...new Set([

--- a/apps/api/src/lib/google-calendar.ts
+++ b/apps/api/src/lib/google-calendar.ts
@@ -17,7 +17,6 @@ const BASE_SCOPES = [
 ];
 
 const MEETING_NOTES_SCOPES = [
-  "https://www.googleapis.com/auth/drive.metadata.readonly",
   "https://www.googleapis.com/auth/documents.readonly",
 ];
 

--- a/apps/api/src/lib/google-drive.ts
+++ b/apps/api/src/lib/google-drive.ts
@@ -1,4 +1,4 @@
-import { google, type drive_v3, type docs_v1 } from "googleapis";
+import { google, type docs_v1 } from "googleapis";
 import { decryptToken, encryptToken } from "./encryption.js";
 import { prisma } from "./prisma.js";
 import type { MeetingTranscriptTurn } from "@brett/types";
@@ -46,16 +46,8 @@ function getAuthenticatedOAuth2Client(account: GoogleAccountInfo) {
   return oauth2Client;
 }
 
-export function getDriveClient(account: GoogleAccountInfo): drive_v3.Drive {
-  return google.drive({ version: "v3", auth: getAuthenticatedOAuth2Client(account) });
-}
-
 export function getDocsClient(account: GoogleAccountInfo): docs_v1.Docs {
   return google.docs({ version: "v1", auth: getAuthenticatedOAuth2Client(account) });
-}
-
-export function escapeDriveQuery(input: string): string {
-  return input.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
 const DRIVE_FILE_ID_RE = /^[a-zA-Z0-9_\-]{10,60}$/;
@@ -65,13 +57,18 @@ export interface DocParagraph {
   text: string;
 }
 
-export async function findMeetArtifacts(
-  driveClient: drive_v3.Drive,
+/**
+ * Pick transcript + notes Doc IDs from a Calendar event's attachments[].
+ *
+ * Google Meet attaches the transcript and notes Docs to the Calendar event post-meeting
+ * (typically 5-30 min after the meeting ends; Calendar webhooks notify us when they arrive).
+ * We used to also fall back to a Drive API search by filename — that required the restricted
+ * drive.metadata.readonly scope. Dropped so the app stays on sensitive-tier scopes only and
+ * can be published without a CASA security audit. The attachment path covers the ~99% case.
+ */
+export function pickMeetArtifacts(
   attachments: Array<{ fileId?: string; title?: string; mimeType?: string }> | null,
-  eventTitle: string,
-  eventStart: Date,
-  eventEnd: Date,
-): Promise<{ transcriptFileId: string | null; notesFileId: string | null }> {
+): { transcriptFileId: string | null; notesFileId: string | null } {
   let transcriptFileId: string | null = null;
   let notesFileId: string | null = null;
 
@@ -85,39 +82,6 @@ export async function findMeetArtifacts(
       } else if (!notesFileId) {
         notesFileId = att.fileId;
       }
-    }
-  }
-
-  if (!transcriptFileId || !notesFileId) {
-    const searchStart = new Date(eventStart.getTime() - 60 * 60 * 1000);
-    const searchEnd = new Date(eventEnd.getTime() + 2 * 60 * 60 * 1000);
-    const escaped = escapeDriveQuery(eventTitle);
-
-    try {
-      const res = await driveClient.files.list({
-        q: `mimeType='application/vnd.google-apps.document' and name contains '${escaped}' and (name contains 'Transcript' or name contains 'Meeting notes') and createdTime > '${searchStart.toISOString()}' and createdTime < '${searchEnd.toISOString()}'`,
-        fields: "files(id,name,createdTime)",
-        pageSize: 10,
-      });
-
-      const files = res.data.files ?? [];
-      files.sort((a, b) => {
-        const aTime = a.createdTime ? Math.abs(new Date(a.createdTime).getTime() - eventEnd.getTime()) : Infinity;
-        const bTime = b.createdTime ? Math.abs(new Date(b.createdTime).getTime() - eventEnd.getTime()) : Infinity;
-        return aTime - bTime;
-      });
-
-      for (const file of files) {
-        if (!file.id) continue;
-        const name = (file.name ?? "").toLowerCase();
-        if (!transcriptFileId && name.startsWith("transcript")) {
-          transcriptFileId = file.id;
-        } else if (!notesFileId) {
-          notesFileId = file.id;
-        }
-      }
-    } catch (err) {
-      console.warn("[google-drive] Drive search failed:", err);
     }
   }
 

--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -56,7 +56,7 @@ calendarAccounts.get("/", async (c) => {
       id: a.id,
       googleEmail: a.googleEmail,
       connectedAt: a.connectedAt.toISOString(),
-      hasDriveScope: a.hasDriveScope,
+      hasMeetingNotesScope: a.hasMeetingNotesScope,
       meetingNotesEnabled: a.meetingNotesEnabled,
       calendars: a.calendars.map((cal) => ({
         id: cal.id,
@@ -140,9 +140,9 @@ calendarAccounts.get("/callback", async (c) => {
     });
   }
 
-  const hasDriveScope =
-    grantedScopes.includes("https://www.googleapis.com/auth/drive.metadata.readonly") &&
-    grantedScopes.includes("https://www.googleapis.com/auth/documents.readonly");
+  const hasMeetingNotesScope = grantedScopes.includes(
+    "https://www.googleapis.com/auth/documents.readonly",
+  );
 
   // Get Google user info
   const oauth2Client = new google.auth.OAuth2();
@@ -175,8 +175,8 @@ calendarAccounts.get("/callback", async (c) => {
       tokenExpiresAt: tokens.expiry_date
         ? new Date(tokens.expiry_date)
         : new Date(Date.now() + 3600 * 1000),
-      hasDriveScope,
-      meetingNotesEnabled: hasDriveScope,
+      hasMeetingNotesScope,
+      meetingNotesEnabled: hasMeetingNotesScope,
     },
     update: {
       googleEmail,
@@ -185,7 +185,7 @@ calendarAccounts.get("/callback", async (c) => {
       tokenExpiresAt: tokens.expiry_date
         ? new Date(tokens.expiry_date)
         : new Date(Date.now() + 3600 * 1000),
-      hasDriveScope,
+      hasMeetingNotesScope,
       // Don't override meetingNotesEnabled on reauth — preserve user's choice
     },
   });
@@ -200,8 +200,8 @@ calendarAccounts.get("/callback", async (c) => {
     console.error(`[calendar-accounts] Initial sync failed for account ${account.id}:`, err);
   });
 
-  // If Drive/Docs scopes were granted, trigger Google Meet initial sync
-  if (hasDriveScope) {
+  // If the Docs scope was granted, trigger Google Meet initial sync
+  if (hasMeetingNotesScope) {
     import("../services/meeting-providers/registry.js").then(({ meetingCoordinator }) => {
       meetingCoordinator.initialSync(user.id, "google_meet").catch((err) =>
         console.error("[calendar-accounts] Google Meet initial sync failed:", err),
@@ -249,9 +249,9 @@ calendarAccounts.patch("/:accountId/meeting-notes", async (c) => {
     return c.json({ error: "enabled must be a boolean" }, 400);
   }
 
-  // Can't enable meeting notes without Drive scopes — client should trigger reauth
-  if (body.enabled && !account.hasDriveScope) {
-    return c.json({ error: "Drive scopes not granted. Re-authenticate to enable meeting notes." }, 409);
+  // Can't enable meeting notes without the Docs scope — client should trigger reauth
+  if (body.enabled && !account.hasMeetingNotesScope) {
+    return c.json({ error: "Docs scope not granted. Re-authenticate to enable meeting notes." }, 409);
   }
 
   const updated = await prisma.googleAccount.update({

--- a/apps/api/src/services/meeting-providers/google-meet-provider.ts
+++ b/apps/api/src/services/meeting-providers/google-meet-provider.ts
@@ -3,9 +3,8 @@ import type { MeetingNoteProvider, ProviderMeetingData } from "./types.js";
 import type { MeetingNoteAttendee } from "@brett/types";
 import { prisma } from "../../lib/prisma.js";
 import {
-  getDriveClient,
   getDocsClient,
-  findMeetArtifacts,
+  pickMeetArtifacts,
   readDocContent,
   parseTranscriptDoc,
   parseMeetingNotesDoc,
@@ -16,7 +15,7 @@ export class GoogleMeetProvider implements MeetingNoteProvider {
 
   async isAvailable(userId: string): Promise<boolean> {
     const account = await prisma.googleAccount.findFirst({
-      where: { userId, hasDriveScope: true, meetingNotesEnabled: true },
+      where: { userId, hasMeetingNotesScope: true, meetingNotesEnabled: true },
       orderBy: { connectedAt: "desc" },
       select: { id: true },
     });
@@ -29,7 +28,7 @@ export class GoogleMeetProvider implements MeetingNoteProvider {
   ): Promise<ProviderMeetingData | null> {
     // Security: always include userId in account lookup
     const account = await prisma.googleAccount.findFirst({
-      where: { userId, hasDriveScope: true, meetingNotesEnabled: true },
+      where: { userId, hasMeetingNotesScope: true, meetingNotesEnabled: true },
       orderBy: { connectedAt: "desc" },
     });
     if (!account) return null;
@@ -37,7 +36,6 @@ export class GoogleMeetProvider implements MeetingNoteProvider {
     // Only process events with a Google Meet link
     if (!calendarEvent.meetingLink?.includes("meet.google.com")) return null;
 
-    const driveClient = getDriveClient(account);
     const docsClient = getDocsClient(account);
 
     // CalendarEvent.attachments is Json? — validate before casting
@@ -45,13 +43,7 @@ export class GoogleMeetProvider implements MeetingNoteProvider {
       ? calendarEvent.attachments as unknown as Array<{ fileId?: string; title?: string; mimeType?: string }>
       : null;
 
-    const { transcriptFileId, notesFileId } = await findMeetArtifacts(
-      driveClient,
-      attachments,
-      calendarEvent.title,
-      calendarEvent.startTime,
-      calendarEvent.endTime,
-    );
+    const { transcriptFileId, notesFileId } = pickMeetArtifacts(attachments);
 
     if (!transcriptFileId && !notesFileId) return null;
 
@@ -112,7 +104,7 @@ export class GoogleMeetProvider implements MeetingNoteProvider {
     until: Date,
   ): Promise<ProviderMeetingData[]> {
     const account = await prisma.googleAccount.findFirst({
-      where: { userId, hasDriveScope: true, meetingNotesEnabled: true },
+      where: { userId, hasMeetingNotesScope: true, meetingNotesEnabled: true },
       orderBy: { connectedAt: "desc" },
     });
     if (!account) return [];

--- a/apps/desktop/src/settings/CalendarSection.tsx
+++ b/apps/desktop/src/settings/CalendarSection.tsx
@@ -128,15 +128,15 @@ function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <span className="text-xs text-white/60">Meeting notes</span>
-            {!account.hasDriveScope && (
+            {!account.hasMeetingNotesScope && (
               <span className="text-[10px] text-brett-gold/60">Requires permissions</span>
             )}
           </div>
           <SettingsToggle
-            checked={account.hasDriveScope && account.meetingNotesEnabled}
+            checked={account.hasMeetingNotesScope && account.meetingNotesEnabled}
             onChange={() => {
-              if (!account.hasDriveScope) {
-                // No Drive scope — trigger reauth to get it
+              if (!account.hasMeetingNotesScope) {
+                // No Docs scope — trigger reauth to get it
                 reauthCalendar.mutate(account.id);
               } else {
                 // Has scope — toggle locally

--- a/packages/types/src/calendar.ts
+++ b/packages/types/src/calendar.ts
@@ -123,7 +123,7 @@ export interface ConnectedCalendarAccount {
   id: string;
   googleEmail: string;
   connectedAt: string;
-  hasDriveScope: boolean;
+  hasMeetingNotesScope: boolean;
   meetingNotesEnabled: boolean;
   calendars: CalendarListRecord[];
 }


### PR DESCRIPTION
## Summary
- Removes the restricted `drive.metadata.readonly` Google OAuth scope from the meeting-notes flow. All remaining scopes are sensitive-tier — no CASA audit needed for publish.
- Meeting-notes ingestion now relies solely on Calendar `event.attachments[]` (populated by Google Meet post-meeting, delivered via Calendar webhooks). Drive fallback search removed.
- Renames `GoogleAccount.hasDriveScope` → `hasMeetingNotesScope` (single-step column rename — no users on this column in prod yet).

## Deploy sequence
This PR's migration does `ALTER TABLE ... RENAME COLUMN` — runs automatically on deploy per the standard Dockerfile `CMD`.

**After this PR merges and deploys succeed, still to do in GCP Console:**
1. APIs & Services → OAuth consent screen → Data access → remove `https://www.googleapis.com/auth/drive.metadata.readonly` from the scope list.
2. APIs & Services → Library → disable Google Drive API (hygiene).

Order matters — the code must ship first, otherwise users mid-flow would see scope-mismatch errors.

## Test plan
- [x] `pnpm typecheck` — all 18 packages clean
- [x] `pnpm test` — 563 tests pass, 14 skipped
- [x] New `pickMeetArtifacts` unit tests cover: empty attachments, transcript/notes picking by title prefix, non-Doc mime rejection, malformed file ID rejection, multi-notes first-wins
- [ ] After deploy: reconnect calendar in prod, confirm OAuth prompt no longer requests Drive metadata
- [ ] After deploy: attach a Google Meet to a test event, verify meeting notes still ingest via Calendar webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)