### PR TITLE
Release: strike-price refusal fix + React Compiler disable

### DIFF
--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -7,7 +7,7 @@
  *   pnpm eval                  # defaults to anthropic, all suites
  */
 
-import { getProvider, resolveModel, createRegistry } from "@brett/ai";
+import { getProvider, resolveModel, createRegistry, getSystemPrompt } from "@brett/ai";
 import type { AIProviderName, StreamChunk } from "@brett/types";
 import fs from "fs";
 import path from "path";
@@ -107,6 +107,13 @@ const model = resolveModel(providerName, "small");
 const registry = createRegistry();
 const tools = registry.toToolDefinitions();
 
+// Use the prod system prompt for intent classification so the eval reflects
+// what the live assistant actually sees. Skip the per-user sections (facts,
+// profile, embeddings) — they require a real user and aren't what this suite
+// tests. Append a fake current-date line to match the shape the assembler
+// produces. Drift on getSystemPrompt() now shows up here.
+const intentSystemPrompt = getSystemPrompt("Brett") + `\nCurrent date: ${new Date().toISOString().split("T")[0]}`;
+
 // ─── LLM call ────────────────────────────────────────────────────────────────
 
 async function classifyIntent(input: string): Promise<{ toolName: string | null; textResponse: string }> {
@@ -115,10 +122,7 @@ async function classifyIntent(input: string): Promise<{ toolName: string | null;
     model,
     messages: [{ role: "user", content: input }],
     tools,
-    system:
-      "You are Brett, a personal productivity assistant. " +
-      "For every user request, call the single most appropriate tool. " +
-      "Do not explain. Do not ask for clarification. Just call the tool.",
+    system: intentSystemPrompt,
     maxTokens: 256,
     temperature: 0,
   })) {

--- a/packages/ai/src/context/__tests__/assembler.test.ts
+++ b/packages/ai/src/context/__tests__/assembler.test.ts
@@ -187,6 +187,58 @@ describe("assembleContext", () => {
       expect(ctx.toolMode).toBe("contextual");
     });
 
+    // Short factual questions ("wh-questions") go to medium because small-tier
+    // models (Haiku) reliably pattern-match these to refusal when the topic
+    // sounds domain-adjacent (finance, real-time data) instead of following
+    // the in-context SEARCH BEFORE REFUSING rule. Prod regression 2026-04-20:
+    // "what is Function Health's strike price?" was refused on Haiku even
+    // though the answer was in a synced meeting note.
+    it('bumps short "what X?" questions to medium tier for omnibar', async () => {
+      const input: AssemblerInput = {
+        type: "omnibar",
+        userId: "user-1",
+        message: "what is Function Health's strike price?",
+      };
+      const ctx = await assembleContext(input, mockPrisma);
+      expect(ctx.modelTier).toBe("medium");
+    });
+
+    it('bumps short "who/when/where/why/how" questions to medium tier', async () => {
+      for (const msg of [
+        "who is Claire?",
+        "when does my cliff vest?",
+        "where did we land on pricing?",
+        "why is the Yves offer delayed?",
+        "how much did Function Health raise?",
+      ]) {
+        const input: AssemblerInput = {
+          type: "omnibar",
+          userId: "user-1",
+          message: msg,
+        };
+        const ctx = await assembleContext(input, mockPrisma);
+        expect(ctx.modelTier, `expected medium for "${msg}"`).toBe("medium");
+      }
+    });
+
+    it('keeps short non-question messages on small tier', async () => {
+      // Guard against over-bumping: short messages that aren't wh-questions
+      // stay on small — they're obvious tool calls Haiku handles fine.
+      for (const msg of [
+        "list today",
+        "show my inbox",
+        "snooze dentist",
+      ]) {
+        const input: AssemblerInput = {
+          type: "omnibar",
+          userId: "user-1",
+          message: msg,
+        };
+        const ctx = await assembleContext(input, mockPrisma);
+        expect(ctx.modelTier, `expected small for "${msg}"`).toBe("small");
+      }
+    });
+
     it('returns "medium" + "contextual" tools for brett_thread', async () => {
       const input: AssemblerInput = {
         type: "brett_thread",

--- a/packages/ai/src/context/__tests__/system-prompts.test.ts
+++ b/packages/ai/src/context/__tests__/system-prompts.test.ts
@@ -32,4 +32,33 @@ describe("getSystemPrompt", () => {
   it("keeps meeting-notes retrieval in domain", () => {
     expect(prompt).toMatch(/meeting notes|get_meeting_notes/);
   });
+
+  // Haiku grabbed the phrase "real-time data the user hasn't discussed" as
+  // justification for refusing "what is Function Health's strike price?" in
+  // prod on 2026-04-20. That escape hatch can't be evaluated without first
+  // retrieving — which is exactly the step SEARCH BEFORE REFUSING requires.
+  // Don't reintroduce any variant of it.
+  it("does not list 'real-time data' as a decline category", () => {
+    expect(prompt).not.toMatch(/real-time data/i);
+    expect(prompt).not.toMatch(/real time data/i);
+  });
+
+  // The rule should be imperative, not conditional. "When a request is a
+  // factual question AND no other tool obviously matches" lets the model
+  // decide either premise is false and skip retrieval.
+  it("frames SEARCH BEFORE REFUSING as mandatory, not conditional", () => {
+    expect(prompt).toMatch(/factual question/i);
+    // Drop the softer conditional framing that lets the model opt out by
+    // deciding "no other tool obviously matches" is false.
+    expect(prompt).not.toMatch(/no other tool obviously matches/i);
+    // Must contain a strong imperative — "never", "must", or "always".
+    expect(prompt).toMatch(/never (say|refuse|decline|answer)|must (call|search|retrieve|trigger)|always (call|search|retrieve)/i);
+  });
+
+  // Finance/health/legal/personal — the topic doesn't matter. Retrieval
+  // decides. Haiku was refusing on topic alone; the prompt should tell it
+  // not to.
+  it("explicitly covers finance/health/legal topics in the retrieval rule", () => {
+    expect(prompt).toMatch(/finance|financial|health|legal/i);
+  });
 });

--- a/packages/ai/src/context/assembler.ts
+++ b/packages/ai/src/context/assembler.ts
@@ -269,10 +269,19 @@ async function assembleOmnibar(
   // Simple requests stay on small for speed/cost.
   // Multi-turn sessions escalate to medium — follow-up messages typically
   // need more context reasoning than standalone queries.
+  //
+  // Wh-questions (what/who/when/where/why/how) also go to medium. Haiku
+  // reliably pattern-matches short factual questions to a refusal when the
+  // topic sounds domain-adjacent (finance, real-time data), ignoring the
+  // in-context SEARCH BEFORE REFUSING rule. Sonnet follows the rule; the
+  // ~5x cost is worth it given how rarely these occur vs. how bad a
+  // false refusal feels. See prod regression 2026-04-20
+  // ("what is Function Health's strike price?").
   const lower = input.message.toLowerCase();
   const actionWords = lower.match(/\b(create|make|move|add|put|delete|remove|archive|update|change|snooze|complete|done|mark)\b/g);
   const hasSessionHistory = (input.sessionMessages?.length ?? 0) >= 2;
-  const isComplex = lower.length > 80 || (actionWords && actionWords.length >= 2) || hasSessionHistory;
+  const isWhQuestion = /^\s*(what|who|when|where|why|how)\b/.test(lower);
+  const isComplex = lower.length > 80 || (actionWords && actionWords.length >= 2) || hasSessionHistory || isWhQuestion;
   const tier = isComplex ? "medium" : "small";
 
   return { system, messages, modelTier: tier, toolMode: "contextual" };

--- a/packages/ai/src/context/system-prompts.ts
+++ b/packages/ai/src/context/system-prompts.ts
@@ -17,7 +17,7 @@ export function getSystemPrompt(assistantName: string): string {
 - ALWAYS call tools — never narrate your plan or describe what you will do. Just act.
 - NEVER ask for permission ("want me to look into that?"). Just do it.
 - Chain tools when needed: search → get_item_detail → answer in one turn.
-- SEARCH BEFORE REFUSING. When a request is a factual question and no other tool obviously matches, default to search_things on the user's own data (plus get_meeting_notes or recall_memory when a meeting or memory is implied). The answer often lives in a note, item, or stored fact — whatever the topic. "I don't have that" is only correct after retrieval returns nothing.
+- SEARCH BEFORE REFUSING. For any factual question — about a person, company, number, date, term, or fact, across any topic (finance, health, legal, personal, anything) — you MUST call search_things before refusing (plus get_meeting_notes or recall_memory when a meeting or memory is implied). Never say "I don't have access to that" without retrieving first. The answer often lives in a note, item, or stored fact. "I don't have that" is only correct after retrieval returns nothing.
 - RESOLVE AMBIGUITY BEFORE ACTING: If a request involves multiple items and you're not sure which ones, search/lookup FIRST. Do NOT create or modify anything until you know exactly what the user wants. If there's ambiguity (e.g., multiple items match), ask the user to clarify BEFORE taking any action — don't create a list and then ask which items to move into it.
 - When there's no ambiguity, act immediately. Don't ask to confirm obvious requests.
 - When referencing tasks or content items, use: [Item Title](brett-item:itemId)
@@ -37,7 +37,7 @@ export function getSystemPrompt(assistantName: string): string {
 - 1-3 sentences for confirmations. Bullet points for 3+ items.
 - Use **bold** for emphasis. Never restate what the user asked — just show the result.
 - Compute relative dates from the current date in context.
-- Stay in domain. Domain = anything in the user's tasks, calendar, content, meeting notes, or stored facts. If a question could plausibly be answered by something the user has captured — regardless of topic — it's in domain; retrieve before deciding whether you can answer. Only decline clearly off-topic requests (general coding help, math homework, political opinions, real-time data the user hasn't discussed).` + SECURITY_BLOCK;
+- Stay in domain. Domain = anything in the user's tasks, calendar, content, meeting notes, or stored facts. Topic doesn't matter — finance, health, legal, personal are all in scope when the answer could live in the user's own data. Retrieve before deciding whether you can answer. Only decline clearly off-topic requests (general coding help, math homework, political opinions).` + SECURITY_BLOCK;
 }
 
 export function getBriefingPrompt(assistantName: string): string {


### PR DESCRIPTION
## Summary

Two fixes landing together:

- [#57](https://github.com/brentbarkman/brett/pull/57) — **fix(ai): prevent refusal on factual questions in omnibar** (tier bump for wh-questions + prompt hardening + eval wiring). Closes the prod regression on 2026-04-20 where Haiku refused "what is Function Health's strike price?" despite the answer being in a synced meeting note.
- [f64db34](https://github.com/brentbarkman/brett/commit/f64db34) — **fix(desktop): disable React Compiler** (Router broke in packaged prod).

## Test plan

- [x] All `@brett/ai` tests pass
- [x] Typecheck clean on `@brett/ai`, `@brett/evals`, `@brett/api`
- [x] Live eval against Haiku + prod prompt — Function Health fixtures PASS
- [ ] Monitor API health + desktop after deploy
- [ ] Spot-check the Function Health strike-price query in prod once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)