### PR TITLE
fix(content): extract tweets via syndication CDN

### DIFF
--- a/apps/api/src/__tests__/content-extractor.test.ts
+++ b/apps/api/src/__tests__/content-extractor.test.ts
@@ -5,6 +5,9 @@ import {
   buildApplePodcastEmbedUrl,
   extractYouTubeVideoId,
   extractArticle,
+  extractTweetId,
+  extractTweetAuthor,
+  computeSyndicationToken,
 } from "../lib/content-extractor.js";
 // cleanFilename is from @brett/ui — import directly since API doesn't depend on ui package
 function cleanFilename(filename: string): string {
@@ -124,6 +127,57 @@ describe("buildApplePodcastEmbedUrl", () => {
 
   it("returns null for non-podcast URL", () => {
     expect(buildApplePodcastEmbedUrl("https://example.com/not-a-podcast")).toBeNull();
+  });
+});
+
+describe("extractTweetId", () => {
+  it("extracts ID from x.com status URL", () => {
+    expect(extractTweetId("https://x.com/aiedge_/status/2046352285622731011")).toBe("2046352285622731011");
+  });
+
+  it("extracts ID from twitter.com status URL", () => {
+    expect(extractTweetId("https://twitter.com/vercel/status/1683920951807971329")).toBe("1683920951807971329");
+  });
+
+  it("ignores trailing query string", () => {
+    expect(extractTweetId("https://x.com/aiedge_/status/2046352285622731011?s=12&t=abc")).toBe("2046352285622731011");
+  });
+
+  it("handles /statuses/ legacy path form", () => {
+    expect(extractTweetId("https://twitter.com/user/statuses/123456789")).toBe("123456789");
+  });
+
+  it("returns null for non-tweet URLs", () => {
+    expect(extractTweetId("https://x.com/aiedge_")).toBeNull();
+    expect(extractTweetId("https://example.com/foo/status/123")).toBeNull();
+  });
+});
+
+describe("extractTweetAuthor", () => {
+  it("extracts @handle from x.com URL", () => {
+    expect(extractTweetAuthor("https://x.com/aiedge_/status/2046352285622731011")).toBe("aiedge_");
+  });
+
+  it("extracts @handle from twitter.com URL", () => {
+    expect(extractTweetAuthor("https://twitter.com/vercel/status/1683920951807971329")).toBe("vercel");
+  });
+
+  it("returns null for URLs without a handle", () => {
+    expect(extractTweetAuthor("https://x.com/i/status/123")).toBe("i"); // edge: "i" is technically the handle here
+    expect(extractTweetAuthor("https://example.com/something")).toBeNull();
+  });
+});
+
+describe("computeSyndicationToken", () => {
+  it("matches react-tweet's token derivation for known tweet IDs", () => {
+    // These values were verified by hitting cdn.syndication.twimg.com manually.
+    expect(computeSyndicationToken("2046352285622731011")).toBe("4ykszoetnf");
+    expect(computeSyndicationToken("1683920951807971329")).toBe("42y6zv7ufp");
+  });
+
+  it("is deterministic", () => {
+    const id = "1234567890123456789";
+    expect(computeSyndicationToken(id)).toBe(computeSyndicationToken(id));
   });
 });
 

--- a/apps/api/src/lib/content-extractor.ts
+++ b/apps/api/src/lib/content-extractor.ts
@@ -85,6 +85,142 @@ async function fetchOEmbed(
   }
 }
 
+export function extractTweetId(url: string): string | null {
+  // Matches twitter.com/<user>/status/<id> and x.com/<user>/statuses/<id>.
+  // The /statuses/ form is legacy but still appears in the wild.
+  const match = url.match(/(?:twitter\.com|x\.com)\/[^/]+\/status(?:es)?\/(\d+)/i);
+  return match?.[1] ?? null;
+}
+
+export function extractTweetAuthor(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (!/(?:^|\.)(twitter\.com|x\.com)$/i.test(parsed.hostname)) return null;
+    const match = parsed.pathname.match(/^\/([^/]+)\/status/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Token derivation matches vercel/react-tweet (MIT): the syndication CDN
+// requires a token keyed off the tweet ID. It's a one-way transform, not a
+// secret — the endpoint is public and returns the same data to anyone who
+// computes the token correctly.
+export function computeSyndicationToken(id: string): string {
+  return ((Number(id) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, "");
+}
+
+interface TweetSyndicationResult {
+  handle: string;               // screen_name, e.g. "aiedge_"
+  displayName: string | null;   // user.name, e.g. "AI Edge"
+  text: string;                 // raw tweet text
+  createdAt: string | null;
+  article: {
+    title: string;
+    previewText: string | null;
+    coverImageUrl: string | null;
+  } | null;
+  mediaImageUrl: string | null; // first media photo if any
+}
+
+async function fetchTweetSyndication(url: string): Promise<TweetSyndicationResult | null> {
+  const id = extractTweetId(url);
+  if (!id) return null;
+  const token = computeSyndicationToken(id);
+  const endpoint = `https://cdn.syndication.twimg.com/tweet-result?id=${id}&token=${token}&lang=en`;
+  try {
+    const res = await safeFetch(endpoint, { timeoutMs: 5000, maxSizeBytes: 500_000 });
+    if (!res.ok) return null;
+    const data = (await res.json()) as Record<string, any>;
+    const handle = data?.user?.screen_name as string | undefined;
+    if (!handle) return null;
+
+    const article = (() => {
+      const a = data?.article;
+      if (!a || typeof a !== "object") return null;
+      const title = a.title as string | undefined;
+      if (!title) return null;
+      return {
+        title,
+        previewText: (a.preview_text as string | undefined) ?? null,
+        coverImageUrl: (a?.cover_media?.media_info?.original_img_url as string | undefined) ?? null,
+      };
+    })();
+
+    const mediaDetails = Array.isArray(data?.mediaDetails) ? data.mediaDetails : [];
+    const photo = mediaDetails.find((m: any) => m?.type === "photo");
+    const mediaImageUrl = (photo?.media_url_https as string | undefined) ?? null;
+
+    return {
+      handle,
+      displayName: (data?.user?.name as string | undefined) ?? null,
+      text: (data?.text as string | undefined) ?? "",
+      createdAt: (data?.created_at as string | undefined) ?? null,
+      article,
+      mediaImageUrl,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function extractTweet(url: string): Promise<ExtractionResult> {
+  const parsed = new URL(url);
+  const domain = parsed.hostname.replace(/^www\./, "");
+  const favicon = `${parsed.origin}/favicon.ico`;
+
+  const syndication = await fetchTweetSyndication(url);
+  if (syndication) {
+    // For "X Article" tweets, the article card is the meaningful content;
+    // data.text is just a t.co shortlink, so prefer the article fields.
+    const isArticle = syndication.article !== null;
+    const effectiveText = isArticle
+      ? syndication.article?.previewText ?? syndication.text
+      : syndication.text;
+    const title = syndication.article?.title ?? `Tweet by @${syndication.handle}`;
+    const imageUrl = syndication.article?.coverImageUrl ?? syndication.mediaImageUrl ?? null;
+
+    return {
+      contentType: "tweet",
+      contentStatus: "extracted",
+      contentTitle: title,
+      contentDescription: effectiveText?.trim() || null,
+      contentImageUrl: imageUrl,
+      contentBody: null,
+      contentFavicon: favicon,
+      contentDomain: domain,
+      contentMetadata: {
+        type: "tweet",
+        author: syndication.handle,
+        tweetText: effectiveText?.trim() || undefined,
+      },
+      title,
+    };
+  }
+
+  // Syndication failed (deleted, rate-limited, or CDN hiccup) — still return a
+  // usable card with the handle derived from the URL path so the panel doesn't
+  // show the raw URL as the title.
+  const urlAuthor = extractTweetAuthor(url);
+  const fallbackTitle = urlAuthor ? `Tweet by @${urlAuthor}` : null;
+  return {
+    contentType: "tweet",
+    contentStatus: "extracted",
+    contentTitle: fallbackTitle,
+    contentDescription: null,
+    contentImageUrl: null,
+    contentBody: null,
+    contentFavicon: favicon,
+    contentDomain: domain,
+    contentMetadata: {
+      type: "tweet",
+      author: urlAuthor ?? undefined,
+    },
+    title: fallbackTitle ?? undefined,
+  };
+}
+
 export function buildSpotifyEmbedUrl(url: string): string | null {
   // https://open.spotify.com/episode/abc → https://open.spotify.com/embed/episode/abc
   const match = url.match(/open\.spotify\.com\/(episode\/[^?#]+)/);
@@ -143,6 +279,13 @@ export async function extractContent(url: string): Promise<ExtractionResult> {
       contentMetadata: { type: "pdf" },
       needsPdfDownload: true,
     };
+  }
+
+  // Tweet: skip x.com page fetch — cdn.syndication.twimg.com/tweet-result
+  // returns structured JSON for any public tweet. X.com serves a JS shell to
+  // non-crawler User-Agents, so scraping its HTML is a dead end.
+  if (contentType === "tweet") {
+    return extractTweet(url);
   }
 
   // YouTube: skip page fetch entirely — oEmbed API is faster and more reliable.
@@ -209,25 +352,6 @@ export async function extractContent(url: string): Promise<ExtractionResult> {
   };
 
   switch (contentType) {
-    case "tweet": {
-      const oembed = await fetchOEmbed("https://publish.twitter.com/oembed", url);
-      const author = oembed?.author_name as string | undefined;
-      return {
-        ...base,
-        contentType: "tweet",
-        // Use oEmbed author for title when OG tags are blocked (common with X)
-        title: base.title ?? (author ? `Tweet by ${author}` : undefined),
-        contentTitle: base.contentTitle ?? (author ? `Tweet by ${author}` : null),
-        contentBody: null,
-        contentMetadata: {
-          type: "tweet",
-          embedHtml: oembed?.html as string | undefined,
-          author,
-          tweetText: ogTags.description ?? undefined,
-        },
-      };
-    }
-
     case "video": {
       const videoId = extractYouTubeVideoId(url);
       const embedUrl = videoId ? `https://www.youtube.com/embed/${videoId}` : undefined;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1282,6 +1282,7 @@ export function App() {
           onRetryExtraction={() => {
             if (selectedId) retryExtraction.mutate(selectedId);
           }}
+          isRetryingExtraction={retryExtraction.isPending}
           calendarEventDetail={calendarEventDetail ?? null}
           isLoadingCalendarDetail={isLoadingCalendarDetail}
           onUpdateRsvp={(status, comment) => {

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -400,7 +400,24 @@ export function useRetryExtraction() {
       });
       return res;
     },
-    onSuccess: (_data, itemId) => {
+    onMutate: async (itemId) => {
+      // Optimistically flip to "pending" so the LoadingSkeleton shows immediately.
+      // Without this the button click feels like a no-op: the server returns 202
+      // fast, background extraction often finishes before the refetch settles,
+      // and the UI flashes through pending too quickly to perceive.
+      await qc.cancelQueries({ queryKey: ["thing-detail", itemId] });
+      const prev = qc.getQueryData<unknown>(["thing-detail", itemId]);
+      qc.setQueryData<any>(["thing-detail", itemId], (old: any) =>
+        old ? { ...old, contentStatus: "pending" } : old
+      );
+      return { prev };
+    },
+    onError: (_err, itemId, context) => {
+      if (context?.prev !== undefined) {
+        qc.setQueryData(["thing-detail", itemId], context.prev);
+      }
+    },
+    onSettled: (_data, _err, itemId) => {
       qc.invalidateQueries({ queryKey: ["thing-detail", itemId] });
     },
   });

--- a/packages/ui/src/ContentDetailPanel.tsx
+++ b/packages/ui/src/ContentDetailPanel.tsx
@@ -58,6 +58,7 @@ interface ContentDetailPanelProps {
   onOpenSettings?: () => void;
   // Content extraction retry
   onRetryExtraction?: () => void;
+  isRetryingExtraction?: boolean;
   onItemClick?: (id: string) => void;
   onEventClick?: (eventId: string) => void;
   onNavigateToScout?: (scoutId: string) => void;
@@ -97,6 +98,7 @@ export function ContentDetailPanel({
   brettAiConfigured,
   onOpenSettings,
   onRetryExtraction,
+  isRetryingExtraction,
   onItemClick,
   onEventClick,
   onNavigateToScout,
@@ -268,6 +270,7 @@ export function ContentDetailPanel({
                 : undefined
             }
             onRetry={onRetryExtraction}
+            isRetrying={isRetryingExtraction}
             assistantName={assistantName}
           />
 

--- a/packages/ui/src/ContentPreview.tsx
+++ b/packages/ui/src/ContentPreview.tsx
@@ -55,6 +55,7 @@ interface ContentPreviewProps {
   contentMetadata?: ContentMetadata;
   attachmentUrl?: string; // presigned S3 URL for drag-dropped PDFs
   onRetry?: () => void;
+  isRetrying?: boolean;
   assistantName?: string;
 }
 
@@ -84,7 +85,7 @@ function LoadingSkeleton({ contentType }: { contentType?: ContentType }) {
   );
 }
 
-function ErrorState({ sourceUrl, onRetry, assistantName = "Brett" }: { sourceUrl?: string; onRetry?: () => void; assistantName?: string }) {
+function ErrorState({ sourceUrl, onRetry, isRetrying, assistantName = "Brett" }: { sourceUrl?: string; onRetry?: () => void; isRetrying?: boolean; assistantName?: string }) {
   return (
     <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-3">
       <div className="flex items-center gap-2">
@@ -105,10 +106,11 @@ function ErrorState({ sourceUrl, onRetry, assistantName = "Brett" }: { sourceUrl
         {onRetry && (
           <button
             onClick={onRetry}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-white/5 text-white/60 border border-white/10 hover:bg-white/10 hover:text-white transition-colors"
+            disabled={isRetrying}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-white/5 text-white/60 border border-white/10 hover:bg-white/10 hover:text-white transition-colors disabled:opacity-60 disabled:cursor-wait disabled:hover:bg-white/5 disabled:hover:text-white/60"
           >
-            <RefreshCw size={12} />
-            Try again
+            <RefreshCw size={12} className={isRetrying ? "animate-spin" : ""} />
+            {isRetrying ? "Retrying…" : "Try again"}
           </button>
         )}
         <span className="text-[10px] text-white/20">
@@ -504,6 +506,7 @@ export function ContentPreview({
   contentMetadata,
   attachmentUrl,
   onRetry,
+  isRetrying,
   assistantName = "Brett",
 }: ContentPreviewProps) {
   // Loading state
@@ -513,7 +516,7 @@ export function ContentPreview({
 
   // Error state
   if (contentStatus === "failed") {
-    return <ErrorState sourceUrl={sourceUrl} onRetry={onRetry} assistantName={assistantName} />;
+    return <ErrorState sourceUrl={sourceUrl} onRetry={onRetry} isRetrying={isRetrying} assistantName={assistantName} />;
   }
 
   // Render based on content type

--- a/packages/ui/src/DetailPanel.tsx
+++ b/packages/ui/src/DetailPanel.tsx
@@ -54,6 +54,7 @@ interface DetailPanelProps {
   onOpenSettings?: () => void;
   // Content extraction
   onRetryExtraction?: () => void;
+  isRetryingExtraction?: boolean;
   // Calendar event callbacks
   calendarEventDetail?: CalendarEventDetailResponse | null;
   isLoadingCalendarDetail?: boolean;
@@ -132,6 +133,7 @@ export function DetailPanel({
   brettAiConfigured,
   onOpenSettings,
   onRetryExtraction,
+  isRetryingExtraction,
   calendarEventDetail,
   isLoadingCalendarDetail,
   onUpdateRsvp,
@@ -289,6 +291,7 @@ export function DetailPanel({
             brettAiConfigured={brettAiConfigured}
             onOpenSettings={onOpenSettings}
             onRetryExtraction={onRetryExtraction}
+            isRetryingExtraction={isRetryingExtraction}
             onItemClick={onItemClick}
             onEventClick={onEventClick}
             onNavigateToScout={onNavigateToScout}


### PR DESCRIPTION
## Summary

- X.com serves a JS shell to our User-Agent, so the prior `publish.twitter.com/oembed` path failed silently. Tweets landed with `contentStatus=failed`, the raw URL as the title, and a Retry button that did nothing visible.
- Swap the tweet branch to `cdn.syndication.twimg.com/tweet-result` (what react-tweet and most link-preview services use). Returns structured JSON for any public tweet with no auth. Handles both regular tweets and X Articles.
- If syndication also fails, still return `extracted` with a URL-derived `"Tweet by @handle"` title so the panel never shows a raw URL.
- Retry UX: `onMutate` flips `contentStatus=pending` optimistically so the loading skeleton renders instantly; Try again button shows a spinner + disabled state while the mutation is in flight.

## Test plan

- [x] New unit tests for `extractTweetId`, `extractTweetAuthor`, `computeSyndicationToken` (token values verified against live CDN)
- [x] `pnpm typecheck` passes across all 17 workspace tasks
- [x] `pnpm lint` clean (1 pre-existing warning unrelated to this change)
- [ ] Manual: save the original failing X.com Article URL via iOS → confirm panel shows article title + author + cover image
- [ ] Manual: save a regular (non-article) tweet → confirm @handle + tweet text render in preview
- [ ] Manual: save a deleted/private tweet URL → confirm fallback `"Tweet by @handle"` title, no error state
- [ ] Manual: simulate extraction failure → confirm Try again button spins + disables

🤖 Generated with [Claude Code](https://claude.com/claude-code)