### PR TITLE
fix(calendar): buffer label pill fix

### DIFF
--- a/packages/ui/src/CalendarTimeline.tsx
+++ b/packages/ui/src/CalendarTimeline.tsx
@@ -442,17 +442,15 @@ export function CalendarTimeline({
             return (
               <div
                 key={`buffer-${buf.afterEventId}`}
-                className="absolute left-12 right-4 flex items-center justify-center z-10 pointer-events-none"
-                style={{ top: `${topPx}px`, height: "12px" }}
+                className="absolute left-12 right-4 flex items-center justify-center z-30 pointer-events-none -translate-y-1/2"
+                style={{ top: `${topPx}px` }}
               >
                 <span
-                  className={`text-[9px] font-medium ${
-                    buf.gapMinutes === 0 ? "text-red-400" : "text-amber-400/60"
+                  className={`text-[9px] font-medium leading-none px-1.5 py-0.5 rounded-full bg-black/70 backdrop-blur-sm ${
+                    buf.gapMinutes === 0 ? "text-red-400" : "text-amber-400/70"
                   }`}
                 >
-                  {buf.gapMinutes === 0
-                    ? "0 min buffer"
-                    : `${buf.gapMinutes} min`}
+                  {`${buf.gapMinutes}m`}
                 </span>
               </div>
             );


### PR DESCRIPTION
## Summary
- Wraps the calendar buffer indicator in a solid pill (`bg-black/70 backdrop-blur-sm`, `z-30`) so it reads cleanly when side-by-side overlapping events share a seam
- Translates the pill `-50%` vertically so it straddles the event boundary instead of overlapping the next event's top edge
- Shortens label to compact form (`0m`, `5m`) — red for `0m`, amber for 1–14m

## Test plan
- [ ] Load Today view with overlapping calendar events (e.g., 11 AM block with two side-by-side meetings)
- [ ] Confirm buffer pill renders above both events, text is readable, no collision
- [ ] Confirm `0m` pill is red, non-zero pills are amber
- [ ] Confirm no regression in single-column (non-overlapping) buffer display

🤖 Generated with [Claude Code](https://claude.com/claude-code)