### PR TITLE
Fix About menu — set Electron app name to Brett

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -24,6 +24,12 @@ const API_URL = getApiURL();
 
 const isDev = process.env.NODE_ENV === "development";
 
+// Electron defaults to package.json "name" (@brett/desktop) for app.getName(),
+// which shows up in the macOS About menu and dock tooltip. Override to the
+// product name. electron-builder sets CFBundleName on the packaged app, but
+// Electron's runtime name is independent of that.
+app.setName("Brett");
+
 // In dev, give each worktree its own userData directory so multiple instances
 // don't share Chromium sessions, cookies, or electron-store data
 if (isDev) {


### PR DESCRIPTION
## Summary
\`About @brett/desktop\` in the macOS menu → \`About Brett\`.

Electron's runtime \`app.getName()\` defaults to package.json \`name\` (\`@brett/desktop\`). electron-builder sets CFBundleName via \`productName\` for the packaged \`.app\` bundle, but the menu label Electron renders at runtime is its own name — setting it explicitly via \`app.setName("Brett")\` fixes the display.

## Test plan
- [x] typecheck
- [ ] Merge → \`scripts/release.sh desktop\` → About menu reads "About Brett"