### PR TITLE
fix: redesign iOS biometric lock screen (#44)

### DIFF
--- a/apps/ios/Brett/Views/Auth/BiometricLockView.swift
+++ b/apps/ios/Brett/Views/Auth/BiometricLockView.swift
@@ -15,14 +15,14 @@ struct BiometricLockView: View {
     var body: some View {
         ZStack {
             BackgroundView()
-                .overlay(Color.black.opacity(0.35))
+                .overlay(Color.black.opacity(0.45))
 
-            VStack(spacing: 18) {
-                // Brand mark to echo the sign-in screen — same visual
-                // anchor so the transition doesn't feel like a different
-                // app took over.
+            VStack(spacing: 0) {
+                Spacer()
+
+                // Brand mark — quiet visual anchor matching the sign-in screen.
                 BrandMark()
-                    .frame(width: 48, height: 48)
+                    .frame(width: 44, height: 44)
                     .shadow(color: BrettColors.gold.opacity(0.25), radius: 14, y: 2)
 
                 VStack(spacing: 6) {
@@ -30,62 +30,66 @@ struct BiometricLockView: View {
                         .font(.system(size: 22, weight: .semibold))
                         .foregroundStyle(.white)
 
-                    Text("Unlock with Face ID to continue")
+                    Text("Tap to unlock with Face ID")
                         .font(.system(size: 13))
-                        .foregroundStyle(Color.white.opacity(0.55))
+                        .foregroundStyle(Color.white.opacity(0.45))
                 }
+                .padding(.top, 20)
+
+                // Primary affordance is the Face ID glyph itself — a single
+                // circular target, no label. Tap to re-prompt.
+                Button {
+                    Task { await lockManager.authenticate() }
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(Color.white.opacity(0.06))
+                            .overlay {
+                                Circle().strokeBorder(Color.white.opacity(0.10), lineWidth: 0.5)
+                            }
+                            .frame(width: 96, height: 96)
+
+                        if lockManager.isEvaluating {
+                            ProgressView().tint(.white).scaleEffect(1.1)
+                        } else {
+                            Image(systemName: "faceid")
+                                .font(.system(size: 40, weight: .regular))
+                                .foregroundStyle(BrettColors.gold)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(lockManager.isEvaluating)
+                .accessibilityLabel("Unlock with Face ID")
+                .padding(.top, 40)
 
                 if let error = lockManager.lastError {
                     Text(error)
                         .font(.system(size: 12))
-                        .foregroundStyle(BrettColors.error)
+                        .foregroundStyle(Color.white.opacity(0.55))
                         .multilineTextAlignment(.center)
-                        .padding(.horizontal, 24)
-                        .padding(.vertical, 8)
-                        .background {
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(BrettColors.error.opacity(0.10))
-                        }
+                        .padding(.horizontal, 32)
+                        .padding(.top, 20)
+                        .transition(.opacity)
                 }
 
-                Button {
-                    Task { await lockManager.authenticate() }
-                } label: {
-                    HStack(spacing: 8) {
-                        if lockManager.isEvaluating {
-                            ProgressView().tint(.white).scaleEffect(0.85)
-                        } else {
-                            Image(systemName: "faceid")
-                                .font(.system(size: 15, weight: .semibold))
-                        }
-                        Text(lockManager.isEvaluating ? "Authenticating…" : "Unlock")
-                            .font(.system(size: 15, weight: .semibold))
-                    }
-                    .foregroundStyle(.white)
-                    .frame(width: 180, height: 48)
-                    .background(BrettColors.gold, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                }
-                .buttonStyle(.plain)
-                .disabled(lockManager.isEvaluating)
-                .padding(.top, 8)
+                Spacer()
 
-                // Escape hatch: if the user can't authenticate for any
-                // reason (changed face, biometry disabled system-wide,
-                // etc.) they can always sign out. Signing out clears the
-                // session + keychain and returns them to SignInView.
+                // Escape hatch: changed face, biometry disabled system-wide,
+                // etc. Signing out clears the session + keychain and returns
+                // to SignInView.
                 Button("Sign out") {
                     showSignOutConfirm = true
                 }
                 .font(.system(size: 13))
-                .foregroundStyle(Color.white.opacity(0.45))
-                .padding(.top, 4)
+                .foregroundStyle(Color.white.opacity(0.35))
+                .padding(.bottom, 24)
             }
             .padding(.horizontal, 32)
         }
         .task {
             // Auto-prompt on first appear. `authenticate` is a no-op while
-            // another prompt is in-flight, so this is safe even if the
-            // view re-renders during the evaluation.
+            // another prompt is in-flight.
             await lockManager.authenticate()
         }
         .confirmationDialog("Sign out?", isPresented: $showSignOutConfirm, titleVisibility: .visible) {


### PR DESCRIPTION
Closes #44

## Root cause
The biometric lock screen leaned on a verbose 180×48pt gold rectangular button with `faceid` icon + "Unlock" text + "Authenticating…" state. That's redundant with the system-provided Face ID sheet, and the extra text weight clashed with the minimal sign-in screen that users just came from.

## Approach
Promote the Face ID glyph itself to the primary tap target — a single circular 96pt affordance with no text label — and strip the surrounding chrome.

Layout changes:
- BrandMark (44pt) → title ("Brett is locked", 22pt) → subtitle ("Tap to unlock with Face ID", 13pt white/45) → circular glyph target (96pt, gold faceid on white/0.06 backdrop) → error inline (if any) → sign out pinned bottom (white/35).
- Wallpaper overlay darkened (0.35 → 0.45) to focus attention on the glyph.
- Error banner switched from red-tinted card → inline low-contrast text. Less shouty when Face ID fails mid-unlock.

Considered alternatives:
- Remove the button entirely and only rely on auto-prompt. Breaks the retry path when the user cancels the system sheet.
- Keep the rectangular button but drop the text. Still a rectangle, still verbose by comparison.
- Use a pulsing animation on the glyph. Over-engineered for a screen that should feel quiet, not kinetic.

## Tests
No unit test added — this is a purely visual SwiftUI layout change with no pure function to assert against. Verification is visual in Xcode.

## Self-review
- `.accessibilityLabel("Unlock with Face ID")` added to the icon button so VoiceOver still announces the affordance clearly (previously it read the "Unlock" text).
- Retry path preserved — tapping the glyph calls `lockManager.authenticate()` just like the old button did.
- `showSignOutConfirm` confirmation dialog untouched.
- `.task { await lockManager.authenticate() }` auto-prompt preserved — re-renders are still safe because `authenticate` is a no-op while evaluating.
- Error-path visual regression considered: errors used to sit above the button; they now sit below. Since the glyph is centred and the error is still in reading order, this is fine.

## Verification
- Swift builds in Xcode.
- Diff is one file: `apps/ios/Brett/Views/Auth/BiometricLockView.swift`.

## Risks
Low. No auth logic changed, no data flow changed. Purely visual/layout.

https://claude.ai/code/session_01TDx7Do5FbgHAffKq9NmCx1