### PR TITLE
fix(desktop): drop "use memo" from ThingCard + InboxItemRow

### DIFF
--- a/packages/ui/src/InboxItemRow.tsx
+++ b/packages/ui/src/InboxItemRow.tsx
@@ -1,5 +1,3 @@
-"use memo";
-
 import React, { useState, useEffect, useRef } from "react";
 import { Zap, BookOpen, Check, MessageSquare, FileText, Play, File, Headphones, Globe, RefreshCw, Download } from "lucide-react";
 import type { Thing } from "@brett/types";

--- a/packages/ui/src/ThingCard.tsx
+++ b/packages/ui/src/ThingCard.tsx
@@ -1,5 +1,3 @@
-"use memo";
-
 import React, { useState, useEffect, useRef } from "react";
 import { StaleTooltip } from "./StaleTooltip";
 import { Zap, BookOpen, Calendar, Check, RotateCcw, MessageSquare, FileText, Play, File, Headphones, Globe, RefreshCw, Download } from "lucide-react";


### PR DESCRIPTION
## Summary
- Packaged Electron nav regressed — clicks updated the URL but the view stayed put. Same class of bug as f64db34.
- Root cause: commit 266eb84 added `"use memo"` to ThingCard + InboxItemRow, but both transitively use `useSyncExternalStore` via `useDisplayTitle` → `useDemoMode`. That violates the rule documented in `apps/desktop/vite.config.ts`: *"Don't opt in anything that touches Router context or useSyncExternalStore-based subscriptions."* React Compiler v1.0.0's closure hoisting mis-wires those subscribers, which detaches Router's popstate listener.
- Dropping the directive restores normal React rendering (no compiler transform) on these two files. No feature change, just loses the auto-memoization wins. Annotation mode itself stays enabled in `vite.config.ts` for future safe opt-ins.

## Test plan
- [ ] `pnpm --filter @brett/desktop electron:build`
- [ ] Launch packaged app (`npx electron dist/electron/main.js` or the .dmg)
- [ ] Click around left nav (Today, Inbox, Upcoming, custom lists) — view should change each time
- [ ] Toggle demo mode (⌘⌥D) — task + inbox titles still swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)