### PR TITLE
fix(ios): CFBundlePackageType for TestFlight upload

### DIFF
--- a/apps/ios/Brett-ShareExtension/Info.plist
+++ b/apps/ios/Brett-ShareExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_TYPE)</string>
+	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>

--- a/apps/ios/Brett/Info.plist
+++ b/apps/ios/Brett/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_TYPE)</string>
+	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
App Store Connect error 90183 — hardcode APPL / XPC! instead of an undefined variable.