### PR TITLE
fix(ios): disable xcpretty in Fastlane

### DIFF
--- a/apps/ios/fastlane/Fastfile
+++ b/apps/ios/fastlane/Fastfile
@@ -50,6 +50,11 @@ platform :ios do
       clean: true,
       output_directory: "build",
       output_name: "Brett.ipa",
+      # Disable xcpretty — it invokes system Ruby 2.6 (via PATH resolution
+      # in the xcodebuild-spawned subshell) which can't load the modern
+      # bundler we use for Fastlane. Raw xcodebuild output is verbose but
+      # works consistently across Ruby versions.
+      xcodebuild_formatter: "",
     )
 
     upload_to_testflight(


### PR DESCRIPTION
xcpretty's Ruby 2.6 vs modern bundler collision was breaking every archive attempt. Raw xcodebuild output works consistently.