### PR TITLE
fix(ai): expose meeting-retrieval skills to query-intent router

### DIFF
--- a/packages/ai/src/skills/__tests__/registry.test.ts
+++ b/packages/ai/src/skills/__tests__/registry.test.ts
@@ -104,4 +104,33 @@ describe("SkillRegistry", () => {
     expect(registry.toToolDefinitions()).toHaveLength(0);
     expect(registry.getNoKeySkills()).toHaveLength(0);
   });
+
+  describe("toToolDefinitionsForMessage — intent-routed meeting queries", () => {
+    // Regression: the "query" intent group filters tools before they reach
+    // the LLM. Meeting-retrieval skills (get_meeting_notes, get_meeting_action_items)
+    // were omitted from the group, so the LLM never saw them for messages like
+    // "what were the notes from my Friday meeting with Yves" and fell back to
+    // wrong tools (get_item_detail / search_things), failing to retrieve notes
+    // that were already correctly stored and linked.
+    beforeEach(() => {
+      registry.register(makeSkill({ name: "get_meeting_notes" }));
+      registry.register(makeSkill({ name: "get_meeting_action_items" }));
+      registry.register(makeSkill({ name: "search_things" }));
+      registry.register(makeSkill({ name: "get_item_detail" }));
+    });
+
+    it("exposes get_meeting_notes to the LLM for a meeting-notes query", () => {
+      const tools = registry.toToolDefinitionsForMessage(
+        "what were the notes from my Friday meeting with Yves",
+      );
+      expect(tools.map((t) => t.name)).toContain("get_meeting_notes");
+    });
+
+    it("exposes get_meeting_action_items to the LLM for an action-items query", () => {
+      const tools = registry.toToolDefinitionsForMessage(
+        "show me the action items from my last meeting",
+      );
+      expect(tools.map((t) => t.name)).toContain("get_meeting_action_items");
+    });
+  });
 });

--- a/packages/ai/src/skills/registry.ts
+++ b/packages/ai/src/skills/registry.ts
@@ -8,6 +8,7 @@ const INTENT_GROUPS: Record<string, string[]> = {
     "search_things", "get_item_detail", "list_today", "list_upcoming",
     "list_inbox", "get_list_items", "get_calendar_events", "get_next_event",
     "up_next", "get_stats", "list_scouts",
+    "get_meeting_notes", "get_meeting_action_items", "analyze_meeting_pattern",
   ],
   create: [
     "create_task", "create_content", "create_list", "create_scout",


### PR DESCRIPTION
## Summary
Follow-up to #46. The prod hotfix and matcher-window fix got the Granola meeting correctly linked to its calendar event, but the AI still couldn't retrieve the notes. Root cause: `SkillRegistry.toToolDefinitionsForMessage()` filters tools by intent before sending them to the LLM, and `get_meeting_notes` / `get_meeting_action_items` / `analyze_meeting_pattern` were registered globally but never added to any `INTENT_GROUP`.

Net effect: for a message like *"what were the notes from my Friday meeting with Yves"*, the classifier matched "query" intent, handed the LLM the query-group tools (`search_things`, `get_item_detail`, etc.), and the LLM never saw `get_meeting_notes` — so it picked the wrong tool and returned "no notes found" for notes that were already in the DB.

## Test plan
- [x] 2 new tests in `registry.test.ts` reproduce the miss (fail pre-fix, pass post-fix)
- [x] Full `@brett/ai` suite: 238 pass / 6 skipped, no regressions
- [x] `pnpm --filter @brett/ai typecheck` clean
- [ ] After deploy: re-ask Brett *"what were the notes from my Friday meeting with Yves"* and confirm the summary is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)