### PR TITLE
fix(ios): halve Done-Today reflow delay from 4s to 2s (#68)

### DIFF
--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -67,7 +67,7 @@ struct TodayPage: View {
     /// Item IDs that were just marked done but should visually stay in
     /// their original section until the debounce window expires. Without
     /// this, completing a task causes the section to immediately re-flow
-    /// and the user's next tap lands on the wrong row. Cleared 4s after
+    /// and the user's next tap lands on the wrong row. Cleared 2s after
     /// the last completion (any new tap resets the clock).
     @State private var pendingDoneIDs: Set<String> = []
 
@@ -344,7 +344,7 @@ struct TodayPage: View {
     /// Toggle a task's status. Fires the completion cascade:
     /// 1. Haptic success
     /// 2. Header stats pulse gold (spring animation on `completionPulse`)
-    /// 3. After ~1.5s idle, the item moves into Done Today — implemented by
+    /// 3. After 2s idle, the item moves into Done Today — implemented by
     ///    bumping `reflowSnapshotKey` which invalidates the cached sections.
     ///    Each fresh toggle cancels the previous reflow so a burst of quick
     ///    completions all settle together.
@@ -364,13 +364,13 @@ struct TodayPage: View {
         // expires. The user's `isCompleted` toggle is reflected in the
         // checkbox + strikethrough immediately (TaskRow reads
         // `item.isCompleted` live from SwiftData), but the row doesn't
-        // *move* until 4 seconds after the user stops tapping. This
+        // *move* until 2 seconds after the user stops tapping. This
         // prevents the "list jumps and I tap the wrong thing" pattern.
         pendingDoneIDs.insert(id)
 
         pendingReflowTask?.cancel()
         pendingReflowTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
             if Task.isCancelled { return }
             withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
                 pendingDoneIDs.removeAll()


### PR DESCRIPTION
Closes #68

## Root cause

`TodayPage.toggle(_:)` schedules a 4-second debounce task (`pendingReflowTask`) that holds a just-completed row in its origin section before reflowing it into Done Today. 4s is long enough to feel like the tap didn't register — the user watches a strikethrough row sit still for four seconds before it actually moves.

The issue body asks "Just reset the timer if a other thing is completed while it's waiting" — that behavior is already wired in at `TodayPage.swift:371` via `pendingReflowTask?.cancel()` right before the next task is scheduled, so a burst of quick completions all settle together in one reflow. The practical ask is the title: halve the delay.

## Approach

Three options:

1. **Halve the literal from 4s to 2s** (chosen). Directly matches the ask. The existing debounce rationale (prevent "list jumps, wrong tap") is preserved because 2s is still well beyond the ~200ms tap repetition window.
2. **Drop the delay and animate in-place.** Riskier — removes the guard entirely. Users rapidly tapping several rows would start seeing the list reflow between taps.
3. **Introduce a named constant `completedRowHoldDuration`.** One callsite, two comment references. Introducing an abstraction for a single literal isn't justified under CLAUDE.md's "don't design for hypothetical future requirements"; inline with updated comments is clearer.

Went with option 1 for the tightest diff.

### Changes

- `apps/ios/Brett/Views/Today/TodayPage.swift` — `4_000_000_000` → `2_000_000_000` plus three stale comments updated from "4s/1.5s" to "2s" (one docstring was already drifted to "~1.5s" when the actual code was "4s").

## Tests

No test added. This is a UI animation-timing tuning — the `Task.sleep` duration controls how long a visual hold lasts before a spring animation. A test that asserts the literal `2_000_000_000` would just mirror the implementation. The surrounding correctness behavior (cancel-on-new-toggle, bump `reflowSnapshotKey`, clear `pendingDoneIDs`) is unchanged.

**Test-prevention reflection:** Could a pragmatic test have caught a bug like this? No — the delay being "too long" is a subjective UX judgement, not a correctness regression. You judge it by completing a task and eyeballing the hold duration.

Verify visually via `gh pr checkout <this pr>` — tap a Today task and confirm it moves into Done Today ~2s later, not 4s.

## Self-review findings

1. Checked the other list surfaces (InboxPage, ListView) for an equivalent reflow delay per CLAUDE.md's "list behavior consistency" rule — neither has one. The Today → Done Today transition is unique to TodayPage because only that page has two sections that a completion row must migrate between. No cross-surface parity work required.
2. The 400ms `completionPulse` at line 359 is a separate stats-header pulse animation, not the item-disappear delay. Intentionally not touched.
3. Double-checked the reset-on-new-completion claim: `pendingReflowTask?.cancel()` fires at the top of every `toggle(_:)` call before a new task is scheduled. Burst of completions settle together — matches the issue body's intent.

## Verification constraints

- Swift toolchain not available on this Linux runner; `.github/workflows/ci.yml` does not build iOS, so no automated verification will run. Please sanity-check on device / simulator before merging.
- No TypeScript changed; `pnpm typecheck` / `pnpm test` unaffected.