### PR TITLE
Release: disable renderer minify — fixes broken nav in packaged Electron

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -41,5 +41,13 @@ export default defineConfig({
   },
   build: {
     outDir: "dist/renderer",
+    // esbuild's minifier mangles something in React Router v7's useSyncExternalStore
+    // subscribe closure — the popstate listener never attaches in the packaged
+    // `app://` bundle, so clicks update the URL but the view doesn't re-render.
+    // Dev works because Vite's dev pipeline doesn't minify. Disabling minify here
+    // trades ~3 MB of bundle size for a working router. Revisit with a targeted
+    // minification config (exclude react-router-dom / history, or switch to terser
+    // with safer options) once we have time to isolate the exact rule that breaks.
+    minify: false,
   },
 });


### PR DESCRIPTION
## Summary
Diagnosed via DevTools instrumentation in 0.1.1266 (after hard-disabling the React Compiler still did not fix nav):

- Clicks fire `history.pushState` correctly. URL updates. Reload lands on last clicked route.
- Native `popstate` and `hashchange` events fire on `window` AND a plain `window.addEventListener` hears them.
- **React Router's own popstate listener is not attached in the packaged bundle** → clicks update URL but view doesn't re-render.

Same symptom as the "React Compiler" bug we chased across two emergency releases — but the compiler has been off for two releases. Remaining suspect: esbuild's minifier mangling React Router's `useSyncExternalStore` subscribe closure. Dev works because Vite's dev pipeline doesn't minify.

**Fix:** disable minification for the renderer build. Bundle goes 1.4 MB → 3.0 MB (gzip 434 KB → 627 KB). Irrelevant size cost for a desktop app served via `app://`.

Follow-up: isolate the exact minifier rule and re-enable with a targeted config.

## Test plan
- [ ] Install 0.1.1267 from the built DMG
- [ ] Click every left-nav item — view updates each time
- [ ] ⌘K → pick item — view navigates
- [ ] Reload — lands on current view (not reverted)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)