### PR TITLE
fix(ios): per-config Google OAuth so Release targets prod project

### DIFF
--- a/apps/ios/Brett/Info.plist
+++ b/apps/ios/Brett/Info.plist
@@ -37,7 +37,7 @@
 			<string>com.brett.app.googlesignin</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.1055113004459-1go91rointqkletog9sc2o4t3ivfph6u</string>
+				<string>$(GOOGLE_IOS_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>
@@ -46,7 +46,7 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>GIDClientID</key>
-	<string>1055113004459-1go91rointqkletog9sc2o4t3ivfph6u.apps.googleusercontent.com</string>
+	<string>$(GOOGLE_IOS_CLIENT_ID)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -42,8 +42,15 @@ settings:
     # whatever that IP resolved to on the tester's network.
     Debug:
       BRETT_API_URL: http://192.168.50.242:3001
+      # Dev Google Cloud project iOS OAuth client
+      GOOGLE_IOS_CLIENT_ID: 1055113004459-1go91rointqkletog9sc2o4t3ivfph6u.apps.googleusercontent.com
+      GOOGLE_IOS_URL_SCHEME: com.googleusercontent.apps.1055113004459-1go91rointqkletog9sc2o4t3ivfph6u
     Release:
       BRETT_API_URL: https://api.brett.brentbarkman.com
+      # Prod Google Cloud project iOS OAuth client (audience Railway's
+      # GOOGLE_IOS_CLIENT_ID verifies against). Must match or sign-in 401s.
+      GOOGLE_IOS_CLIENT_ID: 64916321230-ht3ctvt0kqc8o7a1s1gca2p1r5mmf3uj.apps.googleusercontent.com
+      GOOGLE_IOS_URL_SCHEME: com.googleusercontent.apps.64916321230-ht3ctvt0kqc8o7a1s1gca2p1r5mmf3uj
   # Don't set CODE_SIGN_IDENTITY explicitly when CODE_SIGN_STYLE is Automatic —
   # Xcode picks Apple Development for Debug and Apple Distribution for Release
   # on its own based on the build configuration.


### PR DESCRIPTION
iOS TestFlight builds were shipping with dev Google Cloud client IDs, causing /api/auth/ios/google/token 401s against prod Railway.