### PR TITLE
chore(ios): skip per-build export compliance prompt

### DIFF
--- a/apps/ios/Brett-ShareExtension/Info.plist
+++ b/apps/ios/Brett-ShareExtension/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/apps/ios/Brett/Info.plist
+++ b/apps/ios/Brett/Info.plist
@@ -43,6 +43,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>GIDClientID</key>
 	<string>1055113004459-1go91rointqkletog9sc2o4t3ivfph6u.apps.googleusercontent.com</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Declare ITSAppUsesNonExemptEncryption=false since Brett only uses HTTPS/TLS and keychain.