### PR TITLE
fix: context-aware inbox empty state (#40)

### DIFF
--- a/packages/ui/src/InboxView.tsx
+++ b/packages/ui/src/InboxView.tsx
@@ -64,6 +64,14 @@ export function InboxView({
   const isInitialLoadRef = useRef(true);
   const prevThingIdsRef = useRef<Set<string>>(new Set());
 
+  // Flips to true once the inbox has held at least one item this session.
+  // Lets the empty state distinguish "never seen the inbox" from "you just
+  // cleared it" — the latter deserves a confirmation, not a welcome mat.
+  const [hasEverHadItems, setHasEverHadItems] = useState(false);
+  useEffect(() => {
+    if (things.length > 0) setHasEverHadItems(true);
+  }, [things.length]);
+
   // Cleanup toggle timer
   useEffect(() => {
     return () => { if (toggleTimer.current) clearTimeout(toggleTimer.current); };
@@ -409,16 +417,22 @@ export function InboxView({
     <ItemListShell header={inboxHeader} hints={inboxHints}>
         <QuickAddInput ref={quickAddRef} placeholder="Add to inbox..." onAdd={onAdd} onAddContent={onAddContent} onFocusChange={setAddInputFocused} />
 
-        {/* Empty state */}
+        {/* Empty state — copy adapts to whether the user has ever had items
+            in the inbox this session. "Caught up" reads as a reward after
+            triage; the first-time copy is an invitation. */}
         {isEmpty && (
           <div className="flex flex-col items-center justify-center py-16 gap-4">
             <div className="w-12 h-12 rounded-full bg-brett-gold/10 border border-brett-gold/20 flex items-center justify-center">
               <Inbox size={22} className="text-brett-gold" />
             </div>
             <div className="text-center">
-              <h3 className="text-white font-semibold text-base mb-1">Inbox zero</h3>
+              <h3 className="text-white font-semibold text-base mb-1">
+                {hasEverHadItems ? "Caught up" : "Your inbox is ready"}
+              </h3>
               <p className="text-white/40 text-sm leading-relaxed max-w-xs">
-                Nothing to triage. Add something or let {assistantName} find things for you.
+                {hasEverHadItems
+                  ? "Nothing left to triage. Nice work."
+                  : `Add a thought or let ${assistantName} bring you things to triage.`}
               </p>
             </div>
           </div>

--- a/packages/ui/src/__tests__/InboxView.test.tsx
+++ b/packages/ui/src/__tests__/InboxView.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import type { Thing, NavList } from "@brett/types";
+import { InboxView } from "../InboxView";
+
+function makeThing(id: string, title: string): Thing {
+  return {
+    id,
+    type: "task",
+    title,
+    list: "Inbox",
+    listId: null,
+    status: "active",
+    source: "manual",
+    urgency: "later",
+    isCompleted: false,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function renderInbox(things: Thing[]) {
+  const lists: NavList[] = [];
+  return render(
+    <InboxView
+      things={things}
+      lists={lists}
+      onItemClick={vi.fn()}
+      onToggle={vi.fn()}
+      onArchive={vi.fn()}
+      onAdd={vi.fn()}
+      onTriage={vi.fn()}
+    />,
+  );
+}
+
+describe("InboxView empty state", () => {
+  it("shows first-time copy when the inbox has never had items this session", () => {
+    renderInbox([]);
+    expect(screen.getByText(/Your inbox is ready/i)).toBeInTheDocument();
+    // Must NOT mislead a first-time user with 'caught up' framing.
+    expect(screen.queryByText(/Caught up/i)).not.toBeInTheDocument();
+  });
+
+  it("switches to caught-up copy after the user has cleared previously-present items", () => {
+    const { rerender } = renderInbox([makeThing("a", "something")]);
+    // Sanity: the item is visible, no empty state yet
+    expect(screen.getByText("something")).toBeInTheDocument();
+
+    rerender(
+      <InboxView
+        things={[]}
+        lists={[]}
+        onItemClick={vi.fn()}
+        onToggle={vi.fn()}
+        onArchive={vi.fn()}
+        onAdd={vi.fn()}
+        onTriage={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Caught up/i)).toBeInTheDocument();
+    // First-time copy must NOT render once the user has proven they know the surface
+    expect(screen.queryByText(/Your inbox is ready/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #40

## Root cause

After clearing every item from the inbox, the empty state rendered the same "Inbox zero — Nothing to triage. Add something or let {assistantName} find things for you." copy that a brand-new account would see. To someone who just triaged ten items, that reads as if the app forgot what they did — it felt like a bug even though all the code paths worked correctly.

The fix isn't animation timing or bucket rendering (those are fine). It's the copy: an empty inbox means something different in different contexts, and we were flattening them.

## Approach

Considered three options:

1. **Session-level ref that flips once `things.length > 0`, copy branches on it.** Picked this.
2. Persist the flag in localStorage keyed to userId so even across reloads a returning user never sees the "welcome" copy again. Rejected for this PR: extra scope, and `InboxView` is a reusable UI component that shouldn't know about auth. The bug scenario ("add → delete → empty") happens within a single session, which in-memory tracking handles cleanly. Worth revisiting if we want the distinction to persist across reloads.
3. Server-side flag on the user (e.g., `hasUsedInbox`). Rejected: heavier migration + API surface for a cosmetic string.

What shipped:

- `useState` in `InboxView` that flips to `true` the first time `things.length > 0`. Never flips back. Copy branches on it:
  - **First-time** → *"Your inbox is ready"* / *"Add a thought or let {assistantName} bring you things to triage."*
  - **Caught up** → *"Caught up"* / *"Nothing left to triage. Nice work."*
- Icon and layout unchanged.

## Tests

Added `packages/ui/src/__tests__/InboxView.test.tsx` (2 tests):

1. Rendering with `things=[]` shows the first-time copy and **not** the caught-up copy.
2. Rendering with an item, then re-rendering with `things=[]`, flips to caught-up copy — proves the session state transition works.

**Class of bug these prevent:** stale / context-insensitive copy regressions in empty states. Any future touch to the `InboxView` empty state has to keep both paths distinct; a blanket "simplify the empty state" refactor would fail tests loudly instead of silently regressing the issue.

## Self-review findings

- Considered whether to flip the flag on mount if we *arrived* with items already loaded. Yes — the `useEffect` with `[things.length]` dep fires on mount too, so if react-query's cache serves items immediately (route re-entry), the flag flips during that first commit. Good.
- Considered whether a loading-state flicker could briefly show first-time copy to a returning user. No — the empty state only renders when `displayThings.length === 0`; during the initial load we show the skeleton / populated list from cache, not the empty state.
- Did NOT touch other list views (`ThingsEmptyState` for Today, `UpcomingView`, custom lists). Those have their own empty-state components with different copy requirements. The CLAUDE.md list-consistency rule applies to **behavior** (keyboard nav, selection, archive) — not specifically to empty-state copy which is inherently context-specific per view. Flagged as possible follow-up if we want identical treatment across all empty list surfaces.

## Verification

```
pnpm typecheck  # @brett/ui clean
pnpm test       # @brett/ui new tests pass, @brett/desktop 124/124 still green
```

## Risks / follow-ups

- The flag resets on unmount (route change, reload). A returning user who already cleared their inbox and navigates away + back will see "Your inbox is ready" again. Acceptable for this bug (which is specifically the in-session add→delete scenario); if Brent wants persistence, a follow-up can promote this to localStorage.

Visual verification pending — `gh pr checkout <n>`