### PR TITLE
fix: align Today section entry animations (#41)

### DIFF
--- a/apps/desktop/src/views/TodayView.tsx
+++ b/apps/desktop/src/views/TodayView.tsx
@@ -181,14 +181,12 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
       )}
 
       {showExpandedNextUp && nextUpEvent && nextUpTimer && (
-        <div className="animate-[fadeSlideIn_0.5s_ease-out]">
-          <NextUpCard
-            event={nextUpEvent}
-            timer={nextUpTimer}
-            variant="expanded"
-            onEventClick={() => onItemClick(nextUpEvent)}
-          />
-        </div>
+        <NextUpCard
+          event={nextUpEvent}
+          timer={nextUpTimer}
+          variant="expanded"
+          onEventClick={() => onItemClick(nextUpEvent)}
+        />
       )}
 
       <div className="flex-1 min-h-0 flex flex-col bg-black/40 backdrop-blur-xl rounded-xl border border-white/10 overflow-hidden">

--- a/packages/ui/src/DailyBriefing.tsx
+++ b/packages/ui/src/DailyBriefing.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { X, RefreshCw, Loader2, Settings } from "lucide-react";
 import { displayTitle, useDemoMode } from "./lib/demoMode";
 
@@ -153,12 +153,6 @@ export function DailyBriefing({
   assistantName = "Brett",
 }: DailyBriefingProps) {
   useDemoMode();
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setIsVisible(true), 100);
-    return () => clearTimeout(timer);
-  }, []);
 
   const titleMap = new Map(knownItems.map(item => [item.title.toLowerCase(), item]));
 
@@ -177,13 +171,7 @@ export function DailyBriefing({
     summary.todayEvents === 0;
 
   return (
-    <div
-      className={`
-        relative w-full bg-black/40 backdrop-blur-md border border-brett-cerulean/50 rounded-xl p-4
-        transition-all duration-500 ease-out transform
-        ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
-      `}
-    >
+    <div className="relative w-full bg-black/40 backdrop-blur-md border border-brett-cerulean/50 rounded-xl p-4">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">

--- a/packages/ui/src/__tests__/DailyBriefing.test.tsx
+++ b/packages/ui/src/__tests__/DailyBriefing.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { DailyBriefing } from "../DailyBriefing";
+
+function renderBriefing() {
+  return render(
+    <DailyBriefing
+      content={"- First bullet\n- Second bullet"}
+      hasAI={true}
+      onDismiss={() => {}}
+    />,
+  );
+}
+
+describe("DailyBriefing", () => {
+  it("renders without fade-in entry animation classes (appears instantly for Today-section consistency)", () => {
+    const { container } = renderBriefing();
+    const root = container.firstChild as HTMLElement;
+    expect(root).toBeTruthy();
+    // No opacity-0 / translate-y-4 staggered entry — all Today sections appear together.
+    expect(root.className).not.toContain("opacity-0");
+    expect(root.className).not.toContain("translate-y-4");
+    // No transform transition on the container either
+    expect(root.className).not.toContain("transition-all");
+  });
+});


### PR DESCRIPTION
Closes #41

## Root cause
DailyBriefing animated itself in with a 500ms `opacity/translate-y` transition kicked off by a `setTimeout(…, 100)` on mount, and the expanded NextUpCard was wrapped in a one-off `animate-[fadeSlideIn_0.5s_ease-out]`. The other sections on Today (ThingsList, the filter pills, etc.) have no entry animation, so the briefing and Next Up visibly staggered in behind them on every mount — warm starts, route re-entries, and briefing regenerations all re-triggered the effect.

## Approach
Render both sections statically. DailyBriefing drops the `isVisible` state + `useEffect` timer + transition classes; TodayView drops the `fadeSlideIn` wrapper. Now every Today section appears together on the same frame, which also matches the desktop ↔ iOS visual-parity rule (neither iOS briefing nor iOS Next Up has an entry animation).

Considered alternatives:
- Add matching fade-in to ThingsList / the filter bar — multiplies the twitchiness, does nothing for warm starts.
- Keep animations but fire once per session — still breaks on route re-entry, adds state plumbing for no user benefit.

## Tests
- `packages/ui/src/__tests__/DailyBriefing.test.tsx` — new: asserts the DailyBriefing root has no `opacity-0`, `translate-y-4`, or `transition-all` classes. Written failing against the old implementation, passes after the change.

## Self-review
- Removed `useEffect`/`useState` imports from DailyBriefing since they're no longer used.
- `fadeSlideIn` keyframe is no longer referenced anywhere in the codebase (`grep -r fadeSlideIn` returns nothing) — safe to leave the keyframe definition in Tailwind config since removing it is out of scope.
- No behavior change for the briefing content itself (bullets, skeleton, error, no-AI fallback all unchanged).

## Verification
- `pnpm typecheck` on `@brett/desktop` ✅
- `pnpm exec vitest run` on `@brett/ui` — 66/66 passing (includes new test) ✅

## Risks
Low. Purely visual: removes entry animation from two Today sections. No data, auth, or API changes.

https://claude.ai/code/session_01TDx7Do5FbgHAffKq9NmCx1