### PR TITLE
Release: re-enable minify + React Compiler (annotation mode)

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -6,20 +6,24 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const pkg = require("./package.json");
 
-// React Compiler disabled. v1.0.0 mis-optimizes the packaged prod bundle
-// (minified, served over app://): closure hoisting detaches
-// useSyncExternalStore subscribers, silently killing React Router's popstate
-// listener so clicks update the URL but the view never re-renders. Console
-// stays clean, which makes this a nightmare to catch.
-//
-// We tried `compilationMode: "annotation"` as a compromise — only files with
-// `"use memo";` get compiled — and it still broke navigation in the packaged
-// build even with no files annotated. The plugin is not a no-op just because
-// nothing opts in. Until upstream ships fixes for facebook/react#35342,
-// #36128, #34045, #35009, the compiler stays off entirely. Hand-written
-// useMemo / useCallback / React.memo is fine where it measurably helps.
+// React Compiler in annotation mode: only files with a top-of-file
+// `"use memo";` directive get compiled. The mid-April "compiler broke nav"
+// diagnosis turned out to be wrong (real cause: React 19.2's startTransition
+// inside HashRouter — see apps/desktop/src/main.tsx). But running the
+// compiler in annotation mode keeps the escape hatch while opt-ins have to
+// be made deliberately and verified in the packaged build.
+const ReactCompilerConfig = {
+  compilationMode: "annotation" as const,
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: [["babel-plugin-react-compiler", ReactCompilerConfig]],
+      },
+    }),
+  ],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
@@ -41,13 +45,5 @@ export default defineConfig({
   },
   build: {
     outDir: "dist/renderer",
-    // esbuild's minifier mangles something in React Router v7's useSyncExternalStore
-    // subscribe closure — the popstate listener never attaches in the packaged
-    // `app://` bundle, so clicks update the URL but the view doesn't re-render.
-    // Dev works because Vite's dev pipeline doesn't minify. Disabling minify here
-    // trades ~3 MB of bundle size for a working router. Revisit with a targeted
-    // minification config (exclude react-router-dom / history, or switch to terser
-    // with safer options) once we have time to isolate the exact rule that breaks.
-    minify: false,
   },
 });


### PR DESCRIPTION
## Summary
Red-herring fixes from PRs #72 and #73 are now obsolete — actual nav bug was fixed in PR #74 (startTransition). Restore the original build config:

- Minify back on → renderer 3.0 MB → 1.4 MB
- React Compiler plugin in annotation mode (no opt-ins yet → effectively no-op; escape hatch wired)

## Test plan
- [ ] Install 0.1.1271 DMG
- [ ] Click through Today / Inbox / Upcoming / Calendar / Scouts / Lists / Settings — nav works
- [ ] Reload (⌘R) — stays on current view

## Deferred
React 19.2.0 → 19.2.5 and react-router-dom 7.13.1 → 7.14.2 upgrade attempted but triggered a `@better-auth/passkey` + `@better-auth/core` type mismatch (pnpm re-resolution pulls in incompatible sub-versions). Worth its own session to untangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)