### PR TITLE
fix(ai): search before refusing factual questions about user's world

### DIFF
--- a/packages/ai/src/context/__tests__/system-prompts.test.ts
+++ b/packages/ai/src/context/__tests__/system-prompts.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getSystemPrompt } from "../system-prompts.js";
+
+// These assertions guard the "search before refusing" guidance that keeps
+// the chat assistant from refusing factual questions about the user's world
+// without first trying retrieval. Seen in prod on 2026-04-20: user asked
+// "what is Function Health's strike price?" — the info was in a Granola
+// meeting note that day, but Brett refused ("I don't have access to
+// real-time financial data…") without calling any tool. After telling
+// Brett where to look, retrieval worked fine.
+//
+// A full behavioral eval with real LLM calls lives outside this repo
+// (@brett/evals is a TODO). For now, the cheapest protection is to
+// assert the load-bearing phrases survive edits to the prompt.
+
+describe("getSystemPrompt", () => {
+  const prompt = getSystemPrompt("Brett");
+
+  it("instructs the assistant to search before refusing factual questions", () => {
+    expect(prompt).toMatch(/SEARCH BEFORE REFUSING/);
+    expect(prompt).toMatch(/search_things/);
+  });
+
+  it("does not tell the assistant to decline domain-adjacent questions outright", () => {
+    // The old prompt said 'Stay in domain (tasks/calendar/content).
+    // Decline other requests.' which caused blanket refusals for anything
+    // that sounded finance-y or off-topic, even when the answer was in
+    // the user's own notes.
+    expect(prompt).not.toMatch(/Decline other requests\.?$/m);
+  });
+
+  it("keeps meeting-notes retrieval in domain", () => {
+    expect(prompt).toMatch(/meeting notes|get_meeting_notes/);
+  });
+});

--- a/packages/ai/src/context/system-prompts.ts
+++ b/packages/ai/src/context/system-prompts.ts
@@ -17,6 +17,7 @@ export function getSystemPrompt(assistantName: string): string {
 - ALWAYS call tools — never narrate your plan or describe what you will do. Just act.
 - NEVER ask for permission ("want me to look into that?"). Just do it.
 - Chain tools when needed: search → get_item_detail → answer in one turn.
+- SEARCH BEFORE REFUSING. Before saying "I don't have access" to any factual question about the user's world — companies, people, deals, numbers, opinions — ALWAYS call search_things first (and recall_memory or get_meeting_notes when relevant). The answer often lives in a meeting note, inbox item, or stored fact. "I don't know" is only correct after retrieval returns nothing. Treat every specific factual question ("what is X's Y?", "how much did Z raise?", "what did W say about V?") as potentially-in-the-notes until you've checked.
 - RESOLVE AMBIGUITY BEFORE ACTING: If a request involves multiple items and you're not sure which ones, search/lookup FIRST. Do NOT create or modify anything until you know exactly what the user wants. If there's ambiguity (e.g., multiple items match), ask the user to clarify BEFORE taking any action — don't create a list and then ask which items to move into it.
 - When there's no ambiguity, act immediately. Don't ask to confirm obvious requests.
 - When referencing tasks or content items, use: [Item Title](brett-item:itemId)
@@ -36,7 +37,7 @@ export function getSystemPrompt(assistantName: string): string {
 - 1-3 sentences for confirmations. Bullet points for 3+ items.
 - Use **bold** for emphasis. Never restate what the user asked — just show the result.
 - Compute relative dates from the current date in context.
-- Stay in domain (tasks/calendar/content). Decline other requests.` + SECURITY_BLOCK;
+- Stay in domain. Domain = tasks, calendar, content, meeting notes, and anything retrievable from the user's stored facts or items. Questions about people, companies, deals, or numbers the user has encountered are IN domain — retrieve before deciding whether you can answer. Only decline clearly off-topic requests (general coding help, math homework, political opinions, real-time market data the user hasn't discussed).` + SECURITY_BLOCK;
 }
 
 export function getBriefingPrompt(assistantName: string): string {


### PR DESCRIPTION
## Summary
Fourth and last in the Friday-meeting-notes sequence ([#46](https://github.com/brentbarkman/brett/pull/46), [#47](https://github.com/brentbarkman/brett/pull/47), [#48](https://github.com/brentbarkman/brett/pull/48)).

Even with retrieval fully wired up, the assistant refused a factual question whose answer was sitting in a synced meeting note:
> User: *"what is Function Health's strike price?"*
> Brett: *"I don't have access to real-time financial data or Function Health's specific equity details…"*

Transcript shows zero tool calls on that turn — the LLM declined to retrieve, then refused. After the user said *"it was discussed in the meeting with Yves on Friday"*, retrieval worked and the answer came back in full (409A $36.31, external $89/share, etc.).

Root cause was the prompt. `Stay in domain (tasks/calendar/content). Decline other requests.` biased the LLM toward refusal for anything sounding finance- or company-specific, regardless of what was actually in the notes.

Changes:
- New `SEARCH BEFORE REFUSING` rule pointing to `search_things`, `recall_memory`, `get_meeting_notes`
- Broaden the in-domain boundary: anything retrievable from stored items / meetings / facts is in domain; only decline *clearly* off-topic (general coding help, math, political opinions, real-time market data the user hasn't discussed)

## Tests vs. evals
A behavioral eval (run the same prompt through the orchestrator with a real LLM, assert `search_things` gets called) is the right tool here, but `packages/evals` doesn't exist yet. Adding a cheap unit test that asserts the load-bearing phrases survive prompt edits — enough to catch regressions, not enough to catch new drift. Proper eval harness is worth a follow-up.

## Test plan
- [x] 3 new tests in `system-prompts.test.ts` (failure-mode guard, in-domain phrasing, search-first guidance)
- [x] Full `@brett/ai` suite: 243 pass / 6 skipped
- [x] `pnpm --filter @brett/ai typecheck` clean
- [ ] After deploy: re-ask *"what is Function Health's strike price?"* cold — confirm Brett calls `search_things` and returns the answer without coaching

🤖 Generated with [Claude Code](https://claude.com/claude-code)