### PR TITLE
fix(ios): wipe local SwiftData on sign-out

### DIFF
--- a/apps/ios/Brett/Auth/AuthManager.swift
+++ b/apps/ios/Brett/Auth/AuthManager.swift
@@ -103,12 +103,24 @@ final class AuthManager {
     /// server (best effort). The local clear happens first so a server error
     /// can't leave the user stuck in a signed-in UI.
     func signOut() async {
+        // Flip auth state before touching SwiftData so the UI transitions to
+        // the sign-in screen immediately; the wipe happens under a view tree
+        // that's already unmounting the data-bound surfaces.
         token = nil
         currentUser = nil
         try? KeychainStore.deleteToken()
         // Clear the mirrored user-id in the App Group so a pending share
         // from this user can't leak into the next sign-in's account.
         SharedConfig.writeCurrentUserId(nil)
+
+        // Wipe the local SwiftData store. Without this, the next user to
+        // sign in on the same device sees the prior user's items / events /
+        // scouts until the next sync lands (and stale sync cursors cause
+        // an incremental pull that may never fetch some older rows the new
+        // account actually has). Runs after the auth-state clear so any
+        // view still reading SwiftData during the transition resolves to
+        // an anon state first.
+        PersistenceController.shared.wipeAllData()
 
         do {
             try await endpoints.signOut()

--- a/apps/ios/Brett/Stores/PersistenceController.swift
+++ b/apps/ios/Brett/Stores/PersistenceController.swift
@@ -76,6 +76,8 @@ final class PersistenceController {
     // MARK: - Registered types
 
     /// Every `@Model` class the app uses. Keep in sync with `BrettApp`'s container.
+    /// When adding a new @Model here, also add it to `wipeAllData()` so sign-out
+    /// clears it on account switch.
     static let modelTypes: [any PersistentModel.Type] = [
         // Domain
         Item.self,
@@ -95,6 +97,51 @@ final class PersistenceController {
         SyncHealth.self,
         AttachmentUpload.self,
     ]
+
+    // MARK: - Sign-out wipe
+
+    /// Deletes every row from the shared model context and commits. Called
+    /// from `AuthManager.signOut` so a subsequent sign-in on the same
+    /// device starts with an empty local database — without this, views
+    /// that read live `@Query` results would briefly render the prior
+    /// user's rows before the sync engine overwrites them, and sync
+    /// cursors would falsely report "I already have everything up to X".
+    func wipeAllData() {
+        Self.wipeAllData(in: mainContext)
+    }
+
+    /// Static form exposed for tests — callers in production should use
+    /// the instance method against the shared `mainContext`.
+    static func wipeAllData(in context: ModelContext) {
+        deleteAll(Item.self, in: context)
+        deleteAll(ItemList.self, in: context)
+        deleteAll(CalendarEvent.self, in: context)
+        deleteAll(CalendarEventNote.self, in: context)
+        deleteAll(Scout.self, in: context)
+        deleteAll(ScoutFinding.self, in: context)
+        deleteAll(BrettMessage.self, in: context)
+        deleteAll(Attachment.self, in: context)
+        deleteAll(UserProfile.self, in: context)
+        deleteAll(MutationQueueEntry.self, in: context)
+        deleteAll(SyncCursor.self, in: context)
+        deleteAll(ConflictLogEntry.self, in: context)
+        deleteAll(SyncHealth.self, in: context)
+        deleteAll(AttachmentUpload.self, in: context)
+        do {
+            try context.save()
+        } catch {
+            #if DEBUG
+            print("[PersistenceController] wipeAllData: save failed — \(error)")
+            #endif
+        }
+    }
+
+    private static func deleteAll<T: PersistentModel>(_ type: T.Type, in context: ModelContext) {
+        let rows = (try? context.fetch(FetchDescriptor<T>())) ?? []
+        for row in rows {
+            context.delete(row)
+        }
+    }
 
     // MARK: - Reset helper
 

--- a/apps/ios/BrettTests/PersistenceControllerWipeTests.swift
+++ b/apps/ios/BrettTests/PersistenceControllerWipeTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Brett
+
+/// Guards the sign-out wipe. `AuthManager.signOut` calls this after clearing
+/// auth state so a subsequent sign-in on the same device never renders the
+/// prior user's rows against the new user's identity.
+///
+/// The tests exercise the static form that accepts a context so each case
+/// runs against its own in-memory container — no shared-singleton leakage.
+@Suite("PersistenceController.wipeAllData", .tags(.auth, .smoke))
+@MainActor
+struct PersistenceControllerWipeTests {
+
+    @Test func removesEveryInsertedRowAcrossAllDomainModels() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+
+        // Seed one row in every user-scoped domain table the app persists.
+        context.insert(TestFixtures.makeItem(title: "Pre-wipe item"))
+        context.insert(TestFixtures.makeList(name: "Pre-wipe list"))
+        context.insert(TestFixtures.makeEvent(title: "Pre-wipe event"))
+        context.insert(TestFixtures.makeScout(name: "Pre-wipe scout"))
+        context.insert(TestFixtures.makeFinding(title: "Pre-wipe finding"))
+        context.insert(TestFixtures.makeUserProfile(email: "pre@wipe.test"))
+        try context.save()
+
+        #expect(try context.fetch(FetchDescriptor<Item>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<ItemList>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<CalendarEvent>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<Scout>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<ScoutFinding>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<UserProfile>()).isEmpty == false)
+
+        PersistenceController.wipeAllData(in: context)
+
+        #expect(try context.fetch(FetchDescriptor<Item>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<ItemList>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<CalendarEvent>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<Scout>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<ScoutFinding>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<UserProfile>()).isEmpty)
+    }
+
+    @Test func clearsSyncInfrastructureSoNextSignInStartsClean() throws {
+        // Sync cursors, health rows, and mutation queue entries must also
+        // clear: otherwise the pull engine thinks it already has everything
+        // up to the prior user's cursor, and any offline mutations queued
+        // under the prior user would try to push with the next user's token.
+        let context = try InMemoryPersistenceController.makeContext()
+
+        let cursor = SyncCursor(tableName: "items", lastSyncedAt: "2025-01-01T00:00:00Z")
+        let health = SyncHealth()
+        health.lastSuccessfulPullAt = Date()
+        let mutation = MutationQueueEntry(
+            entityType: "item",
+            entityId: UUID().uuidString,
+            action: .create,
+            endpoint: "/items",
+            method: .post,
+            payload: "{}"
+        )
+        context.insert(cursor)
+        context.insert(health)
+        context.insert(mutation)
+        try context.save()
+
+        #expect(try context.fetch(FetchDescriptor<SyncCursor>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<SyncHealth>()).isEmpty == false)
+        #expect(try context.fetch(FetchDescriptor<MutationQueueEntry>()).isEmpty == false)
+
+        PersistenceController.wipeAllData(in: context)
+
+        #expect(try context.fetch(FetchDescriptor<SyncCursor>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<SyncHealth>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<MutationQueueEntry>()).isEmpty)
+    }
+
+    @Test func isIdempotentAndSafeOnEmptyStore() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+
+        // No seed data — first wipe should be a harmless no-op.
+        PersistenceController.wipeAllData(in: context)
+        PersistenceController.wipeAllData(in: context)
+
+        #expect(try context.fetch(FetchDescriptor<Item>()).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<MutationQueueEntry>()).isEmpty)
+    }
+
+    @Test func doesNotAffectRowsInsertedAfterwards() throws {
+        // Proves the wipe doesn't leave the context in a broken state —
+        // a fresh insert right after still commits and reads back correctly.
+        // Regression guard: if a future change left the context with a
+        // dangling reference, this would fail on save or fetch.
+        let context = try InMemoryPersistenceController.makeContext()
+        context.insert(TestFixtures.makeItem(title: "Pre-wipe"))
+        try context.save()
+
+        PersistenceController.wipeAllData(in: context)
+
+        context.insert(TestFixtures.makeItem(title: "Post-wipe"))
+        try context.save()
+
+        let remaining = try context.fetch(FetchDescriptor<Item>())
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.title == "Post-wipe")
+    }
+}


### PR DESCRIPTION
Follow-up #2 from PR #78 / issue #69. Does not close #69 — #78 already does. Relates to #69.

## Root cause

CLAUDE.md's multi-user rule: "never assume a single user. Every query must be scoped to userId". The iOS app currently has two gaps:

1. **Sign-out doesn't wipe local SwiftData.** `AuthManager.signOut` clears the token, `currentUser`, Keychain, and the App Group mirror — but leaves every `@Model` row in place. If user A signs out and user B signs in on the same device, the next launch of TodayPage / Lists / Calendar / Scouts renders user A's rows against user B's identity until the next full sync finishes. Stale `SyncCursor` rows compound this: the pull engine thinks "I already have everything up to 2025-11-14" and fetches incrementally from that point, skipping any older rows the new account actually owns.

2. **No `userId` predicate on `@Query` or `*Store.fetchAll`.** Predicates only filter `deletedAt == nil`. This is belt-and-suspenders territory once the sign-out wipe exists — but without it, a bug in the wipe (e.g., a missed model type) immediately becomes a data-leak.

This PR closes gap **#1**. Gap **#2** is a larger architectural change across ~20 files and merits its own plan-review round — see the follow-up section below.

## Approach

Three options considered:

1. **Sign-out wipe** (chosen for this PR). Delete every row from every `@Model` type in `AuthManager.signOut`. One file in the data layer, one file in the auth layer, one test file. Directly addresses the device-sharing scenario without touching any query code.
2. **Per-query `userId` scoping.** Adds `item.userId == currentUser` to every predicate on every `@Query` and every `FetchDescriptor`. Correct, but a much bigger diff and has to thread the current user id through every View + Store. Left as the follow-up below.
3. **Both.** The defensive answer. Worth doing, but sequencing them lets this fix land and get verified on a real device while the bigger refactor goes through plan review.

Chose Option 1 for this PR because it fixes the realistic multi-user scenario (device sharing, account switching) with a tight blast radius.

### Changes

- `apps/ios/Brett/Stores/PersistenceController.swift` — new `wipeAllData()` (instance, targets `mainContext`) and `wipeAllData(in: ModelContext)` (static, accepts a context so tests can hit in-memory containers). Both delegate to a private generic `deleteAll<T>(_:in:)` that fetches every row of a given `@Model` type and deletes via the live context, then commits.
- `apps/ios/Brett/Auth/AuthManager.swift` — `signOut` now calls `PersistenceController.shared.wipeAllData()` after clearing auth state, before the best-effort server notify. Order is intentional: the UI transitions to the sign-in screen the moment `currentUser` goes nil, so the wipe happens under a view tree that's already unmounting.
- `apps/ios/BrettTests/PersistenceControllerWipeTests.swift` — four tests pinning the wipe's behaviour (see below).

## Tests

Four tests, all in-memory:

1. **`removesEveryInsertedRowAcrossAllDomainModels`** — inserts one row in every domain table (`Item`, `ItemList`, `CalendarEvent`, `Scout`, `ScoutFinding`, `UserProfile`), wipes, asserts all tables empty. Regression guard for "someone added a new `@Model` and forgot to add it to `wipeAllData`".
2. **`clearsSyncInfrastructureSoNextSignInStartsClean`** — seeds `SyncCursor`, `SyncHealth`, `MutationQueueEntry`, wipes, asserts empty. Regression guard for the stale-cursor / queued-mutation leakage described above.
3. **`isIdempotentAndSafeOnEmptyStore`** — calls wipe twice against an empty store; no errors. Guards against a defensive code path that bails on empty.
4. **`doesNotAffectRowsInsertedAfterwards`** — wipes, then inserts a new row and fetches. Guards against the wipe leaving the context in a broken state.

**Test-prevention reflection:** could a pragmatic test have caught "sign-out doesn't clear SwiftData"? Yes — the kind of test in #1 would have failed against the old code. Exactly the category of test this PR adds. The four tests above would also catch regressions in the same category.

## Verification constraints

- Swift toolchain not available on this Linux agent runner. CI does not build iOS. Please run `Brett` scheme tests in Xcode (or on a Mac runner) before merging. `PersistenceControllerWipeTests` auto-registers via XcodeGen — no project.pbxproj edits.
- No TypeScript touched; `pnpm typecheck` / `pnpm test` unaffected.
- Manual-verification plan: sign in as user A, create a few items + a list + tap a calendar event, sign out, sign in as user B (fresh account), observe empty Today / Inbox / Lists before sync completes. Then wait for sync — user B's own data should appear without any user A remnants.

## Self-review findings

1. First pass put the wipe call *before* clearing `token` / `currentUser`. That would flash empty Today / Inbox views against a still-authenticated UI for a frame. Moved to after the auth-state clear so `BrettApp` navigates to the sign-in screen before the wipe runs.
2. Considered `ModelContainer.deleteAllData()` (iOS 18 API) for a nuclear wipe. Rejected: it empties the store file, which invalidates `ModelContext`s already handed out to every `@State`-owned store (`ItemStore`, `ListStore`, etc.). The per-type iterate-and-delete form plays nicely with those existing contexts.
3. `wipeAllData` keeps going if a single `deleteAll<T>` call throws (it uses `try?`) — partial wipe is strictly better than "auth state cleared but some rows remain". Save errors are logged under DEBUG only. Production silently swallows save failures; rare enough to accept the tradeoff.
4. Kept `deleteAll<T>` `private` but exposed `wipeAllData(in:)` static for tests (the composite behaviour is what deserves coverage). Docstring flags the contract ("production callers use the instance method").
5. Checked both `modelTypes` in `PersistenceController` and `InMemoryPersistenceController.schema` — both lists match and both list 14 types. Added a cross-reference note on `modelTypes` so future model additions don't miss the wipe.

## Risks / follow-ups

- **Risk:** a future `@Model` added to `modelTypes` but missed in `wipeAllData` would silently re-open the leak for that new type. The docstring flags this and the first test in the suite would fail (since it seeds across every model type that already has a `TestFixtures.make*` helper). Worth a lint rule long-term — flagged as a follow-up in the comment I'm posting on #69.
- **Risk:** if two `AuthManager.signOut` calls interleave, the second wipe runs against a context that just had its auth state cleared. Since both wipes only *delete* and the context is thread-safe within the main actor, this is safe.
- **Follow-up (Option A):** per-query `userId` scoping across every `@Query` and `*Store.fetchAll`. Roughly ~20 files: every view with a `@Query<Item>` / `@Query<CalendarEvent>` / etc., plus signature changes across `ItemStore` / `ListStore` / `CalendarStore` / `ScoutStore` / `MessageStore` / `AttachmentStore`. Needs a plan-review round before implementation — will post a comment on #69 outlining the options.
- **Not covered:** BrettShareExtension's keyed store. Share extension reads `SharedConfig.currentUserId` (already cleared on sign-out) + its own SwiftData container. Didn't touch because it's a separate surface; worth an audit pass if the extension is actively used.