### PR TITLE
Reapply demo mode — test whether it's the root cause

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -638,13 +638,13 @@ export function App() {
     return () => document.removeEventListener("keydown", handleFeedbackShortcut);
   }, [feedbackOpen, electronVersion]);
 
-  // Cmd+Option+D toggles demo mode — swaps task + calendar titles for
+  // Cmd+Shift+D toggles demo mode — swaps task + calendar titles for
   // funny placeholders so screen-sharing doesn't leak real content.
-  // Using e.code so it fires regardless of OS key-remapping (on macOS,
-  // Cmd+Option+D reports e.key === "∂", but e.code is always "KeyD").
+  // Paired with Cmd+Shift+. (feedback) so the "Shift+letter" family is
+  // the mental model for meta shortcuts.
   useEffect(() => {
     const handleDemoToggle = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.altKey && e.code === "KeyD") {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.code === "KeyD") {
         e.preventDefault();
         demoMode.toggle();
       }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -34,6 +34,7 @@ import {
   ScoutDetail,
   LivingBackground,
   BackgroundScrim,
+  demoMode,
 } from "@brett/ui";
 import { useAwakening } from "./hooks/useAwakening";
 import { useAppConfig } from "./hooks/useAppConfig";
@@ -636,6 +637,21 @@ export function App() {
     document.addEventListener("keydown", handleFeedbackShortcut);
     return () => document.removeEventListener("keydown", handleFeedbackShortcut);
   }, [feedbackOpen, electronVersion]);
+
+  // Cmd+Option+D toggles demo mode — swaps task + calendar titles for
+  // funny placeholders so screen-sharing doesn't leak real content.
+  // Using e.code so it fires regardless of OS key-remapping (on macOS,
+  // Cmd+Option+D reports e.key === "∂", but e.code is always "KeyD").
+  useEffect(() => {
+    const handleDemoToggle = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.altKey && e.code === "KeyD") {
+        e.preventDefault();
+        demoMode.toggle();
+      }
+    };
+    document.addEventListener("keydown", handleDemoToggle);
+    return () => document.removeEventListener("keydown", handleDemoToggle);
+  }, []);
 
   // Build omnibar props for the bar component
   const currentView = (() => {

--- a/apps/desktop/src/components/calendar/CalendarDayView.tsx
+++ b/apps/desktop/src/components/calendar/CalendarDayView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Video } from "lucide-react";
 import type { CalendarEventRecord } from "@brett/types";
 import { getEventGlassColor, isSafeUrl } from "@brett/utils";
+import { displayTitle, useDemoMode } from "@brett/ui";
 
 export interface CalendarDayViewProps {
   date: Date;
@@ -99,6 +100,7 @@ function layoutEvents(events: CalendarEventRecord[]): Map<string, LayoutInfo> {
 }
 
 export function CalendarDayView({ date, events, onEventClick }: CalendarDayViewProps) {
+  useDemoMode();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [currentTime, setCurrentTime] = useState(new Date());
 
@@ -147,7 +149,7 @@ export function CalendarDayView({ date, events, onEventClick }: CalendarDayViewP
                   color: ec.text,
                 }}
               >
-                {event.title}
+                {displayTitle(event.id, event.title, "calendar")}
               </button>
               );
             })}
@@ -219,7 +221,7 @@ export function CalendarDayView({ date, events, onEventClick }: CalendarDayViewP
                 >
                   <div className="flex justify-between items-start">
                     <h4 className="text-xs font-semibold truncate pr-2">
-                      {event.title}
+                      {displayTitle(event.id, event.title, "calendar")}
                     </h4>
                     {event.meetingLink && isSafeUrl(event.meetingLink) && (
                       <button

--- a/apps/desktop/src/components/calendar/CalendarMonthView.tsx
+++ b/apps/desktop/src/components/calendar/CalendarMonthView.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import type { CalendarEventRecord } from "@brett/types";
 import { getEventGlassColor } from "@brett/utils";
+import { displayTitle, useDemoMode } from "@brett/ui";
 
 export interface CalendarMonthViewProps {
   month: Date;
@@ -51,6 +52,7 @@ function formatTime(isoStr: string): string {
 }
 
 export function CalendarMonthView({ month, events, onEventClick, onDayClick }: CalendarMonthViewProps) {
+  useDemoMode();
   const today = new Date();
   const weeks = getMonthGrid(month);
   const currentMonth = month.getMonth();
@@ -131,7 +133,7 @@ export function CalendarMonthView({ month, events, onEventClick, onDayClick }: C
                         {!event.isAllDay && (
                           <span className="opacity-60 mr-0.5">{formatTime(event.startTime)}</span>
                         )}
-                        {event.title}
+                        {displayTitle(event.id, event.title, "calendar")}
                       </button>
                       );
                     })}

--- a/apps/desktop/src/components/calendar/CalendarWeekView.tsx
+++ b/apps/desktop/src/components/calendar/CalendarWeekView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Video } from "lucide-react";
 import type { CalendarEventRecord } from "@brett/types";
 import { getEventGlassColor } from "@brett/utils";
+import { displayTitle, useDemoMode } from "@brett/ui";
 
 export interface CalendarWeekViewProps {
   startDate: Date;
@@ -107,6 +108,7 @@ function layoutEventsForDay(events: CalendarEventRecord[]): Map<string, LayoutIn
 }
 
 export function CalendarWeekView({ startDate, daysPerWeek, events, onEventClick }: CalendarWeekViewProps) {
+  useDemoMode();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [currentTime, setCurrentTime] = useState(new Date());
   const today = new Date();
@@ -230,7 +232,7 @@ export function CalendarWeekView({ startDate, daysPerWeek, events, onEventClick 
                       color: ec.text,
                     }}
                   >
-                    {event.title}
+                    {displayTitle(event.id, event.title, "calendar")}
                   </button>
                   );
                 })}
@@ -325,7 +327,7 @@ export function CalendarWeekView({ startDate, daysPerWeek, events, onEventClick 
                         }}
                       >
                         <h4 className="text-[10px] font-semibold truncate leading-tight">
-                          {event.title}
+                          {displayTitle(event.id, event.title, "calendar")}
                         </h4>
                         {dur >= 45 && event.location && (
                           <p className="text-[9px] opacity-70 truncate mt-0.5">

--- a/docs/superpowers/specs/2026-04-19-demo-mode-design.md
+++ b/docs/superpowers/specs/2026-04-19-demo-mode-design.md
@@ -16,7 +16,7 @@ Brent demos Brett on calls. Real task titles and calendar events contain private
 
 ## UX
 
-**Trigger:** `Cmd+Option+D` toggles demo mode on/off.
+**Trigger:** `Cmd+Shift+D` toggles demo mode on/off.
 
 **Indicator:** A small gold pill labeled `DEMO MODE` in the top-right of the sidebar header. Clickable — toggles off. Prevents the two failure modes: "I forgot it was on" (embarrassing next time the app is opened in front of someone) and "I forgot it was off" (started a screenshare, titles are live).
 
@@ -55,7 +55,7 @@ Pool size rationale: with ~60 phrases and a good hash, collisions across a demo-
 
 ### Trigger wiring
 
-Register `Cmd+Option+D` in `apps/desktop/src/App.tsx` alongside the existing keyboard handlers. Match the existing pattern (`metaKey && altKey && e.key === 'd'`). Call `demoMode.toggle()`. No Electron `globalShortcut` — in-window only, which is what we want (shortcut only fires when Brett is focused).
+Register `Cmd+Shift+D` in `apps/desktop/src/App.tsx` alongside the existing keyboard handlers. Match the existing pattern (`metaKey && altKey && e.key === 'd'`). Call `demoMode.toggle()`. No Electron `globalShortcut` — in-window only, which is what we want (shortcut only fires when Brett is focused).
 
 ### Indicator placement
 
@@ -85,7 +85,7 @@ Everywhere a thing title or calendar event title is rendered today, replace `thi
 ## Data flow
 
 ```
-Cmd+Option+D
+Cmd+Shift+D
   → App.tsx keydown handler
   → demoMode.toggle()
   → localStorage write + listener fanout
@@ -107,7 +107,7 @@ Unit tests in `packages/ui/src/lib/demoMode.test.ts`:
 
 One integration test (desktop, if the existing test harness allows):
 - Render a ThingCard, assert real title is shown.
-- Fire Cmd+Option+D.
+- Fire Cmd+Shift+D.
 - Assert fake title is shown.
 - Fire again. Assert real title is back.
 
@@ -122,6 +122,6 @@ One integration test (desktop, if the existing test harness allows):
 ## Risks
 
 - **Forgetting to toggle off.** Mitigated by the always-visible gold `DEMO MODE` badge.
-- **Shortcut collision.** `Cmd+Option+D` is currently unused in Brett; confirm during implementation by grepping existing handlers.
+- **Shortcut collision.** `Cmd+Shift+D` is currently unused in Brett; confirm during implementation by grepping existing handlers.
 - **Performance.** `displayTitle` on the hot path for every list item. The `enabled === false` early return keeps this O(1) and allocation-free. The `enabled === true` path is one hash + one array index — also O(1).
 - **Test harness coverage.** The integration test assumes the desktop test setup renders `ThingCard` and can dispatch keyboard events. If that harness doesn't exist, ship the unit tests alone and verify the integration manually before merging.

--- a/packages/ui/src/CalendarEventDetailPanel.tsx
+++ b/packages/ui/src/CalendarEventDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
   Clock,
   CheckSquare,
 } from "lucide-react";
+import { displayTitle, useDemoMode } from "./lib/demoMode";
 import { SimpleMarkdown } from "./SimpleMarkdown";
 import { BrettMark } from "./BrettMark";
 import type {
@@ -202,6 +203,7 @@ export function CalendarEventDetailPanel({
   onNavigate,
   assistantName = "Brett",
 }: CalendarEventDetailPanelProps) {
+  useDemoMode();
   const [showAllAttendees, setShowAllAttendees] = useState(false);
   const [rsvpNote, setRsvpNote] = useState("");
   const [selectedRsvp, setSelectedRsvp] = useState<CalendarRsvpStatus>(
@@ -248,7 +250,7 @@ export function CalendarEventDetailPanel({
           <div className="pb-4">
             <div className="flex items-start justify-between gap-3 mb-2">
               <h2 className="text-2xl font-semibold text-white leading-tight">
-                {detail.title}
+                {displayTitle(detail.id, detail.title, "calendar")}
               </h2>
               <button
                 onClick={onClose}
@@ -461,7 +463,7 @@ export function CalendarEventDetailPanel({
                               isDone ? "text-white/30 line-through" : "text-white/70 hover:text-white/90"
                             }`}
                           >
-                            {item.title}
+                            {displayTitle(item.id, item.title, "thing")}
                           </span>
                           {item.dueDate && (
                             <span className="text-[10px] text-white/30 flex-shrink-0">
@@ -617,7 +619,7 @@ export function CalendarEventDetailPanel({
                             : "text-white/70 group-hover:text-white/90"
                         }`}
                       >
-                        {item.title}
+                        {displayTitle(item.entityId, item.title, "thing")}
                       </span>
                       {isDone && (
                         <CheckSquare size={12} className="text-white/20 flex-shrink-0" />
@@ -682,7 +684,7 @@ export function CalendarEventDetailPanel({
                             >
                               <div className="w-3 h-3 rounded border border-amber-500/40 flex-shrink-0" />
                               <span className="text-xs text-amber-300/70 truncate group-hover:text-amber-300/90">
-                                {item.title}
+                                {displayTitle(item.id, item.title, "thing")}
                               </span>
                             </div>
                           ))}

--- a/packages/ui/src/CalendarTimeline.tsx
+++ b/packages/ui/src/CalendarTimeline.tsx
@@ -4,6 +4,7 @@ import type {
   CalendarEventDisplay,
   CalendarRsvpStatus,
 } from "@brett/types";
+import { displayTitle, useDemoMode } from "./lib/demoMode";
 
 // TODO: Import EventHoverTooltip once available
 // import { EventHoverTooltip } from "./EventHoverTooltip";
@@ -158,6 +159,7 @@ export function CalendarTimeline({
   onToday,
   assistantName = "Brett",
 }: CalendarTimelineProps) {
+  useDemoMode();
   // Empty state: clean timeline grid + connect CTA — no fake events
   if (!isLoading && events.length === 0 && onConnect && onDismiss) {
     const now = new Date();
@@ -488,7 +490,7 @@ export function CalendarTimeline({
                 >
                   <div className="flex justify-between items-start">
                     <h4 className="text-xs font-semibold truncate pr-4">
-                      {event.title}
+                      {displayTitle(event.id, event.title, "calendar")}
                     </h4>
                     <div className="flex items-center gap-1 flex-shrink-0">
                       {event.meetingLink && (

--- a/packages/ui/src/ContentDetailPanel.tsx
+++ b/packages/ui/src/ContentDetailPanel.tsx
@@ -18,6 +18,7 @@ import type { SuggestionItem } from "./LinkedItemsList";
 import { BrettThread } from "./BrettThread";
 import type { BrettThreadMessage } from "./BrettThread";
 import { ContentPreview } from "./ContentPreview";
+import { useDisplayTitle, useDemoMode } from "./lib/demoMode";
 
 interface ContentDetailPanelProps {
   detail: ThingDetail;
@@ -103,6 +104,8 @@ export function ContentDetailPanel({
   onNavigate,
   assistantName = "Brett",
 }: ContentDetailPanelProps) {
+  const { enabled: demoOn } = useDemoMode();
+  const shownTitle = useDisplayTitle(detail.id, detail.title, "thing");
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState(detail.title);
   const titleRef = useRef<HTMLInputElement>(null);
@@ -165,8 +168,8 @@ export function ContentDetailPanel({
             </div>
           </div>
 
-          {/* Editable title */}
-          {editingTitle ? (
+          {/* Editable title (read-only when demo mode is on) */}
+          {editingTitle && !demoOn ? (
             <input
               ref={titleRef}
               value={titleValue}
@@ -183,10 +186,12 @@ export function ContentDetailPanel({
             />
           ) : (
             <h2
-              onClick={() => setEditingTitle(true)}
-              className="text-2xl font-semibold text-white leading-tight cursor-text hover:border-b hover:border-white/20 pb-1 transition-colors"
+              onClick={demoOn ? undefined : () => setEditingTitle(true)}
+              className={`text-2xl font-semibold text-white leading-tight pb-1 transition-colors ${
+                demoOn ? "" : "cursor-text hover:border-b hover:border-white/20"
+              }`}
             >
-              {detail.title}
+              {shownTitle}
             </h2>
           )}
 

--- a/packages/ui/src/DailyBriefing.tsx
+++ b/packages/ui/src/DailyBriefing.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { X, RefreshCw, Loader2, Settings } from "lucide-react";
+import { displayTitle, useDemoMode } from "./lib/demoMode";
 
 interface OverdueItem {
   title: string;
@@ -151,6 +152,7 @@ export function DailyBriefing({
   onItemClick,
   assistantName = "Brett",
 }: DailyBriefingProps) {
+  useDemoMode();
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
@@ -277,20 +279,23 @@ export function DailyBriefing({
               </p>
               {summary.overdueItems.length > 0 && (
                 <ul className="space-y-1">
-                  {summary.overdueItems.map((item, idx) => (
-                    <li
-                      key={idx}
-                      className="flex items-start gap-2 text-sm text-white/60 leading-relaxed"
-                    >
-                      <span className="text-amber-500/50 mt-1">•</span>
-                      <span>
-                        {item.title}{" "}
-                        <span className="text-white/30">
-                          (due {item.dueDate})
+                  {summary.overdueItems.map((item, idx) => {
+                    const matchedId = titleMap.get(item.title.toLowerCase())?.id;
+                    return (
+                      <li
+                        key={idx}
+                        className="flex items-start gap-2 text-sm text-white/60 leading-relaxed"
+                      >
+                        <span className="text-amber-500/50 mt-1">•</span>
+                        <span>
+                          {displayTitle(matchedId ?? item.title, item.title, "thing")}{" "}
+                          <span className="text-white/30">
+                            (due {item.dueDate})
+                          </span>
                         </span>
-                      </span>
-                    </li>
-                  ))}
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </>

--- a/packages/ui/src/DemoModeBadge.tsx
+++ b/packages/ui/src/DemoModeBadge.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { EyeOff } from "lucide-react";
+import { useDemoMode } from "./lib/demoMode";
+
+interface DemoModeBadgeProps {
+  isCollapsed?: boolean;
+}
+
+export function DemoModeBadge({ isCollapsed = false }: DemoModeBadgeProps) {
+  const { enabled, toggle } = useDemoMode();
+  if (!enabled) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      title="Demo mode is on — click to turn off (⌘⌥D)"
+      aria-label="Demo mode on — click to turn off"
+      className={`
+        flex items-center gap-1.5 mb-3 rounded-md border transition-colors
+        bg-brett-gold/15 border-brett-gold/30 text-brett-gold
+        hover:bg-brett-gold/25 hover:border-brett-gold/50
+        ${isCollapsed ? "justify-center h-8 w-full" : "px-2 py-1 w-full"}
+      `}
+    >
+      <EyeOff size={12} className="flex-shrink-0" />
+      {!isCollapsed && (
+        <span className="text-[10px] font-semibold uppercase tracking-[0.15em]">
+          Demo Mode
+        </span>
+      )}
+    </button>
+  );
+}

--- a/packages/ui/src/DemoModeBadge.tsx
+++ b/packages/ui/src/DemoModeBadge.tsx
@@ -14,7 +14,7 @@ export function DemoModeBadge({ isCollapsed = false }: DemoModeBadgeProps) {
     <button
       type="button"
       onClick={toggle}
-      title="Demo mode is on — click to turn off (⌘⌥D)"
+      title="Demo mode is on — click to turn off (⌘⇧D)"
       aria-label="Demo mode on — click to turn off"
       className={`
         flex items-center gap-1.5 mb-3 rounded-md border transition-colors

--- a/packages/ui/src/EventHoverTooltip.tsx
+++ b/packages/ui/src/EventHoverTooltip.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { MapPin, Users, RefreshCw, Check, HelpCircle, X } from "lucide-react";
 import type { CalendarEventDisplay, CalendarRsvpStatus } from "@brett/types";
+import { useDisplayTitle } from "./lib/demoMode";
 
 interface EventHoverTooltipProps {
   event: CalendarEventDisplay;
@@ -63,6 +64,7 @@ export function EventHoverTooltip({
   const triggerRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [position, setPosition] = useState({ top: 0, left: 0 });
+  const shownTitle = useDisplayTitle(event.id, event.title, "calendar");
 
   const updatePosition = () => {
     if (!triggerRef.current) return;
@@ -159,7 +161,7 @@ export function EventHoverTooltip({
             <div className="p-3">
               {/* Compact: always visible */}
               <h4 className="text-sm font-semibold text-white leading-tight mb-1">
-                {event.title}
+                {shownTitle}
               </h4>
               <div className="flex items-center gap-2 text-xs text-white/60 mb-1">
                 <span>

--- a/packages/ui/src/InboxItemRow.tsx
+++ b/packages/ui/src/InboxItemRow.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { Zap, BookOpen, Check, MessageSquare, FileText, Play, File, Headphones, Globe, RefreshCw, Download } from "lucide-react";
 import type { Thing } from "@brett/types";
 import { useDraggable } from "@dnd-kit/core";
+import { useDisplayTitle } from "./lib/demoMode";
 
 interface InboxItemRowProps {
   thing: Thing;
@@ -40,6 +41,7 @@ export function InboxItemRow({
   onInstallUpdate,
 }: InboxItemRowProps) {
   const [completing, setCompleting] = useState(false);
+  const shownTitle = useDisplayTitle(thing.id, thing.title, "thing");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: thing.id,
     data: {
@@ -136,7 +138,7 @@ export function InboxItemRow({
       {/* Title + provenance */}
       <div className="flex-1 min-w-0">
         <span className="text-sm text-white/90 truncate block">
-          {thing.title}
+          {shownTitle}
         </span>
         {((thing.source === "scout" && thing.scoutName) ||
           (thing.source === "Granola" && thing.meetingNoteTitle)) && (

--- a/packages/ui/src/LeftNav.tsx
+++ b/packages/ui/src/LeftNav.tsx
@@ -11,6 +11,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useClickOutside } from "./useClickOutside";
+import { DemoModeBadge } from "./DemoModeBadge";
 
 interface LeftNavUser {
   name: string | null;
@@ -110,6 +111,7 @@ export function LeftNav({
       ${isCollapsed ? "w-[68px] px-2" : "w-[220px] px-4"}
     `}
     >
+      <DemoModeBadge isCollapsed={isCollapsed} />
       {/* Main Links */}
       <div className="space-y-1 mb-8">
         <NavItem

--- a/packages/ui/src/NextUpCard.tsx
+++ b/packages/ui/src/NextUpCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { ExternalLink, MapPin, Clock, Users } from "lucide-react";
 import type { CalendarEventDisplay } from "@brett/types";
 import type { NextUpTimerState } from "./useNextUpTimer";
+import { useDisplayTitle } from "./lib/demoMode";
 
 interface NextUpCardProps {
   event: CalendarEventDisplay;
@@ -28,6 +29,7 @@ function CompactCard({
 }) {
   const [isHovered, setIsHovered] = useState(false);
   const isNow = timer.isHappening;
+  const shownTitle = useDisplayTitle(event.id, event.title, "calendar");
 
   return (
     <div
@@ -57,7 +59,7 @@ function CompactCard({
         </span>
       </div>
 
-      <div className="text-sm font-semibold text-white mb-1 truncate">{event.title}</div>
+      <div className="text-sm font-semibold text-white mb-1 truncate">{shownTitle}</div>
 
       <div className="text-[11px] text-white/50 truncate">
         {formatTimeRange(event.startTime, event.endTime)}
@@ -120,6 +122,7 @@ function ExpandedCard({
   timer: NextUpTimerState;
   onEventClick: () => void;
 }) {
+  const shownTitle = useDisplayTitle(event.id, event.title, "calendar");
   return (
     <div
       onClick={onEventClick}
@@ -149,7 +152,7 @@ function ExpandedCard({
       </div>
 
       <h3 className="text-xl font-semibold text-white mb-3 group-hover:text-amber-50 transition-colors">
-        {event.title}
+        {shownTitle}
       </h3>
 
       <div className="flex flex-wrap gap-4 text-xs text-white/50 mb-4">

--- a/packages/ui/src/Omnibar.tsx
+++ b/packages/ui/src/Omnibar.tsx
@@ -7,6 +7,7 @@ import { SimpleMarkdown } from "./SimpleMarkdown";
 import { WeatherPill, WeatherPillSkeleton, WeatherPillEmpty } from "./WeatherPill";
 import { WeatherExpanded } from "./WeatherExpanded";
 import type { DisplayHint, WeatherData } from "@brett/types";
+import { useDisplayTitle } from "./lib/demoMode";
 
 export interface OmnibarMessage {
   role: "user" | "assistant";
@@ -740,6 +741,16 @@ export function SearchResultRow({
   px?: string;
 }) {
   const metaLabel = getMetaLabel(item);
+  const demoKind = item.entityType === "item"
+    ? "thing"
+    : item.entityType === "calendar_event"
+      ? "calendar"
+      : null;
+  const shownTitle = useDisplayTitle(
+    demoKind ? item.entityId : null,
+    item.title,
+    demoKind ?? "thing",
+  );
   return (
     <button
       className={`w-full flex items-center gap-3 ${px} py-2.5 text-sm text-left transition-colors ${
@@ -752,7 +763,7 @@ export function SearchResultRow({
       <span className="text-[10px] text-white/30 uppercase flex-shrink-0">
         {getEntityTypeLabel(item)}
       </span>
-      <span className="truncate">{item.title}</span>
+      <span className="truncate">{shownTitle}</span>
       {metaLabel && (
         <span className="ml-auto text-[10px] text-white/30 flex-shrink-0">
           {metaLabel}

--- a/packages/ui/src/SkillResultCard.tsx
+++ b/packages/ui/src/SkillResultCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Check, Calendar, Settings, List, ArrowRight } from "lucide-react";
 import { SimpleMarkdown } from "./SimpleMarkdown";
 import type { DisplayHint } from "@brett/types";
+import { displayTitle, useDemoMode } from "./lib/demoMode";
 
 interface SkillResultCardProps {
   displayHint: DisplayHint;
@@ -13,6 +14,7 @@ interface SkillResultCardProps {
 }
 
 export function SkillResultCard({ displayHint, data, message, onItemClick, onEventClick, onNavigate }: SkillResultCardProps) {
+  useDemoMode();
   switch (displayHint.type) {
     // ─── Action confirmations (create, complete, move, etc.) ───
     // Subtle inline confirmation — small check icon, text with links.
@@ -53,7 +55,7 @@ export function SkillResultCard({ displayHint, data, message, onItemClick, onEve
                 }`}
               />
               <span className={`text-sm truncate ${onItemClick ? "text-white/70 hover:text-white/90" : "text-white/70"}`}>
-                {item.title}
+                {displayTitle(item.id, item.title, "thing")}
               </span>
               {onItemClick && (
                 <ArrowRight size={10} className="ml-auto text-white/20 flex-shrink-0" />
@@ -91,7 +93,7 @@ export function SkillResultCard({ displayHint, data, message, onItemClick, onEve
                   {time}
                 </span>
                 <span className="text-sm text-white/70 truncate">
-                  {event.title}
+                  {displayTitle(event.id, event.title, "calendar")}
                 </span>
               </div>
             );

--- a/packages/ui/src/TaskDetailPanel.tsx
+++ b/packages/ui/src/TaskDetailPanel.tsx
@@ -18,6 +18,7 @@ import { LinkedItemsList } from "./LinkedItemsList";
 import type { SuggestionItem } from "./LinkedItemsList";
 import { BrettThread } from "./BrettThread";
 import type { BrettThreadMessage } from "./BrettThread";
+import { useDisplayTitle, useDemoMode } from "./lib/demoMode";
 
 interface TaskDetailPanelProps {
   detail: ThingDetail;
@@ -113,6 +114,8 @@ export function TaskDetailPanel({
   const isApproval = isNewsletterApproval(detail.contentMetadata);
   const pendingNewsletterId = isApproval ? (detail.contentMetadata as any).pendingNewsletterId : undefined;
 
+  const { enabled: demoOn } = useDemoMode();
+  const shownTitle = useDisplayTitle(detail.id, detail.title, "thing");
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState(detail.title);
   const titleRef = useRef<HTMLInputElement>(null);
@@ -181,8 +184,8 @@ export function TaskDetailPanel({
             </div>
           </div>
 
-          {/* Editable title */}
-          {editingTitle ? (
+          {/* Editable title (read-only when demo mode is on) */}
+          {editingTitle && !demoOn ? (
             <input
               ref={titleRef}
               value={titleValue}
@@ -199,10 +202,12 @@ export function TaskDetailPanel({
             />
           ) : (
             <h2
-              onClick={() => setEditingTitle(true)}
-              className="text-2xl font-semibold text-white leading-tight cursor-text hover:border-b hover:border-white/20 pb-1 transition-colors"
+              onClick={demoOn ? undefined : () => setEditingTitle(true)}
+              className={`text-2xl font-semibold text-white leading-tight pb-1 transition-colors ${
+                demoOn ? "" : "cursor-text hover:border-b hover:border-white/20"
+              }`}
             >
-              {detail.title}
+              {shownTitle}
             </h2>
           )}
 

--- a/packages/ui/src/ThingCard.tsx
+++ b/packages/ui/src/ThingCard.tsx
@@ -3,6 +3,7 @@ import { StaleTooltip } from "./StaleTooltip";
 import { Zap, BookOpen, Calendar, Check, RotateCcw, MessageSquare, FileText, Play, File, Headphones, Globe, RefreshCw, Download } from "lucide-react";
 import { useDraggable } from "@dnd-kit/core";
 import type { Thing } from "@brett/types";
+import { useDisplayTitle } from "./lib/demoMode";
 
 interface ThingCardProps {
   thing: Thing;
@@ -16,6 +17,7 @@ interface ThingCardProps {
 }
 
 export function ThingCard({ thing, onClick, onToggle, onFocus, isFocused, onReconnect, reconnectPending, onInstallUpdate }: ThingCardProps) {
+  const shownTitle = useDisplayTitle(thing.id, thing.title, "thing");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: thing.id,
     data: {
@@ -158,7 +160,7 @@ export function ThingCard({ thing, onClick, onToggle, onFocus, isFocused, onReco
                 : "text-white"
             }`}
           >
-            {thing.title}
+            {shownTitle}
           </h4>
           {thing.stalenessDays && !thing.isCompleted && !completing && (
             <StaleTooltip days={thing.stalenessDays}>

--- a/packages/ui/src/UpNextCard.tsx
+++ b/packages/ui/src/UpNextCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { CalendarEventDisplay } from "@brett/types";
+import { useDisplayTitle } from "./lib/demoMode";
 
 interface UpNextCardProps {
   event: CalendarEventDisplay;
@@ -7,6 +8,7 @@ interface UpNextCardProps {
 }
 
 export function UpNextCard({ event, onClick }: UpNextCardProps) {
+  const shownTitle = useDisplayTitle(event.id, event.title, "calendar");
   return (
     <div
       onClick={onClick}
@@ -25,7 +27,7 @@ export function UpNextCard({ event, onClick }: UpNextCardProps) {
       </div>
 
       <h3 className="text-xl font-semibold text-white mb-2 group-hover:text-amber-50 transition-colors">
-        {event.title}
+        {shownTitle}
       </h3>
 
       {event.brettObservation && (

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -60,3 +60,6 @@ export { ScoutMemoryTab } from "./ScoutMemoryTab";
 export { WeatherPill, WeatherPillSkeleton, WeatherPillEmpty } from "./WeatherPill";
 export { WeatherExpanded } from "./WeatherExpanded";
 export { RecentFindingsPanel, type RecentFindingItem } from "./RecentFindingsPanel";
+export { DemoModeBadge } from "./DemoModeBadge";
+export { demoMode, useDemoMode, displayTitle, useDisplayTitle } from "./lib/demoMode";
+export type { DemoTitleKind } from "./lib/demoMode";

--- a/packages/ui/src/lib/demoMode.test.ts
+++ b/packages/ui/src/lib/demoMode.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { demoMode, displayTitle } from "./demoMode";
+
+describe("demoMode", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    demoMode.set(false);
+  });
+
+  afterEach(() => {
+    demoMode.set(false);
+    window.localStorage.clear();
+  });
+
+  describe("displayTitle (disabled)", () => {
+    it("returns the real title when demo mode is off", () => {
+      expect(displayTitle("abc", "Meet with Sarah about Q3", "thing")).toBe(
+        "Meet with Sarah about Q3",
+      );
+      expect(displayTitle("xyz", "Board meeting", "calendar")).toBe("Board meeting");
+    });
+
+    it("passes through even when id is missing (off)", () => {
+      expect(displayTitle(null, "Real", "thing")).toBe("Real");
+      expect(displayTitle(undefined, "Real", "calendar")).toBe("Real");
+      expect(displayTitle("", "Real", "thing")).toBe("Real");
+    });
+  });
+
+  describe("displayTitle (enabled)", () => {
+    beforeEach(() => {
+      demoMode.set(true);
+    });
+
+    it("returns a fake title that is not the real one", () => {
+      const fake = displayTitle("thing-123", "Call mom", "thing");
+      expect(fake).not.toBe("Call mom");
+      expect(typeof fake).toBe("string");
+      expect(fake.length).toBeGreaterThan(0);
+    });
+
+    it("is stable across repeated calls with the same id", () => {
+      const first = displayTitle("stable-id", "Real", "thing");
+      const second = displayTitle("stable-id", "Real", "thing");
+      const third = displayTitle("stable-id", "Different real title", "thing");
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it("is stable across demoMode toggles", () => {
+      const before = displayTitle("toggle-id", "Real", "thing");
+      demoMode.set(false);
+      demoMode.set(true);
+      const after = displayTitle("toggle-id", "Real", "thing");
+      expect(after).toBe(before);
+    });
+
+    it("keeps thing and calendar pools disjoint", () => {
+      // Scan a range of ids; no calendar fake should appear in the thing pool or vice versa.
+      const thingOutputs = new Set<string>();
+      const calendarOutputs = new Set<string>();
+      for (let i = 0; i < 500; i++) {
+        thingOutputs.add(displayTitle(`id-${i}`, "Real", "thing"));
+        calendarOutputs.add(displayTitle(`id-${i}`, "Real", "calendar"));
+      }
+      for (const t of thingOutputs) {
+        expect(calendarOutputs.has(t)).toBe(false);
+      }
+    });
+
+    it("falls back to the real title when id is missing", () => {
+      expect(displayTitle(null, "Fallback", "thing")).toBe("Fallback");
+      expect(displayTitle(undefined, "Fallback", "calendar")).toBe("Fallback");
+      expect(displayTitle("", "Fallback", "thing")).toBe("Fallback");
+    });
+
+    it("distributes reasonably across the pool (no single phrase hogs)", () => {
+      const counts = new Map<string, number>();
+      const N = 500;
+      for (let i = 0; i < N; i++) {
+        const fake = displayTitle(`uuid-${i}-xxxx-${i * 7}`, "Real", "thing");
+        counts.set(fake, (counts.get(fake) ?? 0) + 1);
+      }
+      // With 60 phrases and 500 ids, uniform ≈ 8.3 per phrase. Allow up to 3x as sanity.
+      const max = Math.max(...counts.values());
+      expect(max).toBeLessThanOrEqual(25);
+      // At least half the pool should be used.
+      expect(counts.size).toBeGreaterThanOrEqual(30);
+    });
+  });
+
+  describe("store", () => {
+    it("notifies subscribers synchronously on toggle", () => {
+      let notifications = 0;
+      const unsub = demoMode.subscribe(() => {
+        notifications++;
+      });
+      demoMode.toggle();
+      expect(notifications).toBe(1);
+      demoMode.toggle();
+      expect(notifications).toBe(2);
+      unsub();
+      demoMode.toggle();
+      expect(notifications).toBe(2);
+    });
+
+    it("does not notify when set to the current value", () => {
+      let notifications = 0;
+      const unsub = demoMode.subscribe(() => {
+        notifications++;
+      });
+      demoMode.set(false); // already false
+      expect(notifications).toBe(0);
+      demoMode.set(true);
+      expect(notifications).toBe(1);
+      demoMode.set(true); // already true
+      expect(notifications).toBe(1);
+      unsub();
+    });
+
+    it("persists to localStorage", () => {
+      demoMode.set(true);
+      expect(window.localStorage.getItem("brett:demoMode")).toBe("1");
+      demoMode.set(false);
+      expect(window.localStorage.getItem("brett:demoMode")).toBe("0");
+    });
+  });
+});

--- a/packages/ui/src/lib/demoMode.ts
+++ b/packages/ui/src/lib/demoMode.ts
@@ -1,0 +1,209 @@
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "brett:demoMode";
+
+type Listener = () => void;
+
+let enabled = readPersisted();
+const listeners = new Set<Listener>();
+
+function readPersisted(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writePersisted(value: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    // Storage quota / private-mode etc. — demo mode still works in-memory.
+  }
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): boolean {
+  return enabled;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export const demoMode = {
+  isEnabled(): boolean {
+    return enabled;
+  },
+  set(value: boolean) {
+    if (enabled === value) return;
+    enabled = value;
+    writePersisted(value);
+    listeners.forEach((l) => l());
+  },
+  toggle() {
+    demoMode.set(!enabled);
+  },
+  subscribe,
+};
+
+export function useDemoMode(): { enabled: boolean; toggle: () => void } {
+  const value = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return { enabled: value, toggle: demoMode.toggle };
+}
+
+export type DemoTitleKind = "thing" | "calendar";
+
+/**
+ * Synchronous read. Does NOT subscribe a component to re-render. Use in
+ * non-rendering contexts (filters, handlers). In render paths, prefer
+ * `useDisplayTitle` so the component re-renders when demo mode flips.
+ */
+export function displayTitle(
+  id: string | undefined | null,
+  realTitle: string,
+  kind: DemoTitleKind,
+): string {
+  if (!enabled) return realTitle;
+  if (!id) return realTitle;
+  const pool = kind === "thing" ? THING_POOL : CALENDAR_POOL;
+  return pool[hashFnv1a(id) % pool.length];
+}
+
+/**
+ * Render-path variant: subscribes to the demo mode store so the component
+ * re-renders when it flips, then returns the displayed title.
+ */
+export function useDisplayTitle(
+  id: string | undefined | null,
+  realTitle: string,
+  kind: DemoTitleKind,
+): string {
+  useDemoMode();
+  return displayTitle(id, realTitle, kind);
+}
+
+function hashFnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    // 32-bit FNV prime multiply: h * 16777619
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h;
+}
+
+const THING_POOL: readonly string[] = [
+  "Negotiate truce with the office plant",
+  "Email the dragon about escrow",
+  "Ransom back the stapler",
+  "File taxes for the rubber duck",
+  "Apologize to the printer",
+  "Wrangle the printer cartel",
+  "Teach the toaster some manners",
+  "Decode the pigeon's memo",
+  "Update the quarterly snack forecast",
+  "Book therapy for the router",
+  "Return library book from 2007",
+  "Invoice Santa (attempt three)",
+  "Reconcile the coffee budget",
+  "Audit the snack drawer",
+  "Finalize the banana strategy",
+  "Schedule a summit with the cat",
+  "Recaulk the dream",
+  "Debrief the houseplants",
+  "Follow up with the squirrel",
+  "Draft manifesto re: yogurt",
+  "Brief the interns on vibes",
+  "Pitch memoir to the mailman",
+  "Rewrite life story, act II",
+  "Replace the sad lightbulb",
+  "Finish novel about spreadsheets",
+  "Befriend the neighbor's dog",
+  "Return the borrowed hat",
+  "Mail postcard to past self",
+  "Reassemble the blender",
+  "Host summit with the worm bin",
+  "Alert HR re: the ghost",
+  "Submit expense: one (1) vibe",
+  "Prepare lore for Monday",
+  "Deliver eulogy for the fern",
+  "Log grievance with the wind",
+  "Buy glitter for the rebrand",
+  "Retrieve the sacred hoodie",
+  "Defrag the junk drawer",
+  "Whisper apology to the WiFi",
+  "Mend the beanbag",
+  "Commission portrait of the dog",
+  "Refund the unread book",
+  "Water the imaginary cactus",
+  "Bribe the scanner",
+  "Schedule a vibe check",
+  "Recover the lost sock",
+  "Appease the parking meter",
+  "Edit the group chat lore",
+  "Ghostwrite LinkedIn for the cat",
+  "Audit the tupperware situation",
+  "Haggle with the self-checkout",
+  "Embiggen the garden gnome",
+  "Renew vows with the couch",
+  "Translate the dishwasher's demands",
+  "Pen apology letter to the car",
+  "Steam the ceremonial dumplings",
+  "Calendar a chat with the fog",
+  "Dust off the motivational crystals",
+  "Overthrow the junk mail regime",
+  "Invite the moon to coffee",
+];
+
+const CALENDAR_POOL: readonly string[] = [
+  "Tactical nap sync",
+  "Vibes quarterly",
+  "Stakeholder beef",
+  "Alignment grooming",
+  "Standup about the standup",
+  "Retro: feelings edition",
+  "1:1 with the void",
+  "Pre-meeting meeting",
+  "Post-meeting meeting",
+  "All-hands séance",
+  "Coffee chat (scheduled spontaneity)",
+  "Quarterly crisis review",
+  "Ideation rave",
+  "Kickoff for the kickoff",
+  "Roadmap poetry slam",
+  "Brainstorm dump",
+  "Steering committee brunch",
+  "KPI group therapy",
+  "OKR bake-off",
+  "Sprint planning ritual",
+  "Strategy cosplay",
+  "Feedback confessional",
+  "Leadership huddle (emotional)",
+  "Demo rehearsal rehearsal",
+  "Budget wake",
+  "Cross-functional vibes check",
+  "Roadmap tarot reading",
+  "Pricing séance",
+  "Launch postmortem pre-mortem",
+  "Deep work hour (theoretical)",
+  "Customer escalation opera",
+  "Quarterly metaphor review",
+  "AMA with the algorithm",
+  "Retention ritual",
+  "Onboarding scavenger hunt",
+  "Innovation open mic",
+  "Security drill, kind of",
+  "Offsite (indoor)",
+  "Mandatory fun block",
+  "Syncsync",
+];


### PR DESCRIPTION
## Summary
Reapplies the demo mode commits that were reverted in #49. The revert (v0.1.1218) did not fix the packaged-build Router bug — nav is still broken after auto-update. Reapplying so we can confirm whether demo mode is the cause or a red herring.

Hypotheses this release tests:
- If the new packaged build is **broken** → demo mode is the cause, and auto-update didn't apply the revert for some reason (or the revert build had the same bug baked in somewhere else).
- If the new packaged build is **working** → demo mode wasn't the cause; the "still broken" state means the user is still running the pre-revert version (auto-update didn't apply), and we need a different investigation.

Reapplies:
- \`e0a3fc8\` feat(desktop): demo mode
- \`e09e31a\` feat(desktop): rebind demo mode to ⌘⇧D

## Test plan
- [x] typecheck
- [ ] merge → API redeploys
- [ ] \`scripts/release.sh desktop\` → v0.1.1220
- [ ] User updates + tests nav