### PR TITLE
Disable React Compiler — it was breaking Router in packaged prod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,15 +44,7 @@ The native iOS app lives at `apps/ios/` (Xcode project; not driven by pnpm). See
 - **Auth:** better-auth (email/password + Google OAuth + Sign in with Apple, JWT bearer tokens)
 - **Storage:** Railway Object Storage (S3-compatible)
 - **Notifications:** Firebase Cloud Messaging (planned — notifications only, not auth)
-- **React:** v19 with React Compiler enabled (desktop). Do NOT add `useMemo`/`useCallback`/`React.memo` for general optimization — the compiler handles memoization automatically.
-
-  **Narrow exception — custom hook return values that consumers depend on for stable identity.** When a custom hook (e.g. `useOmnibar`) returns an object literal whose identity matters to consumers (typically because they pass it as a `useEffect` dep), and the React Compiler bails on the hook (large async closures, complex switch statements, deep ref interaction), the consumer's effects will re-run every render and may infinite-loop. In those cases:
-  - Wrap the returned object in `useMemo` with all observable state in deps.
-  - Wrap public functions in `useCallback` so they have stable identity.
-  - For functions that read frequently-changing state, use a ref pattern (`stateRef.current = ...`) so `useCallback` deps stay minimal.
-  - Document at the top of the hook *why* the compiler bails (so future readers don't strip the manual memoization thinking it's redundant).
-
-  Component-level useMemo/useCallback in regular components is still discouraged — trust the compiler there.
+- **React:** v19. React Compiler is currently **disabled** for the desktop build (see `apps/desktop/vite.config.ts`). The compiler silently broke the packaged Electron bundle — React Router's popstate subscriber never fired re-renders, so clicks updated the URL but the view stayed put. Dev Electron was fine because the dev pipeline runs the compiler differently. Re-enable once the specific mis-optimized pattern is isolated. Until then, hand-written `useMemo`/`useCallback`/`React.memo` is fine where it helps — don't rely on automatic memoization.
 
 ## Architecture
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -6,13 +6,23 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const pkg = require("./package.json");
 
+// React Compiler disabled: the prod-mode minified bundle silently corrupted
+// the fiber tree so React Router's popstate subscriber never fired re-renders
+// (clicks updated URL but view stayed). Dev Electron was fine because the
+// dev build pipeline runs the compiler differently. Reproduced by running
+// `electron dist/electron/main.js` (prod mode, app:// protocol) with the
+// compiler on vs off — off worked, on broke. Re-enable once the specific
+// pattern it mis-optimizes is isolated.
 const ReactCompilerConfig = {};
+const REACT_COMPILER_ENABLED = false;
 
 export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [["babel-plugin-react-compiler", ReactCompilerConfig]],
+        plugins: REACT_COMPILER_ENABLED
+          ? [["babel-plugin-react-compiler", ReactCompilerConfig]]
+          : [],
       },
     }),
   ],


### PR DESCRIPTION
## Summary
Root cause of the packaged-prod nav bug. React Compiler was silently eliminating or mis-optimizing React Router's internal \`popstate\` subscriber in the minified bundle, so clicks updated the URL but the view never re-rendered.

## Reproduction
Ran \`electron dist/electron/main.js\` (prod mode, app:// protocol) built twice:
- **Compiler ON:** nav broken (matches the shipped 1232 bug)
- **Compiler OFF:** nav works

Dev Electron was fine because Vite's dev pipeline applies the compiler differently.

## Note on the earlier fix
The CalendarTimeline hooks-above-early-return fix (#53) was a real bug too — it's still in here. That bug would silently corrupt the fiber tree in prod on its own (when events went empty → populated, React saw 0→7 hooks). Fixing it was necessary; it just wasn't sufficient because the compiler was the second, independent cause.

## Follow-up
Re-enable the compiler once we isolate which specific pattern it mis-optimizes — likely something around \`useSyncExternalStore\` calls whose return value is discarded (the CalendarTimeline snippet in the bundle showed no \`useSyncExternalStore\` near the component). CLAUDE.md updated.

## Test plan
- [x] typecheck
- [x] Verified nav works in local prod-mode Electron with Compiler off + dev API
- [ ] Merge → API redeploys (no code change, just rebuild)
- [ ] \`scripts/release.sh desktop\` → ships fix