### PR TITLE
fix(api): widen Granola calendar-match window to absorb timezone drift

### DIFF
--- a/apps/api/src/services/__tests__/granola-sync-window.test.ts
+++ b/apps/api/src/services/__tests__/granola-sync-window.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { calendarCandidateWindow } from "../granola-sync.js";
+
+// Granola's meeting list API returns start/end times that do not reliably
+// line up with the corresponding Google Calendar event times. Observed offsets
+// in production: 4 hours and 7 hours vs the real calendar startTime, with
+// `end_time === start_time` for every row. The candidate-fetch window used by
+// syncMeetings must therefore be padded generously so the real calendar event
+// still falls inside it — otherwise the title-match never gets a chance.
+
+describe("calendarCandidateWindow", () => {
+  it("pads the window wide enough to include a same-day calendar event offset by 7h", () => {
+    // Reproduces the bug where a Granola meeting stored as 10:00 UTC on
+    // 2026-04-17 was actually the 17:00-17:30 UTC calendar event on the
+    // same day. The previous window (earliest-1h .. latest+1h, with
+    // end_time=start_time from Granola) clamped the upper bound to 11:00 UTC
+    // and excluded the real event.
+    const { gte, lte } = calendarCandidateWindow([
+      { start_time: "2026-04-17T10:00:00Z" },
+    ]);
+
+    const calEventStart = new Date("2026-04-17T17:00:00Z");
+    const calEventEnd = new Date("2026-04-17T17:30:00Z");
+
+    expect(calEventStart.getTime()).toBeGreaterThanOrEqual(gte.getTime());
+    expect(calEventStart.getTime()).toBeLessThanOrEqual(lte.getTime());
+    expect(calEventEnd.getTime()).toBeLessThanOrEqual(lte.getTime());
+  });
+
+  it("bounds use start_time only — never collapses even when end_time === start_time", () => {
+    // Granola returns zero-width intervals (end_time === start_time) for
+    // every row. The window must not depend on end_time.
+    const window = calendarCandidateWindow([
+      { start_time: "2026-04-14T15:00:00Z" },
+      { start_time: "2026-04-17T10:00:00Z" },
+    ]);
+
+    expect(window.lte.getTime()).toBeGreaterThan(
+      new Date("2026-04-17T10:00:00Z").getTime(),
+    );
+    expect(window.gte.getTime()).toBeLessThan(
+      new Date("2026-04-14T15:00:00Z").getTime(),
+    );
+  });
+
+  it("spans from the earliest to the latest meeting across a multi-day batch", () => {
+    const { gte, lte } = calendarCandidateWindow([
+      { start_time: "2026-03-23T11:00:00Z" },
+      { start_time: "2026-03-27T14:00:00Z" },
+      { start_time: "2026-04-17T10:00:00Z" },
+    ]);
+
+    // Earliest meeting
+    expect(new Date("2026-03-23T11:00:00Z").getTime()).toBeGreaterThanOrEqual(
+      gte.getTime(),
+    );
+    // Latest meeting + a full day to absorb timezone drift
+    const latestCalPossible = new Date("2026-04-17T23:59:59Z");
+    expect(latestCalPossible.getTime()).toBeLessThanOrEqual(lte.getTime());
+  });
+
+  it("handles a single meeting", () => {
+    const { gte, lte } = calendarCandidateWindow([
+      { start_time: "2026-04-17T10:00:00Z" },
+    ]);
+    expect(lte.getTime()).toBeGreaterThan(gte.getTime());
+  });
+});

--- a/apps/api/src/services/granola-sync.ts
+++ b/apps/api/src/services/granola-sync.ts
@@ -33,6 +33,28 @@ function startOfDayInTimezone(timezone: string): Date {
   }
 }
 
+const CANDIDATE_WINDOW_PAD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute the time range for fetching CalendarEvent candidates to match
+ * against a batch of Granola meetings. Padded by a full day on each side
+ * because Granola's `start_time` does not reliably line up with the
+ * Google Calendar event (observed offsets of 4-7h in production). Uses
+ * `start_time` only — Granola returns `end_time === start_time` for
+ * every row, so relying on end_time would collapse the upper bound.
+ */
+export function calendarCandidateWindow(
+  meetings: { start_time: string }[],
+): { gte: Date; lte: Date } {
+  const starts = meetings.map((m) => new Date(m.start_time).getTime());
+  const earliest = Math.min(...starts);
+  const latest = Math.max(...starts);
+  return {
+    gte: new Date(earliest - CANDIDATE_WINDOW_PAD_MS),
+    lte: new Date(latest + CANDIDATE_WINDOW_PAD_MS),
+  };
+}
+
 export function isWithinWorkingHours(timezone: string): boolean {
   try {
     const now = new Date();
@@ -210,18 +232,16 @@ async function syncMeetings(
     return { detailById, transcripts };
   });
 
-  // Load calendar events for matching (same day window)
-  const earliest = new Date(
-    Math.min(...newMeetings.map((m) => new Date(m.start_time).getTime())),
-  );
-  const latest = new Date(
-    Math.max(...newMeetings.map((m) => new Date(m.end_time).getTime())),
-  );
+  // Load calendar events for matching.
+  // Granola's reported times do not reliably align with Google Calendar's
+  // startTime (observed offsets of 4-7h in prod, and end_time === start_time
+  // on every row). The window must be padded generously so the real calendar
+  // event still falls inside it.
+  const { gte, lte } = calendarCandidateWindow(newMeetings);
   const calendarEvents = await prisma.calendarEvent.findMany({
     where: {
       userId,
-      startTime: { gte: new Date(earliest.getTime() - 60 * 60 * 1000) },
-      endTime: { lte: new Date(latest.getTime() + 60 * 60 * 1000) },
+      startTime: { gte, lte },
     },
     select: {
       id: true,


### PR DESCRIPTION
## Summary
- Granola's meeting API returns start times offset by 4-7h from the corresponding Google Calendar event (timezone parsing quirk) and always returns `end_time === start_time`. The old candidate-fetch window (`earliest-1h .. latest+1h`, using `end_time`) could exclude the real calendar event, so even exact-title meetings never got linked.
- Extract `calendarCandidateWindow()` with ±24h padding, using `start_time` only. Drops the `endTime <= latest+1h` upper-bound filter that was doing the clamping.
- Add 4 unit tests covering the reproducer (Friday meeting stored at 10:00 UTC, real cal event at 17:00-17:30 UTC same day), plus multi-day batches and zero-width intervals.

Hotfix for the single affected meeting was applied directly to prod DB before this PR; this change prevents recurrence.

## Test plan
- [x] `pnpm --filter @brett/api typecheck` clean
- [x] 4 new tests in `granola-sync-window.test.ts` fail pre-fix, pass post-fix
- [x] 76/76 existing API tests pass (no matcher regressions)
- [ ] After deploy: reconnect Granola and sync a future meeting — confirm `calendarEventId` populated when the calendar event exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)