### PR TITLE
sync(ios): regenerate pbxproj + lockfile gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ apps/desktop/public/videos/*.mp4
 *-firebase-adminsdk-*.json
 firebase-service-account.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
+.claude/*.lock
 .worktrees/
 
 # Background audit local artifacts (verdicts + sourced URLs)

--- a/apps/ios/Brett.xcodeproj/project.pbxproj
+++ b/apps/ios/Brett.xcodeproj/project.pbxproj
@@ -1192,20 +1192,20 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					186595853033417F72BC6F1E = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = FQUJNV9M6S;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 35DB8B32AB10170D269EDDE4;
 					};
 					35DB8B32AB10170D269EDDE4 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = FQUJNV9M6S;
 						ProvisioningStyle = Automatic;
 					};
 					4B72560AC660F3001873E768 = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = FQUJNV9M6S;
 						ProvisioningStyle = Automatic;
 					};
 					9B356E87F03CB846F3E8EA8C = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = FQUJNV9M6S;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1584,13 +1584,13 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_LANGUAGE = en;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = FQUJNV9M6S;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1688,13 +1688,13 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_LANGUAGE = en;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = FQUJNV9M6S;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;


### PR DESCRIPTION
Regenerated Brett.xcodeproj/project.pbxproj to reflect project.yml signing changes from earlier. Also gitignores .claude/*.lock. Unblocks iOS TestFlight release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)