### PR TITLE
release: fix(api) /public/* serves feedback/ screenshots

### DIFF
--- a/apps/api/src/__tests__/storage-proxy.test.ts
+++ b/apps/api/src/__tests__/storage-proxy.test.ts
@@ -1,0 +1,77 @@
+import { vi, describe, it, expect } from "vitest";
+
+// Mock S3 before importing app so the proxy's GetObjectCommand resolves
+// to a fake body without hitting the network.
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: vi.fn().mockImplementation(() => ({
+    send: vi.fn().mockImplementation(async () => ({
+      Body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+          controller.close();
+        },
+      }),
+      ContentLength: 4,
+    })),
+  })),
+  PutObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn(),
+  DeleteObjectCommand: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: vi.fn().mockResolvedValue("https://fake-presigned-url.com/file"),
+}));
+
+import { app } from "../app.js";
+
+describe("GET /public/*", () => {
+  describe("allowed prefixes", () => {
+    it("serves videos/ keys", async () => {
+      const res = await app.request("/public/videos/login-bg-1.mp4");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("video/mp4");
+    });
+
+    it("serves backgrounds/ keys", async () => {
+      const res = await app.request("/public/backgrounds/default.webp");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("image/webp");
+    });
+
+    it("serves feedback/ keys (screenshot URLs in GitHub Issues)", async () => {
+      // Feedback route uploads screenshots under feedback/<hex>.png and
+      // renders <img> tags pointing at /public/feedback/*. GitHub fetches
+      // those URLs to inline screenshots in bug reports.
+      const res = await app.request("/public/feedback/abc123def456.png");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("image/png");
+    });
+  });
+
+  describe("rejections", () => {
+    it("rejects non-allowlisted prefixes", async () => {
+      const res = await app.request("/public/attachments/secret.pdf");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects empty key", async () => {
+      const res = await app.request("/public/");
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects keys containing ..", async () => {
+      // Hono decodes URL-encoded paths before the handler runs, so
+      // %2E%2E also lands here as literal "..".
+      const res = await app.request("/public/videos/../../etc/passwd");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("caching", () => {
+    it("sets long Cache-Control on allowed responses", async () => {
+      const res = await app.request("/public/videos/login-bg-1.mp4");
+      expect(res.headers.get("Cache-Control")).toContain("max-age=86400");
+    });
+  });
+});

--- a/apps/api/src/routes/storage-proxy.ts
+++ b/apps/api/src/routes/storage-proxy.ts
@@ -5,7 +5,9 @@ import { publicS3, PUBLIC_STORAGE_BUCKET } from "../lib/storage.js";
 const storageProxy = new Hono();
 
 // Allowed prefixes — only these paths are proxied. Anything else is 404.
-const ALLOWED_PREFIXES = ["videos/", "backgrounds/"];
+// feedback/ serves screenshots embedded in GitHub Issues created by
+// apps/api/src/routes/feedback.ts (keys are crypto.randomBytes(16).hex).
+const ALLOWED_PREFIXES = ["videos/", "backgrounds/", "feedback/"];
 
 // Content-type mapping
 const CONTENT_TYPES: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Adds `feedback/` to the `ALLOWED_PREFIXES` allowlist in `apps/api/src/routes/storage-proxy.ts` so screenshots embedded in GitHub feedback issues stop returning 404.
- Adds the first tests for the `/public/*` storage proxy (`apps/api/src/__tests__/storage-proxy.test.ts`): coverage for each allowed prefix, path-traversal rejection, empty keys, and cache headers.

### Root cause
Feedback uploads to `feedback/<hex>.png` in the public bucket and embeds `/public/feedback/*.png` URLs in issues. The proxy only allowlisted `videos/` and `backgrounds/`, so every screenshot URL 404'd at the allowlist check before S3.

## Test plan
- [x] `pnpm vitest run src/__tests__/storage-proxy.test.ts` — 7/7 pass
- [x] `pnpm vitest run src/__tests__/feedback.test.ts src/__tests__/release-proxy.test.ts` — 35/35 pass (no regression)
- [x] `pnpm typecheck` — clean
- [ ] After deploy: submit a bug report with a screenshot from desktop; confirm the issue on GitHub renders the screenshot inline instead of showing a broken image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)