### PR TITLE
chore(ios): gitignore Bundler vendor dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ apps/ios/fastlane/*.log
 apps/ios/fastlane/test_output/
 apps/ios/fastlane/README.md
 apps/ios/build/
+apps/ios/vendor/
+apps/ios/.bundle/
 apps/ios/*.ipa
 apps/ios/*.app.dSYM.zip
 


### PR DESCRIPTION
Tiny gitignore update to keep `apps/ios/vendor/` (local bundle path) out of git. Unblocks iOS release from the bundle-path workaround.