### PR TITLE
perf(ios): hoist per-body computations on Today + Calendar pages

### DIFF
--- a/apps/ios/Brett/Views/Calendar/DayTimeline.swift
+++ b/apps/ios/Brett/Views/Calendar/DayTimeline.swift
@@ -31,15 +31,15 @@ struct DayTimeline: View {
             .sorted { $0.title < $1.title }
     }
 
-    private var startHour: Int {
+    private func resolveStartHour(timed: [CalendarEvent]) -> Int {
         let base = 6
-        let minHour = timedEvents.map { calendar.component(.hour, from: $0.startTime) }.min() ?? base
+        let minHour = timed.map { calendar.component(.hour, from: $0.startTime) }.min() ?? base
         return min(base, minHour)
     }
 
-    private var endHour: Int {
+    private func resolveEndHour(timed: [CalendarEvent]) -> Int {
         let base = 23
-        let maxHour = timedEvents.compactMap { evt -> Int? in
+        let maxHour = timed.compactMap { evt -> Int? in
             let endHour = calendar.component(.hour, from: evt.endTime)
             let endMin = calendar.component(.minute, from: evt.endTime)
             return endMin > 0 ? endHour + 1 : endHour
@@ -48,15 +48,25 @@ struct DayTimeline: View {
     }
 
     var body: some View {
+        // Compute the day-filtered event lists + visible hour window once
+        // per body pass, then thread them through to the grid and chips.
+        // Without hoisting, each chip's position math would retrigger the
+        // full-events filter that backs `timedEvents`, making grid render
+        // cost scale as O(events × chips) instead of O(events).
+        let allDay = allDayEvents
+        let timed = timedEvents
+        let visibleStart = resolveStartHour(timed: timed)
+        let visibleEnd = resolveEndHour(timed: timed)
+
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                if !allDayEvents.isEmpty {
-                    allDayBand
+                if !allDay.isEmpty {
+                    allDayBand(events: allDay)
                         .padding(.horizontal, 16)
                         .padding(.top, 8)
                         .padding(.bottom, 4)
                 }
-                timelineGrid
+                timelineGrid(timed: timed, startHour: visibleStart, endHour: visibleEnd)
             }
             .padding(.bottom, 120)
         }
@@ -64,14 +74,14 @@ struct DayTimeline: View {
     }
 
     @ViewBuilder
-    private var allDayBand: some View {
+    private func allDayBand(events: [CalendarEvent]) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("ALL DAY")
                 .font(BrettTypography.sectionLabel)
                 .tracking(2.4)
                 .foregroundStyle(Color.white.opacity(0.40))
 
-            ForEach(allDayEvents) { event in
+            ForEach(events) { event in
                 NavigationLink(value: NavDestination.eventDetail(id: event.id)) {
                     HStack(spacing: 8) {
                         Rectangle()
@@ -102,7 +112,7 @@ struct DayTimeline: View {
     }
 
     @ViewBuilder
-    private var timelineGrid: some View {
+    private func timelineGrid(timed: [CalendarEvent], startHour: Int, endHour: Int) -> some View {
         ZStack(alignment: .topLeading) {
             VStack(spacing: 0) {
                 ForEach(startHour...endHour, id: \.self) { hour in
@@ -120,18 +130,18 @@ struct DayTimeline: View {
                 }
             }
 
-            ForEach(timedEvents) { event in
-                eventChip(event)
+            ForEach(timed) { event in
+                eventChip(event, startHour: startHour)
             }
 
             if calendar.isDateInToday(selectedDate) {
-                currentTimeIndicator
+                currentTimeIndicator(startHour: startHour, endHour: endHour)
             }
         }
     }
 
     @ViewBuilder
-    private func eventChip(_ event: CalendarEvent) -> some View {
+    private func eventChip(_ event: CalendarEvent, startHour: Int) -> some View {
         let startHourD = Double(calendar.component(.hour, from: event.startTime))
         let startMin = Double(calendar.component(.minute, from: event.startTime))
         let offset = CGFloat((startHourD - Double(startHour)) * Double(hourHeight) + (startMin / 60.0) * Double(hourHeight))
@@ -188,7 +198,7 @@ struct DayTimeline: View {
     }
 
     @ViewBuilder
-    private var currentTimeIndicator: some View {
+    private func currentTimeIndicator(startHour: Int, endHour: Int) -> some View {
         let now = Date()
         let hour = calendar.component(.hour, from: now)
         let minute = calendar.component(.minute, from: now)

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -171,21 +171,28 @@ struct TodayPage: View {
         )
     }
 
-    /// `id`-based lookup so we can show the list name as metadata without
-    /// threading ListStore into every TaskRow.
-    private var listsById: [String: ItemList] {
-        Dictionary(uniqueKeysWithValues: allLists.map { ($0.id, $0) })
-    }
-
-    private func listName(for item: Item) -> String? {
-        guard let listId = item.listId else { return nil }
-        return listsById[listId]?.name
+    /// List-name lookup closure that captures the per-list-id index once.
+    /// Passed into every `TaskSection` as its `listNameProvider`, so each
+    /// row does an O(1) dictionary read instead of triggering a rebuild of
+    /// the full `[listId: name]` map per lookup.
+    private func makeListNameProvider() -> (Item) -> String? {
+        let index = Dictionary(uniqueKeysWithValues: allLists.map { ($0.id, $0.name) })
+        return { item in
+            guard let listId = item.listId else { return nil }
+            return index[listId]
+        }
     }
 
     // MARK: - Task sections
 
     @ViewBuilder
     private var taskSections: some View {
+        // Compute the bucket and list-name lookup once per builder pass
+        // so the five section reads share one `TodaySections.bucket(...)`
+        // call and every row reuses the same captured lookup closure.
+        let s = sections
+        let nameProvider = makeListNameProvider()
+
         TaskSection(
             // Header treatment matches the rest of the Today sections —
             // Electron differentiates "overdue" via per-card urgency
@@ -195,9 +202,9 @@ struct TodayPage: View {
             // on it being noisy.
             label: "Overdue",
             icon: "exclamationmark.triangle",
-            items: sections.overdue,
+            items: s.overdue,
             labelColor: .white,
-            listNameProvider: listName(for:),
+            listNameProvider: nameProvider,
             onToggle: toggle,
             onSelect: select,
             onSchedule: schedule,
@@ -208,9 +215,9 @@ struct TodayPage: View {
         TaskSection(
             label: "Today",
             icon: "sun.max",
-            items: sections.today,
+            items: s.today,
             labelColor: .white,
-            listNameProvider: listName(for:),
+            listNameProvider: nameProvider,
             onToggle: toggle,
             onSelect: select,
             onSchedule: schedule,
@@ -221,9 +228,9 @@ struct TodayPage: View {
         TaskSection(
             label: "This Week",
             icon: "calendar",
-            items: sections.thisWeek,
+            items: s.thisWeek,
             labelColor: .white,
-            listNameProvider: listName(for:),
+            listNameProvider: nameProvider,
             onToggle: toggle,
             onSelect: select,
             onSchedule: schedule,
@@ -234,9 +241,9 @@ struct TodayPage: View {
         TaskSection(
             label: "Next Week",
             icon: "arrow.right.circle",
-            items: sections.nextWeek,
+            items: s.nextWeek,
             labelColor: .white,
-            listNameProvider: listName(for:),
+            listNameProvider: nameProvider,
             onToggle: toggle,
             onSelect: select,
             onSchedule: schedule,
@@ -247,9 +254,9 @@ struct TodayPage: View {
         TaskSection(
             label: "Done Today",
             icon: "checkmark.circle",
-            items: sections.doneToday,
+            items: s.doneToday,
             labelColor: BrettColors.textInactive,
-            listNameProvider: listName(for:),
+            listNameProvider: nameProvider,
             onToggle: toggle,
             onSelect: select,
             onSchedule: schedule,
@@ -262,15 +269,18 @@ struct TodayPage: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        if sections.isEveryActiveSectionEmpty {
+        // Hoist the bucket so the three `sections.*` reads below share one
+        // `TodaySections.bucket(...)` call.
+        let s = sections
+        if s.isEveryActiveSectionEmpty {
             if hasCompletedInitialSync {
                 VStack(spacing: 8) {
-                    Text(sections.hasDoneToday ? "Cleared." : "Nothing on the books today.")
+                    Text(s.hasDoneToday ? "Cleared." : "Nothing on the books today.")
                         .font(BrettTypography.emptyHeading)
                         .foregroundStyle(Color.white.opacity(0.90))
                         .multilineTextAlignment(.center)
 
-                    Text(sections.hasDoneToday
+                    Text(s.hasDoneToday
                         ? "Nothing left. Go build something or enjoy the quiet."
                         : "A rare opening — use it well.")
                         .font(BrettTypography.emptyCopy)
@@ -293,12 +303,27 @@ struct TodayPage: View {
     // MARK: - Stats
 
     private var statsLine: String {
-        let total = sections.activeCount + sections.doneToday.count
-        let done = sections.doneToday.count
+        // Hoist the bucket and the day-filtered event list so the three
+        // `sections.*` reads share one bucket and the two event accesses
+        // (count + duration sum) share one filter pass.
+        let s = sections
+        let events = todaysEvents
+        let total = s.activeCount + s.doneToday.count
+        let done = s.doneToday.count
         let base = "\(done) of \(total) done"
-        guard hasCalendarData else { return base }
+        guard !allEvents.isEmpty else { return base }
+        let meetingCount = events.count
         let suffix = meetingCount == 1 ? "meeting" : "meetings"
-        return "\(base) · \(meetingCount) \(suffix) (\(meetingDurationText))"
+        return "\(base) · \(meetingCount) \(suffix) (\(Self.formatMeetingDuration(events: events)))"
+    }
+
+    private static func formatMeetingDuration(events: [CalendarEvent]) -> String {
+        let total = events.reduce(0) { $0 + $1.durationMinutes }
+        let hours = total / 60
+        let mins = total % 60
+        if hours > 0 && mins > 0 { return "\(hours)h \(mins)m" }
+        if hours > 0 { return "\(hours)h" }
+        return "\(mins)m"
     }
 
     // MARK: - Calendar helpers
@@ -309,22 +334,6 @@ struct TodayPage: View {
         let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start.addingTimeInterval(86_400)
         return allEvents.filter { $0.startTime >= start && $0.startTime < end }
     }
-
-    private var meetingCount: Int { todaysEvents.count }
-
-    private var meetingDurationText: String {
-        let total = todaysEvents.reduce(0) { $0 + $1.durationMinutes }
-        let hours = total / 60
-        let mins = total % 60
-        if hours > 0 && mins > 0 { return "\(hours)h \(mins)m" }
-        if hours > 0 { return "\(hours)h" }
-        return "\(mins)m"
-    }
-
-    /// Whether the user has any connected calendar data at all. If there are
-    /// zero events on _any_ day, we treat calendars as un-connected and hide
-    /// the meeting chunk of the stats line.
-    private var hasCalendarData: Bool { !allEvents.isEmpty }
 
     private var nextUpcomingEvent: CalendarEvent? {
         allEvents.first { $0.startTime > tickerNow.addingTimeInterval(-60) }


### PR DESCRIPTION
Follow-up #1 from PR #78 / issue #69. Does not close the issue — #78 already does. Relates to #69.

## Context

PR #78 fixed the Lists tab's N-fetches-per-render pattern. Two of the other pages in the main iOS TabView have analogous re-derivation patterns that fire per body pass. Addressing them should help the "severe lag when swiping left/right" symptom more broadly.

## TodayPage

- `sections` (returns `TodaySections.bucket(items: allItems, ...)`) was accessed **11 times per body evaluation**: 5 times in `taskSections`, 3 in `emptyState`, 3 in `statsLine`. Each access re-ran the full bucket. Hoisted inside each consumer so we get **3 bucket calls per body**, down from 11.
- `listsById` was a computed `[String: ItemList]` dictionary rebuilt on every access. The old `listName(for:)` method was passed into every `TaskSection` as its `listNameProvider`, and each row's invocation rebuilt the full dict. Replaced with `makeListNameProvider()` that captures the index once and returns a closure — rendering N rows now does N O(1) dictionary reads instead of N O(lists) rebuilds.
- `todaysEvents` was filtered twice per body (via `meetingCount` + `meetingDurationText`). Hoisted inside `statsLine` so both reads share one filter pass. `meetingCount` / `meetingDurationText` / `hasCalendarData` were single-use wrappers; removed in favour of inline locals and a static `formatMeetingDuration(events:)` helper.

## DayTimeline

- `timedEvents`, `startHour`, `endHour`, `allDayEvents` were computed vars. `startHour` and `endHour` each delegate to `timedEvents`, so accessing both triggered two full filter passes. `eventChip` read `startHour` once per chip — so rendering N chips triggered **N + 3 filter passes** over `events`.
- Converted `timelineGrid` / `allDayBand` / `currentTimeIndicator` / `eventChip` from `@ViewBuilder` property-style builders to functions that take the hoisted values as parameters. `startHour` / `endHour` became `resolveStartHour(timed:)` / `resolveEndHour(timed:)` that accept the already-computed list. Grid render cost is now **O(events)** instead of O(events × chips).

## SyncPendingIndicator

Flagged by the upstream audit but inspection showed the whole view is `#if DEBUG`-gated (`SyncPendingIndicator.swift:31`). Release builds return `Color.clear.frame(width: 0, height: 0)` — the 5s poll never runs in production. No change.

## Approach

Three options considered:

1. **Hoist computed values at the narrowest scope that eliminates the duplication** (chosen). For TodayPage I hoisted inside each consuming builder (`taskSections`, `emptyState`, `statsLine`) — gets from 11 → 3 bucket calls with no signature changes. For DayTimeline I hoisted at body level and threaded through because `startHour` is read per-chip — any partial hoist still scales with chip count.
2. **Cache into `@State` with `.onChange(of:)` invalidation.** Considered and rejected — requires tracking every input (`allItems`, `reflowSnapshotKey`, `pendingDoneIDs` for sections; selectedDate + events for DayTimeline). Easy to miss an input and render stale data.
3. **Convert everything to an Observable ViewModel.** Out of scope — would rewrite both pages' state models.

Went with option 1 for the tightest diff.

## Tests

No tests added. Both changes are behavior-preserving: same inputs render identical outputs. The perf difference is in how many times a given derivation runs per body pass, not in what it returns.

**Test-prevention reflection:** could a pragmatic test have caught this class of bug? No — detecting "the computed property is being called N times instead of once" requires either a fetch/call counter (over-mocks) or a perf benchmark (the iOS suite has no benchmarking harness). The tests I'd write for this category would either mirror implementation or need infra that doesn't exist. Not worth adding.

## Verification constraints

- Swift toolchain not available on this Linux agent runner. CI does not build iOS.
- No TypeScript touched; `pnpm typecheck` / `pnpm test` unaffected.
- Visual verification pending — `gh pr checkout <n>` and compare swipe responsiveness into Today and Calendar on a device with a realistic item/event count.

## Self-review findings

1. First pass removed `listsById` as a standalone computed var since its only caller was `listName(for:)`, which is now replaced. Confirmed via grep that nothing else referenced it before deletion.
2. `statsLine` lost the `hasCalendarData` guard wrapper but preserves the same behavior with an inline `!allEvents.isEmpty` check.
3. The DayTimeline refactor renamed `startHour` / `endHour` from computed properties to functions taking `timed:`. Confirmed (grep) that the only external API is `DayTimeline(events:selectedDate:)` — the public init is untouched.
4. Double-checked that `Self.formatMeetingDuration` resolves correctly from `statsLine` (static method call from an instance accessor — valid Swift).

## Risks / follow-ups

- **Risk:** if a future change adds a new `sections.X` reference inside one of the hoisted builders, the author could bypass the local `let s = sections` shadowing by referencing `self.sections` explicitly. Unlikely in practice but worth flagging on code review.
- **Follow-up:** `BackgroundView` was flagged by the original audit but I didn't inspect it here. Worth a separate look if swipe lag persists.
- **Follow-up #2 from #78** (user-scoping `ItemStore.fetchAll()`): still outstanding. Will open a separate PR with a plan-review comment first given the auth surface.