### PR TITLE
Release: Granola fallback + Railway deploy config

### DIFF
--- a/apps/api/railway.json
+++ b/apps/api/railway.json
@@ -2,5 +2,11 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "dockerfilePath": "apps/api/Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "overlapSeconds": 30,
+    "drainingSeconds": 30
   }
 }


### PR DESCRIPTION
## Summary
- fix(ai): fallback by title+date when get_meeting_notes calendarEventId lookup misses
- chore(api): Railway healthcheck + overlap/drain config for zero-downtime deploys

## Test plan
- [ ] Merge → API redeploys with new config
- [ ] \`scripts/release.sh desktop\` → re-ship desktop on the refreshed API