### PR TITLE
fix: electron-deps copy resolves nested transitives + DMG polish

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,15 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": true
     },
+    "dmg": {
+      "iconSize": 160,
+      "iconTextSize": 13,
+      "window": { "width": 540, "height": 380 },
+      "contents": [
+        { "x": 140, "y": 200, "type": "file" },
+        { "x": 400, "y": 200, "type": "link", "path": "/Applications" }
+      ]
+    },
     "publish": {
       "provider": "generic",
       "url": "https://placeholder.invalid/releases"

--- a/apps/desktop/scripts/copy-electron-deps.js
+++ b/apps/desktop/scripts/copy-electron-deps.js
@@ -61,4 +61,52 @@ for (const dep of ELECTRON_DEPS) {
   copyDep(dep);
 }
 
+// Post-pass: `cpSync` brings along nested node_modules for packages that
+// had them in the root (pnpm pins older versions nested under their
+// parent). Those nested packages reference deps that the initial pass
+// missed — e.g. `p-locate/node_modules/p-limit@2` requires `p-try`, but
+// the hoisted `p-limit@3` we copied from root doesn't declare p-try, so
+// the recursion never sees it. Walk every package.json under the copy
+// target and make sure each declared dep is resolvable (either nested
+// next to the consumer or flat at the top of localModules).
+function ensureDepsResolvable(dir) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    // Handle scoped packages (@foo/bar) — recurse one level
+    if (entry.name.startsWith("@")) {
+      ensureDepsResolvable(path.join(dir, entry.name));
+      continue;
+    }
+    const pkgRoot = path.join(dir, entry.name);
+    const pkgPath = path.join(pkgRoot, "package.json");
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+        for (const dep of Object.keys(pkg.dependencies || {})) {
+          if (dep.startsWith("@types/")) continue;
+          const nestedPath = path.join(pkgRoot, "node_modules", dep);
+          const topPath = path.join(localModules, dep);
+          if (!fs.existsSync(nestedPath) && !fs.existsSync(topPath)) {
+            copyDep(dep);
+          }
+        }
+      } catch {
+        // Malformed package.json — skip
+      }
+    }
+    // Recurse into any nested node_modules
+    const nested = path.join(pkgRoot, "node_modules");
+    if (fs.existsSync(nested)) ensureDepsResolvable(nested);
+  }
+}
+
+// Iterate until stable — a newly copied dep may itself have missing
+// transitives that the previous pass couldn't see.
+let prevCount = -1;
+while (copied.size !== prevCount) {
+  prevCount = copied.size;
+  ensureDepsResolvable(localModules);
+}
+
 console.log(`Copied ${copied.size} packages`);

--- a/scripts/upload-release.ts
+++ b/scripts/upload-release.ts
@@ -118,7 +118,8 @@ async function uploadRelease() {
 
   const endpoint = process.env.RELEASE_STORAGE_ENDPOINT || process.env.STORAGE_ENDPOINT;
   console.log(`\n✓ Release v${version} uploaded!`);
-  console.log(`  Download: ${endpoint}/${RELEASE_BUCKET}/releases/${downloadArtifact}`);
+  // fallbackArtifact already includes the `releases/` prefix
+  console.log(`  Download: ${endpoint}/${RELEASE_BUCKET}/${fallbackArtifact}`);
 }
 
 uploadRelease().catch((err) => {


### PR DESCRIPTION
## Summary

Three fixes stacked together, all build-time / packaging — no server code touched.

- **fix(desktop)**: copy-electron-deps now walks nested package.json files post-copy and pulls missing transitives (e.g. \`p-try\` which the main process crashed on at launch)
- **fix(release)**: electron-builder 26 schema compatibility + trap path bug in release.sh
- **polish(dmg + download)**: bigger DMG icons with a sized install window, cleaner download-page button labels

## Deployment impact

Merge triggers a CI redeploy of the API — will be a no-op since nothing server-side changed. Desktop/iOS releases happen locally via \`scripts/release.sh\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)