### PR TITLE
feat(ai): surface matched meeting chunk alongside summary in search

### DIFF
--- a/packages/ai/src/__tests__/search.test.ts
+++ b/packages/ai/src/__tests__/search.test.ts
@@ -34,6 +34,50 @@ describe("fuseResults", () => {
     const results = fuseResults(kw, vec, 2);
     expect(results).toHaveLength(2);
   });
+
+  it("prefers the vector chunk snippet over the keyword summary for meeting_notes", () => {
+    // For meetings the keyword path returns the full summary as snippet,
+    // while the vector path returns the specific chunk that matched the
+    // query. When both match, callers want the chunk — it's the reason
+    // for surfacing the meeting at all.
+    const meetingKw: RankedResult[] = [
+      {
+        entityType: "meeting_note",
+        entityId: "m1",
+        title: "Sync with Yves",
+        snippet: "Full summary covering Function Health company update.",
+        rank: 1,
+      },
+    ];
+    const meetingVec: RankedResult[] = [
+      {
+        entityType: "meeting_note",
+        entityId: "m1",
+        title: "Sync with Yves",
+        snippet:
+          "Transcript: Them: Hey, Brent. Me: Hey Yves. Them: We announced the GitLab acquisition this week.",
+        rank: 1,
+      },
+    ];
+
+    const [result] = fuseResults(meetingKw, meetingVec, 1);
+    expect(result.matchType).toBe("both");
+    expect(result.snippet).toContain("Transcript:");
+  });
+
+  it("does not swap snippets for non-meeting entity types", () => {
+    // Items have small uniform bodies — keyword snippet is already the
+    // whole body, swapping to the vector chunk (which is often identical)
+    // adds no value and could destabilize existing behavior.
+    const itemKw: RankedResult[] = [
+      { entityType: "item", entityId: "i1", title: "T", snippet: "keyword-body", rank: 1 },
+    ];
+    const itemVec: RankedResult[] = [
+      { entityType: "item", entityId: "i1", title: "T", snippet: "vector-chunk", rank: 1 },
+    ];
+    const [result] = fuseResults(itemKw, itemVec, 1);
+    expect(result.snippet).toBe("keyword-body");
+  });
 });
 
 // --- VALID_ENTITY_TYPES allowlist ---

--- a/packages/ai/src/embedding/search.ts
+++ b/packages/ai/src/embedding/search.ts
@@ -67,6 +67,13 @@ export function fuseResults(
     if (existing) {
       existing.score += add;
       existing.inVector = true;
+      // For meeting_notes, the vector snippet is the specific chunk that
+      // matched (e.g. a transcript passage), while the keyword snippet is
+      // the whole summary. Prefer the chunk — it's the actually-relevant
+      // excerpt the caller will surface back to the LLM.
+      if (r.entityType === "meeting_note") {
+        existing.result = { ...existing.result, snippet: r.snippet };
+      }
     } else {
       scores.set(key, { score: add, result: r, inKeyword: false, inVector: true });
     }

--- a/packages/ai/src/skills/search-things.ts
+++ b/packages/ai/src/skills/search-things.ts
@@ -50,6 +50,16 @@ export const searchThingsSkill: Skill = {
       .filter((r) => r.entityType === "meeting_note")
       .map((r) => r.entityId);
 
+    // Carry the matched chunk snippet per meeting so we can surface the
+    // specific excerpt that matched — the summary alone often doesn't
+    // cover transcript details the user is asking about.
+    const meetingSnippetById = new Map<string, string>();
+    for (const r of searchResults) {
+      if (r.entityType === "meeting_note" && r.snippet) {
+        meetingSnippetById.set(r.entityId, r.snippet);
+      }
+    }
+
     // Fetch full item records for enrichment and post-filtering
     const itemWhere: Record<string, unknown> = {
       id: { in: itemIds },
@@ -92,11 +102,13 @@ export const searchThingsSkill: Skill = {
 
     const meetingResults = meetings.map((m) => {
       const tasks = linkedItems.filter((i) => i.meetingNoteId === m.id);
+      const matchedExcerpt = meetingSnippetById.get(m.id) ?? null;
       return {
         title: m.title,
         calendarEventId: m.calendarEventId,
         date: m.meetingStartedAt.toISOString().split("T")[0],
         summary: m.summary,
+        matchedExcerpt,
         tasks,
       };
     });
@@ -113,6 +125,10 @@ export const searchThingsSkill: Skill = {
           const parts = [`${titleLink} (${m.date}):`];
           if (m.summary) {
             parts.push(m.summary);
+          }
+          if (isDistinctExcerpt(m.matchedExcerpt, m.summary)) {
+            parts.push("**Matched excerpt:**");
+            parts.push(m.matchedExcerpt!);
           }
           if (m.tasks.length > 0) {
             parts.push("**Tasks:**");
@@ -150,3 +166,19 @@ export const searchThingsSkill: Skill = {
     };
   },
 };
+
+/**
+ * An excerpt is worth showing alongside the summary only when it's
+ * substantively different. If the chunk is just a slice of the summary
+ * (the keyword path returns the whole summary as snippet), showing it
+ * again is noise.
+ */
+function isDistinctExcerpt(
+  excerpt: string | null | undefined,
+  summary: string | null | undefined,
+): boolean {
+  if (!excerpt) return false;
+  if (!summary) return true;
+  const head = excerpt.slice(0, 80).trim();
+  return head.length > 0 && !summary.includes(head);
+}


### PR DESCRIPTION
## Summary
Third in the Friday-meeting-notes sequence ([#46](https://github.com/brentbarkman/brett/pull/46), [#47](https://github.com/brentbarkman/brett/pull/47)).

\`search_things\` was dropping the vector-matched chunk when returning meeting results — it only passed the full summary back to the LLM. For content-level questions (*"what did Yves say about the GitLab acquisition?"*), hybrid search correctly ranked a transcript chunk at the top, but the LLM never saw it. Closes the transcript-retrieval gap.

- In \`fuseResults\`: when a meeting_note matches both keyword and vector, keep the vector chunk as the snippet (keyword returns the full summary, which is redundant with what we return separately). Items are unaffected.
- In \`search_things\`: carry the per-meeting snippet through to the response and render it as a "Matched excerpt" under the summary, but only when it adds information the summary doesn't already contain.

## Test plan
- [x] 2 new tests in \`search.test.ts\` for \`fuseResults\` snippet-preference behavior (meeting_note swaps, items don't)
- [x] Full \`@brett/ai\` suite: 240 pass / 6 skipped, no regressions
- [x] \`pnpm --filter @brett/ai typecheck\` clean
- [ ] After deploy: ask Brett a content-detail question about Friday's meeting (something in the transcript, not just the summary) — confirm the excerpt surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)