### PR TITLE
fix(ios): single-pass list counts on Lists tab (#69)

### DIFF
--- a/apps/ios/Brett/Views/List/ListCounts.swift
+++ b/apps/ios/Brett/Views/List/ListCounts.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Per-list item counts used by `ListsPage`'s cards.
+///
+/// Pure grouper kept separate from `ListsPage` so the bucketing rules can
+/// be unit tested without SwiftUI or SwiftData. Callers fetch items once
+/// and hand the array in; the page does not refetch per card.
+enum ListCounts {
+    struct Entry: Equatable {
+        let active: Int
+        let completed: Int
+        let total: Int
+
+        static let empty = Entry(active: 0, completed: 0, total: 0)
+    }
+
+    /// Bucket the given items by `listId`. Items without a `listId`, and
+    /// items in the `.archived` status, are skipped — the counts match
+    /// what a list card renders under its progress ring (total = active
+    /// + completed; archived rows do not influence the ring).
+    ///
+    /// Callers are expected to pass already-non-soft-deleted items (the
+    /// iOS `ItemStore.fetchAll()` predicate filters `deletedAt == nil`).
+    static func groupByListId(_ items: [Item]) -> [String: Entry] {
+        var active: [String: Int] = [:]
+        var completed: [String: Int] = [:]
+        for item in items {
+            guard let listId = item.listId else { continue }
+            switch item.itemStatus {
+            case .archived:
+                continue
+            case .done:
+                completed[listId, default: 0] += 1
+            case .active, .snoozed:
+                // Snoozed rows count as active under the progress ring:
+                // they're not done and the user hasn't archived them.
+                active[listId, default: 0] += 1
+            }
+        }
+        var out: [String: Entry] = [:]
+        for id in Set(active.keys).union(completed.keys) {
+            let a = active[id] ?? 0
+            let c = completed[id] ?? 0
+            out[id] = Entry(active: a, completed: c, total: a + c)
+        }
+        return out
+    }
+}

--- a/apps/ios/Brett/Views/List/ListsPage.swift
+++ b/apps/ios/Brett/Views/List/ListsPage.swift
@@ -36,6 +36,17 @@ struct ListsPage: View {
         return listStore.fetchAll(includeArchived: false)
     }
 
+    /// Counts bucketed by `listId` in a single pass over every item, so
+    /// rendering N list cards triggers one SwiftData fetch instead of N.
+    /// `ItemStore.fetchAll()` reads every non-deleted row and filters in
+    /// memory, which is why this must not run per card. See
+    /// `ListCounts.groupByListId` for the grouping rules.
+    private var countsByList: [String: ListCounts.Entry] {
+        _ = refreshTick
+        let items = itemStore.fetchAll()
+        return ListCounts.groupByListId(items)
+    }
+
     var body: some View {
         ZStack {
             ScrollView {
@@ -96,10 +107,11 @@ struct ListsPage: View {
     // MARK: - Cards
 
     private var listCards: some View {
-        VStack(spacing: 8) {
+        let counts = countsByList
+        return VStack(spacing: 8) {
             ForEach(lists, id: \.id) { list in
                 NavigationLink(value: NavDestination.listView(id: list.id)) {
-                    listCard(list)
+                    listCard(list, counts: counts[list.id] ?? .empty)
                 }
                 .buttonStyle(.plain)
             }
@@ -107,9 +119,8 @@ struct ListsPage: View {
         .padding(.horizontal, 16)
     }
 
-    private func listCard(_ list: ItemList) -> some View {
+    private func listCard(_ list: ItemList, counts: ListCounts.Entry) -> some View {
         let color = ListColor(colorClass: list.colorClass)?.swiftUIColor ?? ListColor.slate.swiftUIColor
-        let counts = itemCounts(for: list.id)
 
         return HStack(spacing: 14) {
             // Progress ring fills clockwise as items are completed —
@@ -209,13 +220,6 @@ struct ListsPage: View {
         refreshTick &+= 1
     }
 
-    private func itemCounts(for listId: String) -> (active: Int, completed: Int, total: Int) {
-        let items = itemStore.fetchAll(listId: listId, status: nil)
-            .filter { $0.itemStatus != .archived }
-        let active = items.filter { $0.itemStatus != .done }.count
-        let completed = items.filter { $0.itemStatus == .done }.count
-        return (active: active, completed: completed, total: items.count)
-    }
 }
 
 /// Tiny progress ring that fills clockwise as items in a list are

--- a/apps/ios/BrettTests/Views/ListCountsTests.swift
+++ b/apps/ios/BrettTests/Views/ListCountsTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Tests for the pure grouper behind `ListsPage`'s per-card counts.
+///
+/// `ListsPage` used to call `ItemStore.fetchAll(listId:)` once per rendered
+/// card, which meant rendering N lists triggered N full-table scans of every
+/// non-deleted item. The new shape fetches items once and groups them by
+/// `listId` in a single pass via `ListCounts.groupByListId`. These tests
+/// guard the grouping rules — they don't try to assert fetch counts, which
+/// would only echo the implementation.
+@Suite("ListCounts", .tags(.views))
+struct ListCountsTests {
+
+    // MARK: - Grouping
+
+    @Test func groupsItemsByListId() {
+        let items = [
+            TestFixtures.makeItem(listId: "a"),
+            TestFixtures.makeItem(listId: "a"),
+            TestFixtures.makeItem(listId: "b"),
+        ]
+        let out = ListCounts.groupByListId(items)
+        #expect(out["a"]?.total == 2)
+        #expect(out["b"]?.total == 1)
+    }
+
+    @Test func skipsItemsWithoutAListId() {
+        let items = [
+            TestFixtures.makeItem(listId: nil),
+            TestFixtures.makeItem(listId: nil),
+            TestFixtures.makeItem(listId: "a"),
+        ]
+        let out = ListCounts.groupByListId(items)
+        #expect(out.count == 1)
+        #expect(out["a"]?.total == 1)
+    }
+
+    @Test func excludesArchivedFromEveryBucket() {
+        let items = [
+            TestFixtures.makeItem(status: .active, listId: "a"),
+            TestFixtures.makeItem(status: .archived, listId: "a"),
+            TestFixtures.makeItem(status: .archived, listId: "a"),
+        ]
+        let entry = ListCounts.groupByListId(items)["a"]
+        #expect(entry?.active == 1)
+        #expect(entry?.completed == 0)
+        #expect(entry?.total == 1)
+    }
+
+    @Test func countsDoneAsCompleted() {
+        let items = [
+            TestFixtures.makeItem(status: .done, listId: "a"),
+            TestFixtures.makeItem(status: .done, listId: "a"),
+            TestFixtures.makeItem(status: .active, listId: "a"),
+        ]
+        let entry = ListCounts.groupByListId(items)["a"]
+        #expect(entry?.active == 1)
+        #expect(entry?.completed == 2)
+        #expect(entry?.total == 3)
+    }
+
+    @Test func countsSnoozedAsActive() {
+        // Snoozed items still belong to the progress ring's "not done
+        // yet" bucket — the old `itemCounts(for:)` kept them in active
+        // by filtering on `!= .done`. Regressing this would make the
+        // list-card subtitle undercount open work.
+        let items = [
+            TestFixtures.makeItem(status: .snoozed, listId: "a"),
+            TestFixtures.makeItem(status: .active, listId: "a"),
+        ]
+        let entry = ListCounts.groupByListId(items)["a"]
+        #expect(entry?.active == 2)
+        #expect(entry?.completed == 0)
+        #expect(entry?.total == 2)
+    }
+
+    @Test func totalEqualsActivePlusCompleted() {
+        let items = [
+            TestFixtures.makeItem(status: .active, listId: "a"),
+            TestFixtures.makeItem(status: .done, listId: "a"),
+            TestFixtures.makeItem(status: .archived, listId: "a"),
+            TestFixtures.makeItem(status: .snoozed, listId: "a"),
+        ]
+        let entry = ListCounts.groupByListId(items)["a"]
+        #expect((entry?.active ?? 0) + (entry?.completed ?? 0) == entry?.total)
+    }
+
+    @Test func emptyInputReturnsEmptyDictionary() {
+        #expect(ListCounts.groupByListId([]).isEmpty)
+    }
+
+    @Test func listsWithOnlyArchivedItemsAreAbsent() {
+        // If every row on a list is archived, the grouper produces no
+        // entry for that list — consumers fall back to `.empty`, which
+        // renders as a zero-state progress dot rather than a spurious
+        // "0 items, all done" ring.
+        let items = [
+            TestFixtures.makeItem(status: .archived, listId: "a"),
+            TestFixtures.makeItem(status: .archived, listId: "a"),
+        ]
+        let out = ListCounts.groupByListId(items)
+        #expect(out["a"] == nil)
+    }
+
+    @Test func emptyEntryDefaultIsAllZeros() {
+        #expect(ListCounts.Entry.empty.active == 0)
+        #expect(ListCounts.Entry.empty.completed == 0)
+        #expect(ListCounts.Entry.empty.total == 0)
+    }
+}


### PR DESCRIPTION
Closes #69

## Root cause (not symptom)

Issue #69 reports "severe lag" when swiping between the four pages of the main iOS `TabView` (Lists / Inbox / Today / Calendar). Exploring the four pages surfaced one clear O(N²)-shaped bug in `ListsPage`:

- `listCards` renders a non-lazy `VStack(ForEach(lists))`, so every list card is built on every body evaluation of `ListsPage`.
- Each card called `itemCounts(for: list.id)`, which called `ItemStore.fetchAll(listId:)`.
- `ItemStore.fetchAll(...)` has no `#Predicate` on `listId` — it fetches **every** non-deleted `Item` row from SwiftData and filters in memory.
- Net effect: rendering N list cards runs N full-table scans over every non-deleted item. A user with ~10 lists and a few hundred items pays ~O(lists × items) per body pass, which is enough to drop frames on the page that SwiftUI is just starting to composite as you swipe into the Lists tab.

The other pages were audited too (TodayPage, InboxPage, CalendarPage, BackgroundView, SyncPendingIndicator). Most have heavier view trees but none exhibited an equivalent N×O(N) data-access pattern. Those may still be worth perf passes — keeping them out of scope so this change is verifiable.

## Approach

Three options considered:

1. **Leave `ItemStore.fetchAll` as-is, fetch once at the page level and group in memory** (chosen). Smallest behavior change, no new `ItemStore` API, the grouping logic extracts cleanly into a pure function for testing.
2. **Add a `#Predicate` on `listId` to `ItemStore.fetchAll`.** Fixes the per-call cost but still calls `fetchAll` N times per render — the per-query overhead in SwiftData is non-trivial, and you still can't group in a single pass.
3. **Add `ItemStore.countsByListId()` that runs a grouped query or aggregate.** SwiftData doesn't expose aggregate queries, and this would still end up materializing every item, just inside the store. More layers for no runtime win.

Option 1 is the tightest fix with the cleanest test seam.

### Changes

- `apps/ios/Brett/Views/List/ListCounts.swift` — new pure helper `ListCounts.groupByListId([Item]) -> [String: Entry]` that buckets items by `listId` in one pass. Skips archived and items without a `listId`; snoozed items stay in the active tally (matching the pre-refactor behavior).
- `apps/ios/Brett/Views/List/ListsPage.swift` — replaced `itemCounts(for:)` with a page-level `countsByList` computed property that does one `fetchAll()` and one grouping pass. Each card reads its entry via dictionary lookup.
- `apps/ios/BrettTests/Views/ListCountsTests.swift` — unit tests for the grouping rules.

## Tests

- `ListCountsTests.swift` covers: grouping by `listId`, nil-`listId` items skipped, archived excluded from every bucket, done → completed, snoozed → active, total == active + completed invariant, empty input, all-archived list absent from output, `Entry.empty` defaults.

These tests pin the **behavioral** invariants of the grouper. They don't try to assert "ListsPage calls `fetchAll` exactly once per render" — that would only mirror the implementation. The perf regression-prevention comes from the architecture (single fetch + pure grouper), not an assertion.

**Test-prevention reflection:** Could a pragmatic test have caught the original bug? No — this is a performance bug, not a correctness bug. The per-card fetch produced correct counts, just slowly. The nearest useful guard is a perf budget on `ListsPage` body evaluation, which would require a Swift benchmarking harness this repo doesn't have yet. Not adding a fake-useful test to check that box.

## Verification

- **Swift toolchain is not available on this Linux agent runner**, so I could not run `xcodebuild test` locally. `.github/workflows/ci.yml` also does not build iOS (grep `swift|xcode|ios` → no matches), so CI won't exercise `ListCountsTests` either. Please run `Brett` scheme tests in Xcode (or on your Mac runner) before merging — the test file is under `BrettTests/Views/ListCountsTests.swift` and XcodeGen picks it up automatically since `project.yml` sources BrettTests by path.
- No TypeScript files changed, so `pnpm typecheck` / `pnpm test` are unaffected — skipped to avoid a no-op `pnpm install` on this runner.
- Visual verification pending — `gh pr checkout 78` (or whatever the PR number is) and swipe into Lists on a device with several lists to confirm the stutter is gone. Verify counts still match what `ListView` shows inside each list.

## Self-review findings

1. First pass put `.active` alone in the switch, missing `.snoozed`. The pre-refactor code filtered by `!= .done`, so snoozed items counted as active. Fixed to `case .active, .snoozed:` with a comment; added a dedicated test so a future "clean up this switch" refactor doesn't silently regress the active tally.
2. First pass stamped the comment block on `countsByList` with narrative about the old `itemCounts(for:)` implementation. Per CLAUDE.md's "no references to the current fix / previous state" rule, rewrote to describe the current contract: why the fetch must not run per card.
3. Checked whether `ItemStore.fetchAll()` is user-scoped — it isn't (predicate is only `deletedAt == nil`). That's a **pre-existing** multi-user concern called out in CLAUDE.md as a rule. This PR preserves existing behavior and does not widen the scope; flagging it as a follow-up rather than touching it in a perf fix.

## Assumptions / risks / follow-ups

- Assumed snoozed items should continue to count as active (matches pre-refactor; pinned by test).
- Assumed callers (only `ListsPage`) hand in already-non-soft-deleted items. `ItemStore.fetchAll()`'s predicate filters `deletedAt == nil`, so this invariant holds.
- **Follow-up #1:** the other three pages (TodayPage section bucketing, DayTimeline hour-range derivation, SyncPendingIndicator 5s polling) are candidates for perf audits if swipe lag persists after this lands. Happy to open a separate issue if you want.
- **Follow-up #2:** `ItemStore.fetchAll()` is not user-scoped. Not in scope for a perf fix, but worth addressing before any shared-device scenario.
- **Risk:** the change does not force a body re-evaluation when items are mutated from another view and the user pops back to `ListsPage`. This was the pre-existing behavior (`refreshTick` is bumped only on local mutations and pull-to-refresh) — the fix preserves it, not worsens it. Worth a separate fix if stale counts are noticed in practice.