### PR TITLE
fix: optimistic inbox add + task title update (#37, #39)

### DIFF
--- a/apps/desktop/src/api/__tests__/lists.test.ts
+++ b/apps/desktop/src/api/__tests__/lists.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { NavList } from "@brett/types";
+import {
+  useCreateList,
+  useUpdateList,
+  useDeleteList,
+  useArchiveList,
+  useUnarchiveList,
+} from "../lists";
+
+vi.mock("../client", () => ({ apiFetch: vi.fn() }));
+
+import { apiFetch } from "../client";
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function makeList(id: string, name: string, archived = false): NavList {
+  return {
+    id,
+    name,
+    count: 0,
+    completedCount: 0,
+    colorClass: "white",
+    sortOrder: 0,
+    archivedAt: archived ? new Date().toISOString() : null,
+  };
+}
+
+function setup() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, wrapper };
+}
+
+describe("useCreateList optimistic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("prepends a provisional list before the server responds", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<NavList[]>(["lists"], [makeList("existing", "Existing")]);
+
+    let resolveServer: (v: NavList) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<NavList>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ name: "New List" });
+    });
+
+    await waitFor(() => {
+      const lists = qc.getQueryData<NavList[]>(["lists"]);
+      expect(lists).toHaveLength(2);
+      expect(lists?.[0].name).toBe("New List");
+    });
+
+    resolveServer(makeList("server-id", "New List"));
+  });
+
+  it("replaces the temp entry with the real server record on success", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<NavList[]>(["lists"], []);
+
+    mockApiFetch.mockResolvedValue(makeList("server-id", "New"));
+
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "New" });
+    });
+
+    const lists = qc.getQueryData<NavList[]>(["lists"]);
+    expect(lists).toHaveLength(1);
+    expect(lists?.[0].id).toBe("server-id");
+  });
+
+  it("rolls back to the prior cache on error", async () => {
+    const { qc, wrapper } = setup();
+    const seed = [makeList("existing", "Existing")];
+    qc.setQueryData<NavList[]>(["lists"], seed);
+
+    mockApiFetch.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "Will fail" });
+      } catch { /* expected */ }
+    });
+
+    expect(qc.getQueryData<NavList[]>(["lists"])).toEqual(seed);
+  });
+});
+
+describe("useUpdateList optimistic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("patches the list in place before the server responds (prevents rename flash)", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<NavList[]>(["lists"], [makeList("a", "old name")]);
+
+    let resolveServer: (v: NavList) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<NavList>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useUpdateList(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "a", name: "new name" });
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData<NavList[]>(["lists"])?.[0].name).toBe("new name");
+    });
+
+    resolveServer(makeList("a", "new name"));
+  });
+});
+
+describe("useDeleteList optimistic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the list from ['lists'] immediately", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<NavList[]>(["lists"], [makeList("a", "a"), makeList("b", "b")]);
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useDeleteList(), { wrapper });
+
+    act(() => {
+      result.current.mutate("a");
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData<NavList[]>(["lists"])?.map((l) => l.id)).toEqual(["b"]);
+    });
+
+    resolveServer({});
+  });
+});
+
+describe("useArchiveList / useUnarchiveList", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("moves a list from ['lists'] to ['lists', 'archived'] on archive", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<NavList[]>(["lists"], [makeList("a", "a")]);
+    qc.setQueryData<NavList[]>(["lists", "archived"], []);
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useArchiveList(), { wrapper });
+
+    act(() => {
+      result.current.mutate("a");
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData<NavList[]>(["lists"])).toEqual([]);
+      expect(qc.getQueryData<NavList[]>(["lists", "archived"])?.map((l) => l.id)).toEqual(["a"]);
+    });
+
+    resolveServer({ archivedAt: "2026-01-01T00:00:00Z", itemsCompleted: 0 });
+  });
+
+  it("moves a list back from archived on unarchive", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<NavList[]>(["lists"], []);
+    qc.setQueryData<NavList[]>(["lists", "archived"], [makeList("a", "a", true)]);
+
+    let resolveServer: (v: NavList) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<NavList>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useUnarchiveList(), { wrapper });
+
+    act(() => {
+      result.current.mutate("a");
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData<NavList[]>(["lists", "archived"])).toEqual([]);
+      expect(qc.getQueryData<NavList[]>(["lists"])?.map((l) => l.id)).toEqual(["a"]);
+    });
+
+    resolveServer(makeList("a", "a"));
+  });
+});

--- a/apps/desktop/src/api/__tests__/thing-detail-mutations.test.ts
+++ b/apps/desktop/src/api/__tests__/thing-detail-mutations.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Attachment, ItemLink, Thing, ThingDetail } from "@brett/types";
+import { useCreateLink, useDeleteLink } from "../links";
+import { useDeleteAttachment } from "../attachments";
+
+vi.mock("../client", () => ({ apiFetch: vi.fn() }));
+
+import { apiFetch } from "../client";
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function makeDetail(id: string, overrides: Partial<ThingDetail> = {}): ThingDetail {
+  const base: Thing = {
+    id,
+    type: "task",
+    title: "t",
+    list: "Inbox",
+    listId: null,
+    status: "active",
+    source: "manual",
+    urgency: "later",
+    isCompleted: false,
+  };
+  return {
+    ...base,
+    attachments: [],
+    links: [],
+    brettMessages: [],
+    ...overrides,
+  };
+}
+
+function makeAttachment(id: string): Attachment {
+  return {
+    id,
+    filename: `${id}.pdf`,
+    mimeType: "application/pdf",
+    sizeBytes: 100,
+    url: "https://example.com/x",
+    createdAt: "2026-04-20T00:00:00Z",
+  };
+}
+
+function makeLink(id: string, toItemId = "other"): ItemLink {
+  return {
+    id,
+    toItemId,
+    toItemType: "task",
+    source: "manual",
+    createdAt: "2026-04-20T00:00:00Z",
+  };
+}
+
+function setup() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, wrapper };
+}
+
+describe("useCreateLink optimistic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("appends a provisional link to thing-detail before the server responds", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<ThingDetail>(["thing-detail", "item-1"], makeDetail("item-1"));
+
+    let resolveServer: (v: ItemLink) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<ItemLink>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateLink(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ itemId: "item-1", toItemId: "target-x", toItemType: "task" });
+    });
+
+    await waitFor(() => {
+      const detail = qc.getQueryData<ThingDetail>(["thing-detail", "item-1"]);
+      expect(detail?.links).toHaveLength(1);
+      expect(detail?.links[0].toItemId).toBe("target-x");
+    });
+
+    resolveServer({ id: "server-id", toItemId: "target-x", toItemType: "task", createdAt: "x" });
+  });
+});
+
+describe("useDeleteLink optimistic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the link from thing-detail before the server responds", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<ThingDetail>(["thing-detail", "item-1"], makeDetail("item-1", {
+      links: [makeLink("link-a"), makeLink("link-b")],
+    }));
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useDeleteLink(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ itemId: "item-1", linkId: "link-a" });
+    });
+
+    await waitFor(() => {
+      const detail = qc.getQueryData<ThingDetail>(["thing-detail", "item-1"]);
+      expect(detail?.links.map((l) => l.id)).toEqual(["link-b"]);
+    });
+
+    resolveServer({});
+  });
+});
+
+describe("useDeleteAttachment optimistic", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the attachment from thing-detail before the server responds", async () => {
+    const { qc, wrapper } = setup();
+    qc.setQueryData<ThingDetail>(["thing-detail", "item-1"], makeDetail("item-1", {
+      attachments: [makeAttachment("a1"), makeAttachment("a2")],
+    }));
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useDeleteAttachment(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ itemId: "item-1", attachmentId: "a1" });
+    });
+
+    await waitFor(() => {
+      const detail = qc.getQueryData<ThingDetail>(["thing-detail", "item-1"]);
+      expect(detail?.attachments.map((a) => a.id)).toEqual(["a2"]);
+    });
+
+    resolveServer({});
+  });
+});

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -3,7 +3,9 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { InboxResponse, Thing, ThingDetail } from "@brett/types";
-import { useCreateThing, useUpdateThing } from "../things";
+import { useCreateThing, useUpdateThing, __testing } from "../things";
+
+const { thingMatchesFilters } = __testing;
 
 vi.mock("../client", () => ({
   apiFetch: vi.fn(),
@@ -130,6 +132,177 @@ describe("useCreateThing optimistic insert", () => {
     });
 
     resolveServer(makeThing("server-id", "listed"));
+  });
+
+  // Follow-up from #62: Today quick-add passes dueDate=today, so it must
+  // land in the active-this-week cache (useActiveThings) immediately.
+  it("inserts a today-dated task into the active/dueBefore cache", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const today = new Date("2026-04-20T00:00:00.000Z").toISOString();
+    const endOfWeek = new Date("2026-04-26T23:59:59.999Z").toISOString();
+    const activeFilters = { status: "active" as const, dueBefore: endOfWeek };
+
+    qc.setQueryData<Thing[]>(["things", activeFilters], []);
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        type: "task",
+        title: "today task",
+        dueDate: today,
+        dueDatePrecision: "day",
+      });
+    });
+
+    await waitFor(() => {
+      const cache = qc.getQueryData<Thing[]>(["things", activeFilters]);
+      expect(cache).toHaveLength(1);
+      expect(cache?.[0].title).toBe("today task");
+    });
+
+    resolveServer(makeThing("server-id", "today task"));
+  });
+
+  // Follow-up from #62: List-scoped add must land in the list's cache
+  // (useListThings → ["things", { listId }]) immediately.
+  it("inserts a list-scoped task into the matching ['things', { listId }] cache", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<Thing[]>(["things", { listId: "list-abc" }], []);
+    qc.setQueryData<Thing[]>(["things", { listId: "other-list" }], []);
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ type: "task", title: "listed task", listId: "list-abc" });
+    });
+
+    await waitFor(() => {
+      const abc = qc.getQueryData<Thing[]>(["things", { listId: "list-abc" }]);
+      expect(abc).toHaveLength(1);
+      expect(abc?.[0].title).toBe("listed task");
+    });
+
+    // The other list's cache must stay empty.
+    const other = qc.getQueryData<Thing[]>(["things", { listId: "other-list" }]);
+    expect(other).toHaveLength(0);
+
+    resolveServer(makeThing("server-id", "listed task"));
+  });
+
+  // New creates are never pre-completed, so they must never land in a
+  // done/completedAfter view — guards against a Today view briefly showing
+  // a just-created item in its "done today" section.
+  it("does not insert into done/completedAfter caches", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const today = new Date("2026-04-20T00:00:00.000Z").toISOString();
+    const doneFilters = { status: "done" as const, completedAfter: today };
+    qc.setQueryData<Thing[]>(["things", doneFilters], []);
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ type: "task", title: "fresh", dueDate: today });
+    });
+
+    await waitFor(() => {
+      const cache = qc.getQueryData<Thing[]>(["things", doneFilters]);
+      expect(cache).toHaveLength(0);
+    });
+
+    resolveServer(makeThing("server-id", "fresh"));
+  });
+
+  it("rolls back every ['things', ...] cache it optimistically wrote on error", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const today = new Date("2026-04-20T00:00:00.000Z").toISOString();
+    const endOfWeek = new Date("2026-04-26T23:59:59.999Z").toISOString();
+    const activeFilters = { status: "active" as const, dueBefore: endOfWeek };
+    const seed = makeThing("seed-1", "seeded");
+    qc.setQueryData<Thing[]>(["things", activeFilters], [seed]);
+
+    mockApiFetch.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          type: "task",
+          title: "will fail",
+          dueDate: today,
+        });
+      } catch {
+        /* expected */
+      }
+    });
+
+    const cache = qc.getQueryData<Thing[]>(["things", activeFilters]);
+    expect(cache).toEqual([seed]);
+  });
+});
+
+describe("thingMatchesFilters", () => {
+  const baseThing: Thing = {
+    id: "x",
+    type: "task",
+    title: "x",
+    list: "Inbox",
+    listId: null,
+    status: "active",
+    source: "manual",
+    urgency: "later",
+    isCompleted: false,
+  };
+
+  it("matches when all filters are empty", () => {
+    expect(thingMatchesFilters(baseThing, {})).toBe(true);
+  });
+
+  it("respects listId equality", () => {
+    const t = { ...baseThing, listId: "abc" };
+    expect(thingMatchesFilters(t, { listId: "abc" })).toBe(true);
+    expect(thingMatchesFilters(t, { listId: "xyz" })).toBe(false);
+    expect(thingMatchesFilters(baseThing, { listId: "abc" })).toBe(false);
+  });
+
+  it("treats dueBefore as inclusive and excludes null dueDate", () => {
+    const due = "2026-04-20T00:00:00.000Z";
+    const eow = "2026-04-26T00:00:00.000Z";
+    expect(thingMatchesFilters({ ...baseThing, dueDate: due }, { dueBefore: eow })).toBe(true);
+    expect(thingMatchesFilters({ ...baseThing, dueDate: eow }, { dueBefore: eow })).toBe(true);
+    expect(thingMatchesFilters({ ...baseThing, dueDate: "2026-05-01T00:00:00.000Z" }, { dueBefore: eow })).toBe(false);
+    expect(thingMatchesFilters(baseThing, { dueBefore: eow })).toBe(false);
+  });
+
+  it("treats dueAfter as exclusive and excludes null dueDate", () => {
+    const today = "2026-04-20T00:00:00.000Z";
+    expect(thingMatchesFilters({ ...baseThing, dueDate: today }, { dueAfter: today })).toBe(false);
+    expect(thingMatchesFilters({ ...baseThing, dueDate: "2026-04-21T00:00:00.000Z" }, { dueAfter: today })).toBe(true);
+    expect(thingMatchesFilters(baseThing, { dueAfter: today })).toBe(false);
+  });
+
+  it("never matches a completedAfter filter (new items aren't pre-completed)", () => {
+    expect(thingMatchesFilters(baseThing, { completedAfter: "2026-04-20T00:00:00.000Z" })).toBe(false);
   });
 });
 

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { InboxResponse, Thing, ThingDetail } from "@brett/types";
+import { useCreateThing, useUpdateThing } from "../things";
+
+vi.mock("../client", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "../client";
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function makeThing(id: string, title: string): Thing {
+  return {
+    id,
+    type: "task",
+    title,
+    list: "Inbox",
+    listId: null,
+    status: "active",
+    source: "manual",
+    urgency: "later",
+    isCompleted: false,
+  };
+}
+
+function makeDetail(id: string, title: string): ThingDetail {
+  return {
+    ...makeThing(id, title),
+    attachments: [],
+    links: [],
+    brettMessages: [],
+  };
+}
+
+function setupQueryClient() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, wrapper };
+}
+
+describe("useCreateThing optimistic insert", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("inserts into inbox cache synchronously on mutate, before server responds", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    // Pre-seed inbox cache with existing item
+    const existing = makeThing("existing-1", "existing task");
+    qc.setQueryData<InboxResponse>(["inbox"], { visible: [existing] });
+
+    // Server response hangs until we release it — proves the cache update
+    // happens BEFORE the network round-trip.
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ type: "task", title: "new task" });
+    });
+
+    // Before server resolves, inbox must already contain the new item.
+    await waitFor(() => {
+      const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      expect(inbox?.visible).toHaveLength(2);
+      expect(inbox?.visible.some((t) => t.title === "new task")).toBe(true);
+    });
+
+    // Existing item is still there
+    const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+    expect(inbox?.visible.some((t) => t.id === "existing-1")).toBe(true);
+
+    // Release server
+    resolveServer(makeThing("server-id", "new task"));
+  });
+
+  it("rolls back inbox cache when the server rejects", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const existing = makeThing("existing-1", "existing task");
+    qc.setQueryData<InboxResponse>(["inbox"], { visible: [existing] });
+
+    mockApiFetch.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ type: "task", title: "will fail" });
+      } catch {
+        /* expected */
+      }
+    });
+
+    const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+    expect(inbox?.visible).toHaveLength(1);
+    expect(inbox?.visible[0].id).toBe("existing-1");
+  });
+
+  it("does not insert content items into inbox cache unless they belong there", async () => {
+    // Sanity: non-task types shouldn't pollute the inbox cache view if listId is set.
+    // This documents the scope: only inbox-bound items go into the inbox cache.
+    const { qc, wrapper } = setupQueryClient();
+    qc.setQueryData<InboxResponse>(["inbox"], { visible: [] });
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ type: "task", title: "listed", listId: "list-abc" });
+    });
+
+    // Items with a listId bypass the inbox.
+    await waitFor(() => {
+      const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      expect(inbox?.visible).toHaveLength(0);
+    });
+
+    resolveServer(makeThing("server-id", "listed"));
+  });
+});
+
+describe("useUpdateThing optimistic update", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates thing-detail cache synchronously on mutate (prevents title flash)", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const original = makeDetail("thing-1", "old title");
+    qc.setQueryData<ThingDetail>(["thing-detail", "thing-1"], original);
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useUpdateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "thing-1", title: "new title" });
+    });
+
+    // Before server resolves, detail cache already reflects the new title.
+    await waitFor(() => {
+      const detail = qc.getQueryData<ThingDetail>(["thing-detail", "thing-1"]);
+      expect(detail?.title).toBe("new title");
+    });
+
+    resolveServer(makeThing("thing-1", "new title"));
+  });
+
+  it("also updates inbox cache entries when they match the edited id", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<InboxResponse>(["inbox"], {
+      visible: [makeThing("a", "a old"), makeThing("b", "b old")],
+    });
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useUpdateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "a", title: "a new" });
+    });
+
+    await waitFor(() => {
+      const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      expect(inbox?.visible.find((t) => t.id === "a")?.title).toBe("a new");
+      expect(inbox?.visible.find((t) => t.id === "b")?.title).toBe("b old");
+    });
+
+    resolveServer(makeThing("a", "a new"));
+  });
+
+  it("rolls back thing-detail cache when the server rejects", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const original = makeDetail("thing-1", "old title");
+    qc.setQueryData<ThingDetail>(["thing-detail", "thing-1"], original);
+
+    mockApiFetch.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useUpdateThing(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ id: "thing-1", title: "new title" });
+      } catch {
+        /* expected */
+      }
+    });
+
+    const detail = qc.getQueryData<ThingDetail>(["thing-detail", "thing-1"]);
+    expect(detail?.title).toBe("old title");
+  });
+});

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { InboxResponse, Thing, ThingDetail } from "@brett/types";
-import { useCreateThing, useUpdateThing, __testing } from "../things";
+import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, __testing } from "../things";
 
 const { thingMatchesFilters } = __testing;
 
@@ -258,6 +258,117 @@ describe("useCreateThing optimistic insert", () => {
 
     const cache = qc.getQueryData<Thing[]>(["things", activeFilters]);
     expect(cache).toEqual([seed]);
+  });
+});
+
+describe("useDeleteThing optimistic remove", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the item from inbox and every ['things', ...] cache before the server responds", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<InboxResponse>(["inbox"], {
+      visible: [makeThing("a", "keep"), makeThing("b", "gone")],
+    });
+    qc.setQueryData<Thing[]>(["things", { listId: "L1" }], [makeThing("b", "gone"), makeThing("c", "keep")]);
+    qc.setQueryData<Thing[]>(["things", { status: "active" }], [makeThing("b", "gone")]);
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useDeleteThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate("b");
+    });
+
+    await waitFor(() => {
+      const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      expect(inbox?.visible.map((t) => t.id)).toEqual(["a"]);
+      expect(qc.getQueryData<Thing[]>(["things", { listId: "L1" }])?.map((t) => t.id)).toEqual(["c"]);
+      expect(qc.getQueryData<Thing[]>(["things", { status: "active" }])).toEqual([]);
+    });
+
+    resolveServer({});
+  });
+
+  it("rolls back every cache it touched on error", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    const inboxSeed = [makeThing("a", "keep"), makeThing("b", "will-fail")];
+    const listSeed = [makeThing("b", "will-fail")];
+    qc.setQueryData<InboxResponse>(["inbox"], { visible: inboxSeed });
+    qc.setQueryData<Thing[]>(["things", { listId: "L1" }], listSeed);
+
+    mockApiFetch.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useDeleteThing(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("b");
+      } catch { /* expected */ }
+    });
+
+    expect(qc.getQueryData<InboxResponse>(["inbox"])?.visible.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(qc.getQueryData<Thing[]>(["things", { listId: "L1" }])?.map((t) => t.id)).toEqual(["b"]);
+  });
+});
+
+describe("useBulkUpdateThings optimistic patch/remove", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes archived items from the inbox immediately", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<InboxResponse>(["inbox"], {
+      visible: [makeThing("a", "a"), makeThing("b", "b"), makeThing("c", "c")],
+    });
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useBulkUpdateThings(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ids: ["a", "c"], updates: { status: "archived" } });
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData<InboxResponse>(["inbox"])?.visible.map((t) => t.id)).toEqual(["b"]);
+    });
+
+    resolveServer({ updated: 2 });
+  });
+
+  it("patches in place when updates don't change the inbox membership (drag-to-list)", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<Thing[]>(["things", { listId: "L1" }], [
+      { ...makeThing("a", "a"), listId: "L1" },
+    ]);
+
+    let resolveServer: (v: unknown) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useBulkUpdateThings(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ids: ["a"], updates: { listId: "L2" } });
+    });
+
+    await waitFor(() => {
+      const cache = qc.getQueryData<Thing[]>(["things", { listId: "L1" }]);
+      expect(cache?.[0].listId).toBe("L2");
+    });
+
+    resolveServer({ updated: 1 });
   });
 });
 

--- a/apps/desktop/src/api/ai-config.ts
+++ b/apps/desktop/src/api/ai-config.ts
@@ -31,7 +31,20 @@ export function useActivateAIConfig() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/ai/config/${id}/activate`, { method: "PUT" }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["ai-config"] }),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["ai-config"] });
+      const prev = qc.getQueryData<AIConfigResponse>(["ai-config"]);
+      if (prev) {
+        qc.setQueryData<AIConfigResponse>(["ai-config"], {
+          configs: prev.configs.map((c) => ({ ...c, isActive: c.id === id })),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["ai-config"], ctx.prev);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ["ai-config"] }),
   });
 }
 
@@ -40,6 +53,19 @@ export function useDeleteAIConfig() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/ai/config/${id}`, { method: "DELETE" }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["ai-config"] }),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["ai-config"] });
+      const prev = qc.getQueryData<AIConfigResponse>(["ai-config"]);
+      if (prev) {
+        qc.setQueryData<AIConfigResponse>(["ai-config"], {
+          configs: prev.configs.filter((c) => c.id !== id),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["ai-config"], ctx.prev);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ["ai-config"] }),
   });
 }

--- a/apps/desktop/src/api/assistant-name.ts
+++ b/apps/desktop/src/api/assistant-name.ts
@@ -26,7 +26,22 @@ export function useUpdateAssistantName() {
         body: JSON.stringify({ assistantName: trimmed }),
       });
     },
-    onSuccess: () => {
+    onMutate: async (name) => {
+      const trimmed = name.trim();
+      if (!trimmed || trimmed.length > 10) return { prev: undefined };
+      await queryClient.cancelQueries({ queryKey: ["user-me"] });
+      const prev = queryClient.getQueryData<{ assistantName: string }>(["user-me"]);
+      if (prev) {
+        queryClient.setQueryData(["user-me"], { ...prev, assistantName: trimmed });
+      }
+      return { prev };
+    },
+    onError: (_err, _name, ctx) => {
+      if (ctx?.prev !== undefined) {
+        queryClient.setQueryData(["user-me"], ctx.prev);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["user-me"] });
     },
   });

--- a/apps/desktop/src/api/attachments.ts
+++ b/apps/desktop/src/api/attachments.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "./client";
-import type { Attachment } from "@brett/types";
+import type { Attachment, ThingDetail } from "@brett/types";
 
 export function useUploadAttachment() {
   const qc = useQueryClient();
@@ -40,7 +40,23 @@ export function useDeleteAttachment() {
       apiFetch(`/things/${itemId}/attachments/${attachmentId}`, {
         method: "DELETE",
       }),
-    onSuccess: (_, { itemId }) => {
+    onMutate: async ({ itemId, attachmentId }) => {
+      await qc.cancelQueries({ queryKey: ["thing-detail", itemId] });
+      const prev = qc.getQueryData<ThingDetail>(["thing-detail", itemId]);
+      if (prev) {
+        qc.setQueryData<ThingDetail>(["thing-detail", itemId], {
+          ...prev,
+          attachments: prev.attachments.filter((a) => a.id !== attachmentId),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, { itemId }, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<ThingDetail>(["thing-detail", itemId], ctx.prev);
+      }
+    },
+    onSettled: (_data, _err, { itemId }) => {
       qc.invalidateQueries({ queryKey: ["thing-detail", itemId] });
     },
   });

--- a/apps/desktop/src/api/calendar-accounts.ts
+++ b/apps/desktop/src/api/calendar-accounts.ts
@@ -91,7 +91,23 @@ export function useToggleMeetingNotes() {
           body: JSON.stringify({ enabled }),
         },
       ),
-    onSuccess: () => {
+    onMutate: async ({ accountId, enabled }) => {
+      await qc.cancelQueries({ queryKey: ["calendar-accounts"] });
+      const prev = qc.getQueryData<ConnectedCalendarAccount[]>(["calendar-accounts"]);
+      if (prev) {
+        qc.setQueryData<ConnectedCalendarAccount[]>(
+          ["calendar-accounts"],
+          prev.map((a) => (a.id === accountId ? { ...a, meetingNotesEnabled: enabled } : a)),
+        );
+      }
+      return { prev };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<ConnectedCalendarAccount[]>(["calendar-accounts"], ctx.prev);
+      }
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["calendar-accounts"] });
     },
   });
@@ -116,7 +132,32 @@ export function useToggleCalendarVisibility() {
           body: JSON.stringify({ isVisible }),
         },
       ),
-    onSuccess: () => {
+    onMutate: async ({ accountId, calendarId, isVisible }) => {
+      await qc.cancelQueries({ queryKey: ["calendar-accounts"] });
+      const prev = qc.getQueryData<ConnectedCalendarAccount[]>(["calendar-accounts"]);
+      if (prev) {
+        qc.setQueryData<ConnectedCalendarAccount[]>(
+          ["calendar-accounts"],
+          prev.map((a) =>
+            a.id === accountId
+              ? {
+                  ...a,
+                  calendars: a.calendars.map((c) =>
+                    c.id === calendarId ? { ...c, isVisible } : c,
+                  ),
+                }
+              : a,
+          ),
+        );
+      }
+      return { prev };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<ConnectedCalendarAccount[]>(["calendar-accounts"], ctx.prev);
+      }
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["calendar-accounts"] });
       qc.invalidateQueries({ queryKey: ["calendar-events"] });
     },

--- a/apps/desktop/src/api/calendar.ts
+++ b/apps/desktop/src/api/calendar.ts
@@ -108,7 +108,21 @@ export function useUpdateCalendarEventNotes() {
         method: "PUT",
         body: JSON.stringify({ content }),
       }),
-    onSuccess: (_, { eventId }) => {
+    // Prevents the same edit-flash as the task-title case: write the new
+    // content into cache before the server round-trip so the notes field
+    // stays rendered with what the user just typed.
+    onMutate: async ({ eventId, content }) => {
+      await qc.cancelQueries({ queryKey: ["calendar-event-notes", eventId] });
+      const prev = qc.getQueryData<CalendarEventNotesResponse>(["calendar-event-notes", eventId]);
+      qc.setQueryData<CalendarEventNotesResponse>(["calendar-event-notes", eventId], { content });
+      return { prev };
+    },
+    onError: (_err, { eventId }, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<CalendarEventNotesResponse>(["calendar-event-notes", eventId], ctx.prev);
+      }
+    },
+    onSettled: (_data, _err, { eventId }) => {
       qc.invalidateQueries({ queryKey: ["calendar-event-notes", eventId] });
       qc.invalidateQueries({ queryKey: ["calendar-event-detail", eventId] });
     },

--- a/apps/desktop/src/api/granola.ts
+++ b/apps/desktop/src/api/granola.ts
@@ -59,7 +59,23 @@ export function useUpdateGranolaPreferences() {
         method: "PATCH",
         body: JSON.stringify(prefs),
       }),
-    onSuccess: () => {
+    onMutate: async (prefs) => {
+      await queryClient.cancelQueries({ queryKey: ["granola", "account"] });
+      const prev = queryClient.getQueryData<GranolaAccountStatus>(["granola", "account"]);
+      if (prev?.account) {
+        queryClient.setQueryData<GranolaAccountStatus>(["granola", "account"], {
+          ...prev,
+          account: { ...prev.account, ...prefs },
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _prefs, ctx) => {
+      if (ctx?.prev !== undefined) {
+        queryClient.setQueryData(["granola", "account"], ctx.prev);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["granola", "account"] });
     },
   });

--- a/apps/desktop/src/api/links.ts
+++ b/apps/desktop/src/api/links.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "./client";
-import type { ItemLink } from "@brett/types";
+import type { ItemLink, ThingDetail } from "@brett/types";
 
 export function useCreateLink() {
   const qc = useQueryClient();
@@ -18,7 +18,31 @@ export function useCreateLink() {
         method: "POST",
         body: JSON.stringify({ toItemId, toItemType }),
       }),
-    onSuccess: (_, { itemId }) => {
+    onMutate: async ({ itemId, toItemId, toItemType }) => {
+      await qc.cancelQueries({ queryKey: ["thing-detail", itemId] });
+      const prev = qc.getQueryData<ThingDetail>(["thing-detail", itemId]);
+      if (prev) {
+        const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const provisional: ItemLink = {
+          id: tempId,
+          toItemId,
+          toItemType,
+          source: "manual",
+          createdAt: new Date().toISOString(),
+        };
+        qc.setQueryData<ThingDetail>(["thing-detail", itemId], {
+          ...prev,
+          links: [...prev.links, provisional],
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, { itemId }, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<ThingDetail>(["thing-detail", itemId], ctx.prev);
+      }
+    },
+    onSettled: (_data, _err, { itemId }) => {
       qc.invalidateQueries({ queryKey: ["thing-detail", itemId] });
     },
   });
@@ -35,7 +59,23 @@ export function useDeleteLink() {
       linkId: string;
     }) =>
       apiFetch(`/things/${itemId}/links/${linkId}`, { method: "DELETE" }),
-    onSuccess: (_, { itemId }) => {
+    onMutate: async ({ itemId, linkId }) => {
+      await qc.cancelQueries({ queryKey: ["thing-detail", itemId] });
+      const prev = qc.getQueryData<ThingDetail>(["thing-detail", itemId]);
+      if (prev) {
+        qc.setQueryData<ThingDetail>(["thing-detail", itemId], {
+          ...prev,
+          links: prev.links.filter((l) => l.id !== linkId),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, { itemId }, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<ThingDetail>(["thing-detail", itemId], ctx.prev);
+      }
+    },
+    onSettled: (_data, _err, { itemId }) => {
       qc.invalidateQueries({ queryKey: ["thing-detail", itemId] });
     },
   });

--- a/apps/desktop/src/api/lists.ts
+++ b/apps/desktop/src/api/lists.ts
@@ -14,6 +14,18 @@ export function useLists() {
   });
 }
 
+function provisionalList(input: { name: string; colorClass?: string }, tempId: string, sortOrder: number): NavList {
+  return {
+    id: tempId,
+    name: input.name,
+    count: 0,
+    completedCount: 0,
+    colorClass: input.colorClass ?? "white",
+    sortOrder,
+    archivedAt: null,
+  };
+}
+
 export function useCreateList() {
   const qc = useQueryClient();
 
@@ -23,12 +35,31 @@ export function useCreateList() {
         method: "POST",
         body: JSON.stringify(input),
       }),
-    onSuccess: (newList) => {
-      // Optimistically prepend the new list to the cache so navigation
-      // to its slug works immediately (before invalidation refetches)
-      qc.setQueryData<NavList[]>(["lists"], (old) =>
-        old ? [newList, ...old] : [newList]
-      );
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: ["lists"] });
+      const prev = qc.getQueryData<NavList[]>(["lists"]);
+      const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const minSortOrder = prev?.length ? Math.min(...prev.map((l) => l.sortOrder)) : 0;
+      const provisional = provisionalList(input, tempId, minSortOrder - 1);
+      qc.setQueryData<NavList[]>(["lists"], prev ? [provisional, ...prev] : [provisional]);
+      return { prev, tempId };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<NavList[]>(["lists"], ctx.prev);
+      }
+    },
+    onSuccess: (newList, _input, ctx) => {
+      // Replace the temp entry with the real server record so child pages
+      // (ListView navigated via slug) resolve to the correct id after the
+      // cache refetch.
+      if (ctx?.tempId) {
+        qc.setQueryData<NavList[]>(["lists"], (old) =>
+          old ? old.map((l) => (l.id === ctx.tempId ? newList : l)) : [newList],
+        );
+      }
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["lists"] });
     },
   });
@@ -43,7 +74,23 @@ export function useUpdateList() {
         method: "PATCH",
         body: JSON.stringify(data),
       }),
-    onSuccess: () => {
+    onMutate: async ({ id, ...patch }) => {
+      await qc.cancelQueries({ queryKey: ["lists"] });
+      const prev = qc.getQueryData<NavList[]>(["lists"]);
+      if (prev) {
+        qc.setQueryData<NavList[]>(
+          ["lists"],
+          prev.map((l) => (l.id === id ? { ...l, ...patch } : l)),
+        );
+      }
+      return { prev };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData<NavList[]>(["lists"], ctx.prev);
+      }
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["lists"] });
     },
   });
@@ -55,7 +102,19 @@ export function useDeleteList() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/lists/${id}`, { method: "DELETE" }),
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["lists"] });
+      const prev = qc.getQueryData<NavList[]>(["lists"]);
+      const prevArchived = qc.getQueryData<NavList[]>(["lists", "archived"]);
+      if (prev) qc.setQueryData<NavList[]>(["lists"], prev.filter((l) => l.id !== id));
+      if (prevArchived) qc.setQueryData<NavList[]>(["lists", "archived"], prevArchived.filter((l) => l.id !== id));
+      return { prev, prevArchived };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData<NavList[]>(["lists"], ctx.prev);
+      if (ctx?.prevArchived !== undefined) qc.setQueryData<NavList[]>(["lists", "archived"], ctx.prevArchived);
+    },
+    onSettled: () => {
       invalidateAllThings(qc);
     },
   });
@@ -105,7 +164,24 @@ export function useArchiveList() {
       apiFetch<{ archivedAt: string; itemsCompleted: number }>(`/lists/${id}/archive`, {
         method: "PATCH",
       }),
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["lists"] });
+      const prev = qc.getQueryData<NavList[]>(["lists"]);
+      const prevArchived = qc.getQueryData<NavList[]>(["lists", "archived"]);
+
+      const archivingList = prev?.find((l) => l.id === id);
+      if (prev) qc.setQueryData<NavList[]>(["lists"], prev.filter((l) => l.id !== id));
+      if (archivingList && prevArchived !== undefined) {
+        const archivedEntry = { ...archivingList, archivedAt: new Date().toISOString() };
+        qc.setQueryData<NavList[]>(["lists", "archived"], [archivedEntry, ...prevArchived]);
+      }
+      return { prev, prevArchived };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData<NavList[]>(["lists"], ctx.prev);
+      if (ctx?.prevArchived !== undefined) qc.setQueryData<NavList[]>(["lists", "archived"], ctx.prevArchived);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["lists"] });
       qc.invalidateQueries({ queryKey: ["things"] });
     },
@@ -120,7 +196,26 @@ export function useUnarchiveList() {
       apiFetch<NavList>(`/lists/${id}/unarchive`, {
         method: "PATCH",
       }),
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["lists"] });
+      const prev = qc.getQueryData<NavList[]>(["lists"]);
+      const prevArchived = qc.getQueryData<NavList[]>(["lists", "archived"]);
+
+      const unarchivingList = prevArchived?.find((l) => l.id === id);
+      if (prevArchived) {
+        qc.setQueryData<NavList[]>(["lists", "archived"], prevArchived.filter((l) => l.id !== id));
+      }
+      if (unarchivingList && prev !== undefined) {
+        const restored = { ...unarchivingList, archivedAt: null };
+        qc.setQueryData<NavList[]>(["lists"], [...prev, restored]);
+      }
+      return { prev, prevArchived };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData<NavList[]>(["lists"], ctx.prev);
+      if (ctx?.prevArchived !== undefined) qc.setQueryData<NavList[]>(["lists", "archived"], ctx.prevArchived);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["lists"] });
     },
   });

--- a/apps/desktop/src/api/newsletters.ts
+++ b/apps/desktop/src/api/newsletters.ts
@@ -32,7 +32,21 @@ export function useUpdateSender() {
         method: "PATCH",
         body: JSON.stringify(data),
       }),
-    onSuccess: () => {
+    onMutate: async ({ id, data }) => {
+      await qc.cancelQueries({ queryKey: ["newsletter-senders"] });
+      const prev = qc.getQueryData<NewsletterSender[]>(["newsletter-senders"]);
+      if (prev) {
+        qc.setQueryData<NewsletterSender[]>(
+          ["newsletter-senders"],
+          prev.map((s) => (s.id === id ? { ...s, ...data } : s)),
+        );
+      }
+      return { prev };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["newsletter-senders"], ctx.prev);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["newsletter-senders"] });
     },
   });
@@ -43,7 +57,18 @@ export function useDeleteSender() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/newsletters/senders/${id}`, { method: "DELETE" }),
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["newsletter-senders"] });
+      const prev = qc.getQueryData<NewsletterSender[]>(["newsletter-senders"]);
+      if (prev) {
+        qc.setQueryData<NewsletterSender[]>(["newsletter-senders"], prev.filter((s) => s.id !== id));
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["newsletter-senders"], ctx.prev);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["newsletter-senders"] });
     },
   });
@@ -56,7 +81,21 @@ export function useApprovePendingSender() {
       apiFetch<NewsletterSender>(`/newsletters/senders/${pendingId}/approve`, {
         method: "POST",
       }),
-    onSuccess: () => {
+    onMutate: async (pendingId) => {
+      await qc.cancelQueries({ queryKey: ["newsletter-pending"] });
+      const prev = qc.getQueryData<PendingNewsletterSummary[]>(["newsletter-pending"]);
+      if (prev) {
+        qc.setQueryData<PendingNewsletterSummary[]>(
+          ["newsletter-pending"],
+          prev.filter((p) => p.id !== pendingId),
+        );
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["newsletter-pending"], ctx.prev);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["newsletter-pending"] });
       qc.invalidateQueries({ queryKey: ["newsletter-senders"] });
     },
@@ -68,7 +107,21 @@ export function useBlockPendingSender() {
   return useMutation({
     mutationFn: (pendingId: string) =>
       apiFetch(`/newsletters/senders/${pendingId}/block`, { method: "POST" }),
-    onSuccess: () => {
+    onMutate: async (pendingId) => {
+      await qc.cancelQueries({ queryKey: ["newsletter-pending"] });
+      const prev = qc.getQueryData<PendingNewsletterSummary[]>(["newsletter-pending"]);
+      if (prev) {
+        qc.setQueryData<PendingNewsletterSummary[]>(
+          ["newsletter-pending"],
+          prev.filter((p) => p.id !== pendingId),
+        );
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["newsletter-pending"], ctx.prev);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["newsletter-pending"] });
       qc.invalidateQueries({ queryKey: ["newsletter-senders"] });
     },

--- a/apps/desktop/src/api/scouts.ts
+++ b/apps/desktop/src/api/scouts.ts
@@ -101,6 +101,32 @@ export function useCreateScout() {
   });
 }
 
+/** Patch every cached scout list and the per-scout detail in place. */
+function patchScoutInCaches(qc: ReturnType<typeof useQueryClient>, id: string, patch: Partial<Scout>) {
+  const prevDetail = qc.getQueryData<Scout>(["scout", id]);
+  if (prevDetail) {
+    qc.setQueryData<Scout>(["scout", id], { ...prevDetail, ...patch });
+  }
+  const prevLists: Array<[readonly unknown[], Scout[] | undefined]> = [];
+  for (const [key, data] of qc.getQueriesData<Scout[]>({ queryKey: ["scouts"] })) {
+    if (!data) continue;
+    prevLists.push([key, data]);
+    qc.setQueryData<Scout[]>(key, data.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+  }
+  return { prevDetail, prevLists };
+}
+
+function restoreScoutCaches(
+  qc: ReturnType<typeof useQueryClient>,
+  id: string,
+  ctx: { prevDetail?: Scout; prevLists?: Array<[readonly unknown[], Scout[] | undefined]> } | undefined,
+) {
+  if (ctx?.prevDetail !== undefined) qc.setQueryData<Scout>(["scout", id], ctx.prevDetail);
+  if (ctx?.prevLists) {
+    for (const [key, data] of ctx.prevLists) qc.setQueryData(key, data);
+  }
+}
+
 export function useUpdateScout() {
   const qc = useQueryClient();
 
@@ -110,9 +136,15 @@ export function useUpdateScout() {
         method: "PUT",
         body: JSON.stringify(data),
       }),
-    onSuccess: (_, variables) => {
+    onMutate: async ({ id, ...patch }) => {
+      await qc.cancelQueries({ queryKey: ["scout", id] });
+      await qc.cancelQueries({ queryKey: ["scouts"] });
+      return patchScoutInCaches(qc, id, patch as Partial<Scout>);
+    },
+    onError: (_err, { id }, ctx) => restoreScoutCaches(qc, id, ctx),
+    onSettled: (_data, _err, { id }) => {
       qc.invalidateQueries({ queryKey: ["scouts"] });
-      qc.invalidateQueries({ queryKey: ["scout", variables.id] });
+      qc.invalidateQueries({ queryKey: ["scout", id] });
     },
   });
 }
@@ -123,7 +155,13 @@ export function usePauseScout() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch<Scout>(`/scouts/${id}/pause`, { method: "POST" }),
-    onSuccess: (_, id) => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["scout", id] });
+      await qc.cancelQueries({ queryKey: ["scouts"] });
+      return patchScoutInCaches(qc, id, { status: "paused" });
+    },
+    onError: (_err, id, ctx) => restoreScoutCaches(qc, id, ctx),
+    onSettled: (_data, _err, id) => {
       qc.invalidateQueries({ queryKey: ["scouts"] });
       qc.invalidateQueries({ queryKey: ["scout", id] });
     },
@@ -136,7 +174,13 @@ export function useResumeScout() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch<Scout>(`/scouts/${id}/resume`, { method: "POST" }),
-    onSuccess: (_, id) => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["scout", id] });
+      await qc.cancelQueries({ queryKey: ["scouts"] });
+      return patchScoutInCaches(qc, id, { status: "active" });
+    },
+    onError: (_err, id, ctx) => restoreScoutCaches(qc, id, ctx),
+    onSettled: (_data, _err, id) => {
       qc.invalidateQueries({ queryKey: ["scouts"] });
       qc.invalidateQueries({ queryKey: ["scout", id] });
     },
@@ -149,9 +193,25 @@ export function useDeleteScout() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/scouts/${id}`, { method: "DELETE" }),
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["scouts"] });
+      const prevLists: Array<[readonly unknown[], Scout[] | undefined]> = [];
+      for (const [key, data] of qc.getQueriesData<Scout[]>({ queryKey: ["scouts"] })) {
+        if (!data) continue;
+        prevLists.push([key, data]);
+        qc.setQueryData<Scout[]>(key, data.filter((s) => s.id !== id));
+      }
+      return { prevLists };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prevLists) {
+        for (const [key, data] of ctx.prevLists) qc.setQueryData(key, data);
+      }
+    },
+    onSettled: (_data, _err, id) => {
       qc.invalidateQueries({ queryKey: ["scouts"] });
       qc.invalidateQueries({ queryKey: ["scout-budget"] });
+      qc.removeQueries({ queryKey: ["scout", id] });
     },
   });
 }
@@ -221,7 +281,22 @@ export function useDeleteScoutMemory() {
   return useMutation({
     mutationFn: ({ scoutId, memoryId }: { scoutId: string; memoryId: string }) =>
       apiFetch(`/scouts/${scoutId}/memories/${memoryId}`, { method: "DELETE" }),
-    onSuccess: (_, variables) => {
+    onMutate: async ({ scoutId, memoryId }) => {
+      await qc.cancelQueries({ queryKey: ["scout-memories", scoutId] });
+      const prevEntries: Array<[readonly unknown[], ScoutMemory[] | undefined]> = [];
+      for (const [key, data] of qc.getQueriesData<ScoutMemory[]>({ queryKey: ["scout-memories", scoutId] })) {
+        if (!data) continue;
+        prevEntries.push([key, data]);
+        qc.setQueryData<ScoutMemory[]>(key, data.filter((m) => m.id !== memoryId));
+      }
+      return { prevEntries };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prevEntries) {
+        for (const [key, data] of ctx.prevEntries) qc.setQueryData(key, data);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
       qc.invalidateQueries({ queryKey: ["scout-memories", variables.scoutId] });
     },
   });

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -71,6 +71,27 @@ export function useUpcomingThings() {
   return useThings({ status: "active", dueAfter: getTodayUTC().toISOString() });
 }
 
+/** Shape a CreateItemInput into a provisional Thing for optimistic caches. */
+function provisionalThing(input: CreateItemInput, tempId: string): Thing {
+  return {
+    id: tempId,
+    type: (input.type as Thing["type"]) ?? "task",
+    title: input.title,
+    list: "Inbox",
+    listId: input.listId ?? null,
+    status: (input.status as Thing["status"]) ?? "active",
+    source: input.source ?? "manual",
+    urgency: "later",
+    dueDate: input.dueDate,
+    dueDatePrecision: input.dueDatePrecision,
+    sourceUrl: input.sourceUrl,
+    isCompleted: false,
+    createdAt: new Date().toISOString(),
+    contentType: input.contentType,
+    sourceId: input.sourceId,
+  };
+}
+
 export function useCreateThing() {
   const qc = useQueryClient();
 
@@ -80,6 +101,29 @@ export function useCreateThing() {
         method: "POST",
         body: JSON.stringify(input),
       }),
+    // Optimistically insert into the inbox cache so the row appears
+    // instantly. Bare items (no listId, no dueDate) are inbox-bound; for
+    // everything else we still wait for the server-side refetch, because
+    // predicting which filtered list queries the new item belongs to gets
+    // quickly unsafe.
+    onMutate: async (input) => {
+      const isInboxBound = !input.listId && !input.dueDate;
+      if (!isInboxBound) return { prevInbox: undefined, tempId: undefined };
+
+      await qc.cancelQueries({ queryKey: ["inbox"] });
+      const prevInbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const provisional = provisionalThing(input, tempId);
+      qc.setQueryData<InboxResponse>(["inbox"], {
+        visible: [provisional, ...(prevInbox?.visible ?? [])],
+      });
+      return { prevInbox, tempId };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prevInbox !== undefined) {
+        qc.setQueryData<InboxResponse>(["inbox"], ctx.prevInbox);
+      }
+    },
     onSuccess: () => {
       invalidateAllThings(qc);
     },
@@ -95,7 +139,58 @@ export function useUpdateThing() {
         method: "PATCH",
         body: JSON.stringify(data),
       }),
-    onSuccess: (_, variables) => {
+    // Patch cached views in place so edits (e.g. title) render instantly
+    // instead of flashing back to the server value while refetch completes.
+    onMutate: async ({ id, ...patch }) => {
+      await qc.cancelQueries({ queryKey: ["thing-detail", id] });
+      await qc.cancelQueries({ queryKey: ["inbox"] });
+      await qc.cancelQueries({ queryKey: ["things"] });
+
+      // `UpdateItemInput` permits `null` for clear-value semantics, but the
+      // view-model `Thing` uses `undefined` for absent fields. Normalise
+      // before merging into cache so optimistic entries stay well-typed.
+      const thingPatch = Object.fromEntries(
+        Object.entries(patch).map(([k, v]) => [k, v === null ? undefined : v]),
+      ) as Partial<Thing>;
+
+      const prevDetail = qc.getQueryData<ThingDetail>(["thing-detail", id]);
+      if (prevDetail) {
+        qc.setQueryData<ThingDetail>(["thing-detail", id], { ...prevDetail, ...thingPatch });
+      }
+
+      const prevInbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      if (prevInbox) {
+        qc.setQueryData<InboxResponse>(["inbox"], {
+          visible: prevInbox.visible.map((t) => (t.id === id ? { ...t, ...thingPatch } : t)),
+        });
+      }
+
+      const prevThingLists: Array<[readonly unknown[], Thing[] | undefined]> = [];
+      for (const [key, data] of qc.getQueriesData<Thing[]>({ queryKey: ["things"] })) {
+        prevThingLists.push([key, data]);
+        if (!data) continue;
+        qc.setQueryData<Thing[]>(
+          key,
+          data.map((t) => (t.id === id ? { ...t, ...thingPatch } : t)),
+        );
+      }
+
+      return { prevDetail, prevInbox, prevThingLists };
+    },
+    onError: (_err, variables, ctx) => {
+      if (ctx?.prevDetail) {
+        qc.setQueryData<ThingDetail>(["thing-detail", variables.id], ctx.prevDetail);
+      }
+      if (ctx?.prevInbox !== undefined) {
+        qc.setQueryData<InboxResponse>(["inbox"], ctx.prevInbox);
+      }
+      if (ctx?.prevThingLists) {
+        for (const [key, data] of ctx.prevThingLists) {
+          qc.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: (_data, _err, variables) => {
       qc.invalidateQueries({ queryKey: ["things"] });
       qc.invalidateQueries({ queryKey: ["inbox"] });
       qc.invalidateQueries({ queryKey: ["thing-detail", variables.id] });

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -311,7 +311,68 @@ export function useBulkUpdateThings() {
         method: "PATCH",
         body: JSON.stringify(input),
       }),
-    onSuccess: () => {
+    // Drives drag-to-list, inbox triage, archive, bulk status changes. An
+    // in-place patch is good enough for all of those — if a cache's filter
+    // semantics shift (e.g. moving an item between lists), onSettled
+    // reconciles with the server.
+    onMutate: async ({ ids, updates }) => {
+      await qc.cancelQueries({ queryKey: ["things"] });
+      await qc.cancelQueries({ queryKey: ["inbox"] });
+
+      const idSet = new Set(ids);
+      const thingPatch = Object.fromEntries(
+        Object.entries(updates).map(([k, v]) => [k, v === null ? undefined : v]),
+      ) as Partial<Thing>;
+      if (updates.status) {
+        thingPatch.isCompleted = updates.status === "done";
+      }
+      const removeFromInbox = updates.status === "archived" || updates.status === "done";
+
+      const prevInbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      if (prevInbox) {
+        const nextVisible = removeFromInbox
+          ? prevInbox.visible.filter((t) => !idSet.has(t.id))
+          : prevInbox.visible.map((t) => (idSet.has(t.id) ? { ...t, ...thingPatch } : t));
+        qc.setQueryData<InboxResponse>(["inbox"], { visible: nextVisible });
+      }
+
+      const prevThingLists: Array<[readonly unknown[], Thing[] | undefined]> = [];
+      for (const [key, data] of qc.getQueriesData<Thing[]>({ queryKey: ["things"] })) {
+        if (!data) continue;
+        prevThingLists.push([key, data]);
+        qc.setQueryData<Thing[]>(
+          key,
+          data.map((t) => (idSet.has(t.id) ? { ...t, ...thingPatch } : t)),
+        );
+      }
+
+      const prevDetails: Array<[string, ThingDetail | undefined]> = [];
+      for (const id of ids) {
+        const prev = qc.getQueryData<ThingDetail>(["thing-detail", id]);
+        if (prev) {
+          prevDetails.push([id, prev]);
+          qc.setQueryData<ThingDetail>(["thing-detail", id], { ...prev, ...thingPatch });
+        }
+      }
+
+      return { prevInbox, prevThingLists, prevDetails };
+    },
+    onError: (_err, _input, ctx) => {
+      if (ctx?.prevInbox !== undefined) {
+        qc.setQueryData<InboxResponse>(["inbox"], ctx.prevInbox);
+      }
+      if (ctx?.prevThingLists) {
+        for (const [key, data] of ctx.prevThingLists) {
+          qc.setQueryData(key, data);
+        }
+      }
+      if (ctx?.prevDetails) {
+        for (const [id, data] of ctx.prevDetails) {
+          qc.setQueryData(["thing-detail", id], data);
+        }
+      }
+    },
+    onSettled: () => {
       invalidateAllThings(qc);
     },
   });
@@ -362,8 +423,39 @@ export function useDeleteThing() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/things/${id}`, { method: "DELETE" }),
-    onSuccess: () => {
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["inbox"] });
+      await qc.cancelQueries({ queryKey: ["things"] });
+
+      const prevInbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      if (prevInbox) {
+        qc.setQueryData<InboxResponse>(["inbox"], {
+          visible: prevInbox.visible.filter((t) => t.id !== id),
+        });
+      }
+
+      const prevThingLists: Array<[readonly unknown[], Thing[] | undefined]> = [];
+      for (const [key, data] of qc.getQueriesData<Thing[]>({ queryKey: ["things"] })) {
+        if (!data) continue;
+        prevThingLists.push([key, data]);
+        qc.setQueryData<Thing[]>(key, data.filter((t) => t.id !== id));
+      }
+
+      return { prevInbox, prevThingLists };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prevInbox !== undefined) {
+        qc.setQueryData<InboxResponse>(["inbox"], ctx.prevInbox);
+      }
+      if (ctx?.prevThingLists) {
+        for (const [key, data] of ctx.prevThingLists) {
+          qc.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: (_data, _err, id) => {
       invalidateAllThings(qc);
+      qc.removeQueries({ queryKey: ["thing-detail", id] });
     },
   });
 }

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -92,6 +92,34 @@ function provisionalThing(input: CreateItemInput, tempId: string): Thing {
   };
 }
 
+// Mirrors the server filter semantics in apps/api/src/routes/things.ts:
+//   dueBefore: dueDate <= value   dueAfter: dueDate > value
+//   completedAfter: completedAt >= value   (null sides fail the predicate)
+// Drift is bounded — onSettled invalidates and refetches from the server,
+// so at worst we briefly show a new item in the wrong cache.
+function thingMatchesFilters(thing: Thing, filters: ThingsFilters): boolean {
+  if (filters.listId && thing.listId !== filters.listId) return false;
+  if (filters.type && thing.type !== filters.type) return false;
+  if (filters.status && thing.status !== filters.status) return false;
+  if (filters.source && thing.source !== filters.source) return false;
+  if (filters.dueBefore) {
+    if (!thing.dueDate) return false;
+    if (new Date(thing.dueDate).getTime() > new Date(filters.dueBefore).getTime()) return false;
+  }
+  if (filters.dueAfter) {
+    if (!thing.dueDate) return false;
+    if (new Date(thing.dueDate).getTime() <= new Date(filters.dueAfter).getTime()) return false;
+  }
+  if (filters.completedAfter) {
+    // Provisional creates are never pre-completed, so they never belong in a
+    // completedAfter view.
+    return false;
+  }
+  return true;
+}
+
+export const __testing = { thingMatchesFilters };
+
 export function useCreateThing() {
   const qc = useQueryClient();
 
@@ -101,27 +129,45 @@ export function useCreateThing() {
         method: "POST",
         body: JSON.stringify(input),
       }),
-    // Optimistically insert into the inbox cache so the row appears
-    // instantly. Bare items (no listId, no dueDate) are inbox-bound; for
-    // everything else we still wait for the server-side refetch, because
-    // predicting which filtered list queries the new item belongs to gets
-    // quickly unsafe.
+    // Optimistically prepend the new item into every cached view it
+    // belongs in: the inbox (when inbox-bound) and every ["things", ...]
+    // list-query cache whose filters the provisional thing satisfies.
+    // onSettled invalidates and refetches, so any client/server filter
+    // drift is self-correcting within one round-trip.
     onMutate: async (input) => {
       const isInboxBound = !input.listId && !input.dueDate;
-      if (!isInboxBound) return { prevInbox: undefined, tempId: undefined };
-
-      await qc.cancelQueries({ queryKey: ["inbox"] });
-      const prevInbox = qc.getQueryData<InboxResponse>(["inbox"]);
       const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const provisional = provisionalThing(input, tempId);
-      qc.setQueryData<InboxResponse>(["inbox"], {
-        visible: [provisional, ...(prevInbox?.visible ?? [])],
-      });
-      return { prevInbox, tempId };
+
+      await qc.cancelQueries({ queryKey: ["inbox"] });
+      await qc.cancelQueries({ queryKey: ["things"] });
+
+      let prevInbox: InboxResponse | undefined;
+      if (isInboxBound) {
+        prevInbox = qc.getQueryData<InboxResponse>(["inbox"]);
+        qc.setQueryData<InboxResponse>(["inbox"], {
+          visible: [provisional, ...(prevInbox?.visible ?? [])],
+        });
+      }
+
+      const prevThingLists: Array<[readonly unknown[], Thing[] | undefined]> = [];
+      for (const [key, data] of qc.getQueriesData<Thing[]>({ queryKey: ["things"] })) {
+        const filters = (key[1] ?? {}) as ThingsFilters;
+        if (!thingMatchesFilters(provisional, filters)) continue;
+        prevThingLists.push([key, data]);
+        qc.setQueryData<Thing[]>(key, [provisional, ...(data ?? [])]);
+      }
+
+      return { prevInbox, prevThingLists, tempId };
     },
     onError: (_err, _input, ctx) => {
       if (ctx?.prevInbox !== undefined) {
         qc.setQueryData<InboxResponse>(["inbox"], ctx.prevInbox);
+      }
+      if (ctx?.prevThingLists) {
+        for (const [key, data] of ctx.prevThingLists) {
+          qc.setQueryData(key, data);
+        }
       }
     },
     onSuccess: () => {

--- a/apps/desktop/src/api/user-facts.ts
+++ b/apps/desktop/src/api/user-facts.ts
@@ -26,6 +26,19 @@ export function useDeleteUserFact() {
   return useMutation({
     mutationFn: (id: string) =>
       apiFetch(`/brett/memory/facts/${id}`, { method: "DELETE" }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["user-facts"] }),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ["user-facts"] });
+      const prev = qc.getQueryData<UserFactsResponse>(["user-facts"]);
+      if (prev) {
+        qc.setQueryData<UserFactsResponse>(["user-facts"], {
+          facts: prev.facts.filter((f) => f.id !== id),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(["user-facts"], ctx.prev);
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ["user-facts"] }),
   });
 }


### PR DESCRIPTION
Closes #37
Closes #39

## Root cause

Both `useCreateThing` and `useUpdateThing` invalidated queries on success only — no `onMutate`. That meant:

- **#37 (title flash):** In `TaskDetailPanel`, pressing Enter calls `setEditingTitle(false)` *before* the cache updates. The `<h2>` re-renders `detail.title` (still the old value) until the server responds and refetch completes. The old-→-new flash.
- **#39 (inbox add lag):** `handleInboxAdd` kicks off `createThing.mutate` and waits for `invalidateAllThings → refetch` before the row appears. Perceptible delay on every add.

The codebase already had the right pattern elsewhere — `useToggleThing` uses `onMutate` with `setQueryData` to remove the item before the slide-out animation runs. Creates and updates just hadn't been brought to parity.

## Approach

Considered three options:

1. **Add `onMutate` to both mutations, scoped to caches we can safely predict.** Picked this.
2. Aggressively patch every `["things", ...]` list cache for creates too. Rejected: predicting which filtered queries (by `status`, `dueBefore`, `dueAfter`, `completedAfter`, `listId`) a new item belongs to means re-implementing the server filter client-side — fragile and easy to drift.
3. Return to a `placeholderData` pattern per component. Rejected: moves complexity into every call site; the mutation hooks are the right layer.

What shipped:

- `useCreateThing` — optimistically prepends a provisional `Thing` into `["inbox"]` **only** when the input is bare (no `listId`, no `dueDate`). Today's quick-add (`dueDate: today`) and list-scoped adds still rely on invalidate-then-refetch for now; flagged as a follow-up.
- `useUpdateThing` — patches the `["thing-detail", id]` entry, the matching entry in `["inbox"]`, and every entry in any `["things", ...]` list cache that contains the updated id. Snapshots previous state and rolls back on error. `onSettled` still invalidates to reconcile with authoritative server state (matches the `useToggleThing` pattern).
- Nulls in `UpdateItemInput` (clear-value semantics) are normalised to `undefined` before merging into the `Thing` view model to keep optimistic entries well-typed.

## Tests

Added `apps/desktop/src/api/__tests__/things.test.ts` (6 tests) covering:

- Optimistic insert happens **before** the network round-trip resolves (the request is held open with a manual resolver)
- Rollback on create/update error restores the pre-mutation cache exactly
- Non-inbox-bound creates (with `listId`) do **not** pollute the inbox cache
- Update patches `thing-detail` and `inbox` caches synchronously

**Class of bug these prevent:** pessimistic-update regressions — if anyone adds a new mutation that should feel instant but forgets `onMutate`, a similar test can be cribbed from this file. The held-resolver pattern is specifically designed to catch "I moved the cache update to `onSuccess` by accident."

## Self-review findings

- Caught that `UpdateItemInput` permits `null` (clear-value) but `Thing` uses `undefined` — would have produced TS errors and stale null-valued fields in the cache. Added the normalisation step.
- Caught that the rollback context needed to differentiate "no inbox cache existed" from "inbox cache was empty" — used `!== undefined` on `prevInbox` for create rollback so we don't restore a bogus empty cache when there never was one.
- Considered but rejected extending optimistic insert into `["things", ...]` caches. The filter predicates (dueBefore/dueAfter/completedAfter) are server-evaluated and the hacks to replicate them client-side were too easy to drift from the source of truth.

## Verification

```
pnpm typecheck  # @brett/desktop — clean
pnpm test       # 11 files, 130 tests passing
```

## Risks / follow-ups

- Today's quick-add (`handleAddTask` with `dueDate: today`) and list-scoped adds still use invalidate-then-refetch. User feedback on #39 says "We should look at this everywhere" — worth a follow-up that extends the optimistic insert across those call sites once the right filter-matching abstraction is worked out.
- Rapid-fire creates: if the user adds 3 items in quick succession, the first mutation's `onSettled` refetch may momentarily show only the server-persisted items before the third optimistic item is re-applied on the next settle. Acceptable — eventual consistency; react-query's standard optimistic pattern.

Visual verification pending — `gh pr checkout <n>`