### PR TITLE
fix: iOS feedback sheet uses solid background (#43)

### DIFF
--- a/apps/ios/Brett/Views/Shared/FeedbackSheet.swift
+++ b/apps/ios/Brett/Views/Shared/FeedbackSheet.swift
@@ -42,44 +42,45 @@ struct FeedbackSheet: View {
     }
 
     var body: some View {
-        ZStack {
-            BackgroundView()
+        // Rely on the caller's .presentationBackground(Color.black) — don't
+        // render the photography wallpaper inside the sheet. The wallpaper
+        // dropped contrast under the inputs and made the labels/help text
+        // hard to read. Other sheets (TaskDetailView, SearchSheet) follow
+        // the same pattern.
+        VStack(spacing: 16) {
+            header
 
-            VStack(spacing: 16) {
-                header
-
-                Picker("Type", selection: $type) {
-                    ForEach(FeedbackType.allCases) { t in
-                        Text(t.label).tag(t)
-                    }
+            Picker("Type", selection: $type) {
+                ForEach(FeedbackType.allCases) { t in
+                    Text(t.label).tag(t)
                 }
-                .pickerStyle(.segmented)
-                .padding(.horizontal, 20)
-
-                titleField
-                descriptionField
-
-                if let errorMessage {
-                    Text(errorMessage)
-                        .font(.system(size: 13))
-                        .foregroundStyle(BrettColors.error)
-                        .padding(.horizontal, 20)
-                }
-
-                if let successMessage {
-                    Text(successMessage)
-                        .font(.system(size: 13))
-                        .foregroundStyle(BrettColors.success)
-                        .padding(.horizontal, 20)
-                }
-
-                Spacer(minLength: 0)
-
-                submitButton
             }
-            .padding(.top, 20)
-            .padding(.bottom, 24)
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 20)
+
+            titleField
+            descriptionField
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 13))
+                    .foregroundStyle(BrettColors.error)
+                    .padding(.horizontal, 20)
+            }
+
+            if let successMessage {
+                Text(successMessage)
+                    .font(.system(size: 13))
+                    .foregroundStyle(BrettColors.success)
+                    .padding(.horizontal, 20)
+            }
+
+            Spacer(minLength: 0)
+
+            submitButton
         }
+        .padding(.top, 20)
+        .padding(.bottom, 24)
     }
 
     private var header: some View {


### PR DESCRIPTION
Closes #43

## Root cause
`FeedbackSheet.body` was structured as a ZStack with `BackgroundView()` at the bottom, which drew the photography wallpaper on top of the call-site's solid `.presentationBackground(Color.black)` in `MainContainer.swift:196`. That wallpaper made the input labels, placeholders, and the "Thanks — sent" confirmation hard to read.

## Approach
Remove the ZStack + BackgroundView wrapper. The sheet now only renders its form content and relies on the caller's solid `.presentationBackground`. This matches every other sheet in the app — TaskDetailView, SearchSheet, LinksSection, and DetailsCard all set a solid `presentationBackground` at the call site and do NOT re-render `BackgroundView` inside the sheet body.

Considered alternatives:
- Keep `BackgroundView` but darken it (e.g. overlay `Color.black.opacity(0.85)`). Still shows wallpaper artifacts and adds a second dark layer on top of the solid presentation bg.
- Move the solid color into the sheet body instead of relying on the presentation bg. Duplicates state; the call site is already correct.

## Tests
No unit test added — this is a purely structural SwiftUI view change with no pure function to assert against. Verification is visual (the sheet body no longer contains `BackgroundView()`; diff is a one-line structural drop).

## Self-review
- Scoped to `FeedbackSheet.swift` only. All inner content (header, pickers, fields, buttons) preserved identically; only the outer wrapper changed.
- Other `BackgroundView()` call sites (full-screen containers like `TodayPage`, `SignInView`, `ListView`, etc.) are correct — those are full-screen pages, not sheets over a pre-set presentation background.

## Verification
- Diff: `-ZStack { BackgroundView() … }` wrapper removed, VStack indented one level up, explanatory comment added.
- Swift builds in Xcode.

## Risks
None. No data, auth, or API changes.

https://claude.ai/code/session_01TDx7Do5FbgHAffKq9NmCx1