### PR TITLE
fix(ai): fallback by title+date when get_meeting_notes misses calendar link

### DIFF
--- a/packages/ai/src/skills/__tests__/get-meeting-notes.test.ts
+++ b/packages/ai/src/skills/__tests__/get-meeting-notes.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { titleMatchesCalendarEvent } from "../get-meeting-notes.js";
+
+// Title-match helper for the get_meeting_notes fallback path. When a
+// calendarEventId lookup returns null (matcher didn't link the meeting
+// to its calendar event), we look for an unlinked MeetingNote on the
+// same day whose title matches either direction of containment.
+
+describe("titleMatchesCalendarEvent", () => {
+  it("matches exact titles", () => {
+    expect(
+      titleMatchesCalendarEvent(
+        "Brent Barkman and Yves Beauzil",
+        "Brent Barkman and Yves Beauzil",
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      titleMatchesCalendarEvent(
+        "brent barkman and yves beauzil",
+        "BRENT BARKMAN AND YVES BEAUZIL",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches when Granola's title is a prefix/subset of the calendar title", () => {
+    // Observed in prod: calendar titles often carry brackets/tags that
+    // Granola strips (e.g. "[VC] " prefix on VC intro calls).
+    expect(
+      titleMatchesCalendarEvent(
+        "Intros: Brent x Swetha",
+        "[VC] Intros: Brent x Swetha",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches when the calendar title is a subset of Granola's title", () => {
+    expect(
+      titleMatchesCalendarEvent(
+        "Weekly Sync — Brent and Dan",
+        "Weekly Sync",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated titles", () => {
+    expect(
+      titleMatchesCalendarEvent(
+        "Brent Barkman and Yves Beauzil",
+        "Q3 Planning Review",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects empty titles", () => {
+    expect(titleMatchesCalendarEvent("", "anything")).toBe(false);
+    expect(titleMatchesCalendarEvent("anything", "")).toBe(false);
+    expect(titleMatchesCalendarEvent("  ", "anything")).toBe(false);
+  });
+});

--- a/packages/ai/src/skills/get-meeting-notes.ts
+++ b/packages/ai/src/skills/get-meeting-notes.ts
@@ -33,9 +33,38 @@ export const getMeetingNotesSkill: Skill = {
 
     // 1. Lookup by calendar event ID
     if (p.calendarEventId) {
-      const meeting = await ctx.prisma.meetingNote.findFirst({
+      let meeting = await ctx.prisma.meetingNote.findFirst({
         where: { calendarEventId: p.calendarEventId, userId: ctx.userId },
       });
+
+      // Fallback: the matcher may have missed linking this meeting to
+      // its CalendarEvent (zero-width intervals + drifted timezones in
+      // Granola's payload have broken this before). Look up the event
+      // itself and find an unlinked MeetingNote with a matching title
+      // within ±12h — enough to absorb any residual drift.
+      if (!meeting) {
+        const calEvent = await ctx.prisma.calendarEvent.findFirst({
+          where: { id: p.calendarEventId, userId: ctx.userId },
+          select: { title: true, startTime: true },
+        });
+        if (calEvent) {
+          const HALF_DAY_MS = 12 * 60 * 60 * 1000;
+          const candidates = await ctx.prisma.meetingNote.findMany({
+            where: {
+              userId: ctx.userId,
+              meetingStartedAt: {
+                gte: new Date(calEvent.startTime.getTime() - HALF_DAY_MS),
+                lte: new Date(calEvent.startTime.getTime() + HALF_DAY_MS),
+              },
+            },
+            orderBy: { meetingStartedAt: "asc" },
+          });
+          meeting =
+            candidates.find((m) =>
+              titleMatchesCalendarEvent(m.title, calEvent.title),
+            ) ?? null;
+        }
+      }
 
       if (!meeting) {
         return {
@@ -146,6 +175,21 @@ interface MeetingRow {
   title: string;
   summary: string | null;
   meetingStartedAt: Date;
+}
+
+/**
+ * Relaxed title match for the fallback path. Either side may contain
+ * the other — Granola's title sometimes trims the calendar event's
+ * prefix (e.g. "[VC] Intros: Brent x Swetha" vs "Intros: Brent x Swetha").
+ */
+export function titleMatchesCalendarEvent(
+  meetingTitle: string,
+  calendarEventTitle: string,
+): boolean {
+  const m = meetingTitle.trim().toLowerCase();
+  const c = calendarEventTitle.trim().toLowerCase();
+  if (!m || !c) return false;
+  return m === c || m.includes(c) || c.includes(m);
 }
 
 function formatMeeting(m: MeetingRow): string {


### PR DESCRIPTION
## Summary
Closing the last loose end from the Friday-meeting-notes sequence. When the Granola matcher fails to link a MeetingNote to its CalendarEvent, a direct \`get_meeting_notes({ calendarEventId })\` lookup returns null — even when the note is sitting in the DB trivially findable by title on the same day. Adding a fallback.

- If the calendarEventId lookup misses, fetch the calendar event, then find a MeetingNote within ±12h whose title matches loosely (either side contains the other, case-insensitive).
- New \`titleMatchesCalendarEvent\` helper with 6 unit tests covering the common patterns (exact, bracket-prefix stripping, either-way containment, rejections).

## Test plan
- [x] 6 new helper tests pass
- [x] 249 @brett/ai tests pass, none regressed
- [x] \`pnpm --filter @brett/ai typecheck\` clean
- [ ] After deploy: manually nullify a test meeting's calendarEventId, ask Brett for notes, confirm it's still retrievable via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)