### PR TITLE
feat(download): per-arch Apple Silicon + Intel buttons

### DIFF
--- a/apps/api/src/__tests__/download.test.ts
+++ b/apps/api/src/__tests__/download.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { app } from "../app.js";
 
 // Mock the storage-urls module so tests don't need S3
@@ -13,7 +13,14 @@ vi.mock("../lib/storage-urls.js", () => ({
       "https://api.example.com/public/videos/login-bg-2.mp4",
     ],
   }),
-  getLatestVersion: vi.fn().mockResolvedValue({ version: "1.2.3", artifact: "releases/Brett-1.2.3-mac.zip" }),
+  getLatestVersion: vi.fn().mockResolvedValue({
+    version: "1.2.3",
+    downloads: {
+      arm64: "releases/Brett-1.2.3-arm64.dmg",
+      x64: "releases/Brett-1.2.3-x64.dmg",
+    },
+    artifact: "releases/Brett-1.2.3-arm64.dmg",
+  }),
 }));
 
 describe("GET /download", () => {
@@ -36,26 +43,62 @@ describe("GET /download", () => {
     expect(html).toContain("v1.2.3");
   });
 
-  it("contains a download link pointing to the release proxy", async () => {
+  it("renders both Apple Silicon and Intel download buttons", async () => {
     const res = await app.request("/download");
     const html = await res.text();
-    // electron-builder produces "Brett-{version}-mac.zip"; latest-mac.yml references
-    // that exact name, so the download link MUST match it or the auto-updater 404s.
-    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-mac.zip");
-    expect(html).toContain("Download for macOS");
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-arm64.dmg");
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-x64.dmg");
+    expect(html).toContain("Apple Silicon");
+    expect(html).toContain("Intel");
   });
 
   it("rejects poisoned artifact keys and falls back to a safe default", async () => {
     const { getLatestVersion } = await import("../lib/storage-urls.js");
     (getLatestVersion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       version: "1.2.3",
-      artifact: "releases/../../etc/passwd",
+      downloads: {
+        arm64: "releases/../../etc/passwd",
+        x64: "releases/../../etc/shadow",
+      },
     });
 
     const res = await app.request("/download");
     const html = await res.text();
     expect(html).not.toContain("etc/passwd");
+    expect(html).not.toContain("etc/shadow");
+    // Falls back to the per-arch default filenames the uploader produces.
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-arm64.dmg");
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-x64.dmg");
+  });
+
+  it("falls back to legacy artifact field when downloads map is missing", async () => {
+    const { getLatestVersion } = await import("../lib/storage-urls.js");
+    (getLatestVersion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      version: "1.2.3",
+      artifact: "releases/Brett-1.2.3-mac.zip",
+    });
+
+    const res = await app.request("/download");
+    const html = await res.text();
+    // Arm64 button reads the legacy artifact, x64 falls back to default per-arch name.
     expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-mac.zip");
+    expect(html).toContain("https://api.example.com/releases/Brett-1.2.3-x64.dmg");
+  });
+
+  it("accepts multi-segment arch suffixes like -arm64-mac", async () => {
+    const { getLatestVersion } = await import("../lib/storage-urls.js");
+    (getLatestVersion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      version: "1.2.3",
+      downloads: {
+        arm64: "releases/Brett-1.2.3-arm64-mac.zip",
+        x64: "releases/Brett-1.2.3-x64-mac.zip",
+      },
+    });
+
+    const res = await app.request("/download");
+    const html = await res.text();
+    expect(html).toContain("Brett-1.2.3-arm64-mac.zip");
+    expect(html).toContain("Brett-1.2.3-x64-mac.zip");
   });
 
   it("contains video URLs in the script", async () => {
@@ -74,7 +117,10 @@ describe("GET /download", () => {
     const { getLatestVersion } = await import("../lib/storage-urls.js");
     (getLatestVersion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       version: '<script>alert("xss")</script>',
-      artifact: "releases/Brett-evil.zip",
+      downloads: {
+        arm64: "releases/Brett-evil.zip",
+        x64: "releases/Brett-evil.zip",
+      },
     });
 
     const res = await app.request("/download");

--- a/apps/api/src/__tests__/release-proxy.test.ts
+++ b/apps/api/src/__tests__/release-proxy.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { app } from "../app.js";
+
+// Tests exercise the whitelist, not real S3. With storage unconfigured,
+// allowed patterns short-circuit to 503 and disallowed patterns get 404
+// from the whitelist check — both are observable without network.
+
+describe("GET /releases/*", () => {
+  let originalEndpoint: string | undefined;
+  let originalStorageEndpoint: string | undefined;
+
+  beforeEach(() => {
+    originalEndpoint = process.env.RELEASE_STORAGE_ENDPOINT;
+    originalStorageEndpoint = process.env.STORAGE_ENDPOINT;
+    delete process.env.RELEASE_STORAGE_ENDPOINT;
+    delete process.env.STORAGE_ENDPOINT;
+  });
+
+  afterEach(() => {
+    if (originalEndpoint !== undefined) process.env.RELEASE_STORAGE_ENDPOINT = originalEndpoint;
+    if (originalStorageEndpoint !== undefined) process.env.STORAGE_ENDPOINT = originalStorageEndpoint;
+  });
+
+  describe("whitelist — disallowed paths", () => {
+    it("rejects path traversal with ..", async () => {
+      const res = await app.request("/releases/../../etc/passwd");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects URL-encoded traversal", async () => {
+      // Hono decodes the path before the handler sees it, so %2E%2E
+      // becomes .. and gets caught by the same traversal check.
+      const res = await app.request("/releases/%2E%2E/etc/passwd");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects non-whitelisted filenames", async () => {
+      const res = await app.request("/releases/random.txt");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects executable extensions", async () => {
+      const res = await app.request("/releases/Brett-1.2.3.exe");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects shell scripts", async () => {
+      const res = await app.request("/releases/Brett-1.2.3.sh");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects nested paths", async () => {
+      const res = await app.request("/releases/nested/Brett-1.2.3.dmg");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects arbitrary filenames that start with Brett but miss the version", async () => {
+      const res = await app.request("/releases/Brett-evil.dmg");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects empty key", async () => {
+      const res = await app.request("/releases/");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("whitelist — allowed patterns (short-circuit to 503 when unconfigured)", () => {
+    // All these should pass the whitelist. Without storage configured they
+    // short-circuit to 503 instead of hitting S3. Anything other than 503
+    // means the whitelist rejected them — a regression.
+
+    it.each([
+      "Brett-1.2.3.dmg",
+      "Brett-0.1.950.dmg",
+      "Brett-1.2.3-arm64.dmg",
+      "Brett-1.2.3-x64.dmg",
+      "Brett-1.2.3-mac.zip",
+      "Brett-1.2.3-arm64-mac.zip",
+      "Brett-1.2.3-x64-mac.zip",
+    ])("allows %s", async (filename) => {
+      const res = await app.request(`/releases/${filename}`);
+      expect(res.status).toBe(503);
+    });
+
+    it("allows latest-mac.yml", async () => {
+      const res = await app.request("/releases/latest-mac.yml");
+      expect(res.status).toBe(503);
+    });
+
+    it("allows latest.json", async () => {
+      const res = await app.request("/releases/latest.json");
+      expect(res.status).toBe(503);
+    });
+  });
+});

--- a/apps/api/src/lib/storage-urls.ts
+++ b/apps/api/src/lib/storage-urls.ts
@@ -19,7 +19,7 @@ export function getStorageUrls() {
 }
 
 // Cached latest version — fetched directly from S3 (not through the proxy)
-let cachedVersion: { version: string; dmg?: string; artifact?: string } | null = null;
+let cachedVersion: { version: string; dmg?: string; artifact?: string; downloads?: { arm64?: string; x64?: string } } | null = null;
 let lastFetchTime = 0;
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -45,7 +45,7 @@ function getReleaseClient() {
   return _releaseClientPromise;
 }
 
-export async function getLatestVersion(): Promise<{ version: string; dmg?: string; artifact?: string }> {
+export async function getLatestVersion(): Promise<{ version: string; dmg?: string; artifact?: string; downloads?: { arm64?: string; x64?: string } }> {
   const now = Date.now();
   if (cachedVersion && now - lastFetchTime < CACHE_TTL_MS) {
     return cachedVersion;
@@ -66,7 +66,7 @@ export async function getLatestVersion(): Promise<{ version: string; dmg?: strin
 
     if (result.Body) {
       const text = await result.Body.transformToString();
-      const data = JSON.parse(text) as { version: string; dmg?: string; artifact?: string };
+      const data = JSON.parse(text) as { version: string; dmg?: string; artifact?: string; downloads?: { arm64?: string; x64?: string } };
       cachedVersion = data;
       lastFetchTime = now;
       return data;

--- a/apps/api/src/routes/download.ts
+++ b/apps/api/src/routes/download.ts
@@ -12,24 +12,37 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#39;");
 }
 
+// Validates electron-builder release filenames. Accepts multi-segment arch
+// suffixes like `-arm64` or `-arm64-mac` (the `-` is in the character class
+// explicitly). Must stay in sync with ALLOWED_RELEASE_PATTERNS in release-proxy.ts.
+const FILENAME_PATTERN = /^Brett-[\d.]+(?:-[\w.-]+)?\.(zip|dmg)$/;
+
+function pickFilename(rawKey: string | undefined, fallback: string): string {
+  if (!rawKey) return fallback;
+  const stripped = rawKey.replace(/^releases\//, "");
+  return FILENAME_PATTERN.test(stripped) ? stripped : fallback;
+}
+
 download.get("/", async (c) => {
   const { releasesUrl, videoFiles } = getStorageUrls();
   const latest = await getLatestVersion();
   const version = latest.version;
-  // artifact key from latest.json includes "releases/" prefix — strip it for the proxy URL
-  const rawKey = latest.artifact || latest.dmg || `releases/Brett-${version}-mac.zip`;
-  let filename = rawKey.replace(/^releases\//, "");
-  // Validate filename to prevent open redirect via poisoned latest.json.
-  // Pattern matches electron-builder outputs: "Brett-X.Y.Z.zip", "Brett-X.Y.Z-mac.zip",
-  // "Brett-X.Y.Z-arm64-mac.dmg", etc. Must stay in sync with ALLOWED_RELEASE_PATTERNS
-  // in release-proxy.ts.
-  if (!/^Brett-[\d.]+(?:-[\w.]+)?\.(zip|dmg)$/.test(filename)) {
-    filename = `Brett-${version}-mac.zip`;
-  }
+
+  // Per-arch DMG URLs. Falls back to the legacy `artifact` field for the
+  // primary button if `downloads` is missing (e.g. latest.json from an older
+  // release). If both are missing, we still link to the autoupdate ZIP by
+  // convention so the page never 404s the user.
+  const arm64Key = latest.downloads?.arm64;
+  const x64Key = latest.downloads?.x64;
+  const legacyKey = latest.artifact || latest.dmg;
+
+  const arm64File = pickFilename(arm64Key ?? legacyKey, `Brett-${version}-arm64.dmg`);
+  const x64File = pickFilename(x64Key, `Brett-${version}-x64.dmg`);
 
   // Escape all interpolated values for safe HTML embedding
   const safeVersion = escapeHtml(version);
-  const safeDownloadHref = escapeHtml(`${releasesUrl}/${filename}`);
+  const safeArm64Href = escapeHtml(`${releasesUrl}/${arm64File}`);
+  const safeX64Href = escapeHtml(`${releasesUrl}/${x64File}`);
   // Escape </script> in JSON to prevent early script tag termination
   const safeVideoJson = JSON.stringify(videoFiles).replace(/<\//g, "<\\/");
 
@@ -102,16 +115,23 @@ download.get("/", async (c) => {
       font-size: 16px;
       margin-bottom: 32px;
     }
+    .downloads {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      align-items: stretch;
+    }
     .download-btn {
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       gap: 10px;
-      padding: 14px 32px;
+      padding: 14px 24px;
       background: #3b82f6;
       border: none;
       border-radius: 10px;
       color: white;
-      font-size: 16px;
+      font-size: 15px;
       font-weight: 600;
       cursor: pointer;
       transition: all 200ms ease;
@@ -122,9 +142,31 @@ download.get("/", async (c) => {
       transform: translateY(-1px);
       box-shadow: 0 4px 20px rgba(59, 130, 246, 0.4);
     }
+    .download-btn.secondary {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.85);
+    }
+    .download-btn.secondary:hover {
+      background: rgba(255, 255, 255, 0.1);
+      box-shadow: none;
+    }
+    .download-btn .btn-sub {
+      font-size: 12px;
+      font-weight: 500;
+      opacity: 0.7;
+      margin-left: 4px;
+    }
     .download-btn svg {
-      width: 18px;
-      height: 18px;
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+    .arch-hint {
+      color: rgba(255, 255, 255, 0.35);
+      font-size: 12px;
+      margin-top: 12px;
+      line-height: 1.5;
     }
     .version-info {
       color: rgba(255, 255, 255, 0.3);
@@ -221,14 +263,26 @@ download.get("/", async (c) => {
   <div class="app-name">Brett</div>
   <div class="tagline">Your day, handled.</div>
 
-  <a href="${safeDownloadHref}" class="download-btn" id="download-link">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-      <polyline points="7 10 12 15 17 10"/>
-      <line x1="12" y1="15" x2="12" y2="3"/>
-    </svg>
-    <span id="download-text">Download for macOS</span>
-  </a>
+  <div class="downloads">
+    <a href="${safeArm64Href}" class="download-btn">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+        <polyline points="7 10 12 15 17 10"/>
+        <line x1="12" y1="15" x2="12" y2="3"/>
+      </svg>
+      <span>Apple Silicon</span>
+      <span class="btn-sub">M1 and later</span>
+    </a>
+    <a href="${safeX64Href}" class="download-btn secondary">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+        <polyline points="7 10 12 15 17 10"/>
+        <line x1="12" y1="15" x2="12" y2="3"/>
+      </svg>
+      <span>Intel</span>
+    </a>
+  </div>
+  <div class="arch-hint">Not sure? Pick Apple Silicon if your Mac is from late 2020 or later.</div>
   <div class="version-info">v${safeVersion} · macOS 12+</div>
 
   <div class="platform-note" id="platform-note" style="display:none">

--- a/apps/api/src/routes/release-proxy.ts
+++ b/apps/api/src/routes/release-proxy.ts
@@ -25,9 +25,13 @@ function getReleaseStorage(): Promise<{ s3: S3Client; bucket: string }> {
   return _initPromise;
 }
 
-// Allowed files in releases/ — whitelist specific patterns
+// Allowed files in releases/ — whitelist specific patterns.
+// The suffix group accepts multi-segment arch markers like `-arm64-mac`
+// because electron-builder produces e.g. `Brett-1.2.3-arm64-mac.zip` for
+// per-arch update ZIPs. Traversal is still blocked by the `..` / `/` /
+// `%` rejection in the handler, and the anchored regex prevents path escape.
 const ALLOWED_RELEASE_PATTERNS = [
-  /^releases\/Brett-[\d.]+(?:-[\w.]+)?\.(zip|dmg)$/,
+  /^releases\/Brett-[\d.]+(?:-[\w.-]+)?\.(zip|dmg)$/,
   /^releases\/latest-mac\.yml$/,
   /^releases\/latest\.json$/,
 ];

--- a/scripts/upload-release.ts
+++ b/scripts/upload-release.ts
@@ -80,14 +80,29 @@ async function uploadRelease() {
 
   await uploadFile(ymlPath, "releases/latest-mac.yml", "text/yaml", "latest-mac.yml");
 
-  // latest.json points the download page at the preferred first-install artifact:
-  // DMG if we produced one, otherwise the ZIP. Autoupdate reads latest-mac.yml,
-  // not this file, so it's safe to prefer DMG here.
-  const downloadArtifact = dmgs[0] ?? zips[0];
+  // Classify each DMG by architecture from its electron-builder filename.
+  // Convention: `Brett-<version>-arm64.dmg` / `Brett-<version>-x64.dmg`.
+  // Bare `Brett-<version>.dmg` is electron-builder's x64 default — treat as x64.
+  const downloads: Record<"arm64" | "x64", string> = { arm64: "", x64: "" };
+  for (const f of dmgs) {
+    const arch = f.includes("arm64") ? "arm64" : "x64";
+    if (downloads[arch]) {
+      throw new Error(
+        `Multiple ${arch} DMGs found (${downloads[arch]} and ${f}). Build output is ambiguous.`,
+      );
+    }
+    downloads[arch] = `releases/${f}`;
+  }
+
+  // Fallback for any client still reading the legacy `artifact` field — prefer
+  // Apple Silicon since that's ~95% of Macs sold in the last several years.
+  const fallbackArtifact = downloads.arm64 || downloads.x64 || `releases/${zips[0]}`;
+
   const latestKey = "releases/latest.json";
   const latestBody = JSON.stringify({
     version,
-    artifact: `releases/${downloadArtifact}`,
+    downloads,
+    artifact: fallbackArtifact,
   });
   console.log(`Uploading latest.json → ${latestKey}`);
   await releaseS3.send(


### PR DESCRIPTION
## Summary

Follow-up to the release-pipeline PR. Makes the download page serve per-arch DMGs correctly and closes a latent regex gap that would have broken autoupdate ZIPs.

- **Two download buttons** — Apple Silicon (primary) and Intel (secondary), with a short hint for users who don't know. Replaces the previous single-button design that served an arbitrary DMG depending on filesystem ordering.
- **Release-proxy whitelist widened** — now accepts multi-segment arch suffixes like \`Brett-1.2.3-arm64-mac.zip\`. Previously the regex only handled single-segment suffixes and would 404 electron-builder's per-arch update ZIPs, silently breaking autoupdate.
- **\`latest.json\` now carries a \`downloads: {arm64, x64}\` map** — uploader classifies each DMG by filename; download page reads both and renders matching buttons. Legacy \`artifact\` field preserved for backwards compat.

## New test coverage

- **\`apps/api/src/__tests__/release-proxy.test.ts\` (NEW, 17 tests)** — the release-proxy route had zero test coverage despite being a security-sensitive whitelist. Added coverage for:
  - Allowed patterns (all DMG/ZIP shapes including multi-segment, \`latest-mac.yml\`, \`latest.json\`)
  - Disallowed (path traversal \`..\`, URL-encoded traversal, nested paths, executable extensions, arbitrary non-matching filenames, empty keys)
- **\`download.test.ts\`** — updated for two-button UX, added tests for legacy-artifact fallback, multi-segment suffix acceptance, and per-arch poisoned-key defense.

## Test plan

- [x] \`pnpm --filter @brett/api test download release-proxy\` — 31/31 passing
- [x] \`pnpm typecheck\` — clean
- [ ] After merging: CI deploys API → hit \`/download\` in a browser, verify two buttons render
- [ ] Run \`scripts/release.sh desktop\` → verify \`latest.json\` in the release bucket contains \`downloads: {arm64, x64}\`
- [ ] Click each button, verify correct DMG downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)