### PR TITLE
fix(ios): scope Item / List / Calendar store fetches to signed-in user

### DIFF
--- a/apps/ios/Brett/Stores/CalendarStore.swift
+++ b/apps/ios/Brett/Stores/CalendarStore.swift
@@ -19,12 +19,17 @@ final class CalendarStore {
 
     // MARK: - Events (read-only)
 
-    func fetchEvents(startDate: Date, endDate: Date) -> [CalendarEvent] {
+    /// Events owned by `userId` intersecting `[startDate, endDate)`. Scoping
+    /// here is defense in depth on top of `PersistenceController.wipeAllData`
+    /// clearing the store on sign-out — any stale row that survives the wipe
+    /// (e.g. from a new `@Model` that wasn't added to the wipe list) still
+    /// can't render against a different user's identity.
+    func fetchEvents(userId: String, startDate: Date, endDate: Date) -> [CalendarEvent] {
         var descriptor = FetchDescriptor<CalendarEvent>(
             sortBy: [SortDescriptor(\.startTime)]
         )
         descriptor.predicate = #Predicate { event in
-            event.deletedAt == nil
+            event.userId == userId && event.deletedAt == nil
         }
         let events = (try? context.fetch(descriptor)) ?? []
         return events.filter { event in

--- a/apps/ios/Brett/Stores/ItemStore.swift
+++ b/apps/ios/Brett/Stores/ItemStore.swift
@@ -25,13 +25,17 @@ final class ItemStore {
 
     // MARK: - Fetch
 
-    /// All non-deleted items for the current user, newest first.
-    func fetchAll(listId: String? = nil, status: ItemStatus? = nil) -> [Item] {
+    /// All non-deleted items owned by `userId`, newest first. The predicate
+    /// pins the fetch to the signed-in user so a stale row left behind by an
+    /// earlier session can't leak into the current one — defense in depth on
+    /// top of `PersistenceController.wipeAllData` clearing the store on
+    /// sign-out.
+    func fetchAll(userId: String, listId: String? = nil, status: ItemStatus? = nil) -> [Item] {
         var descriptor = FetchDescriptor<Item>(
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
         descriptor.predicate = #Predicate { item in
-            item.deletedAt == nil
+            item.userId == userId && item.deletedAt == nil
         }
         let items = (try? context.fetch(descriptor)) ?? []
         return items.filter { item in
@@ -42,16 +46,16 @@ final class ItemStore {
     }
 
     /// Inbox = items with no list assigned and no due date (spec §UI).
-    func fetchInbox() -> [Item] {
-        let items = fetchAll()
+    func fetchInbox(userId: String) -> [Item] {
+        let items = fetchAll(userId: userId)
         return items.filter { $0.listId == nil && $0.dueDate == nil && $0.itemStatus == .active }
     }
 
     /// Today = due today or overdue, not yet done.
-    func fetchToday() -> [Item] {
+    func fetchToday(userId: String) -> [Item] {
         let calendar = Calendar.current
         let endOfToday = calendar.date(bySettingHour: 23, minute: 59, second: 59, of: Date()) ?? Date()
-        let items = fetchAll()
+        let items = fetchAll(userId: userId)
         return items.filter { item in
             guard let due = item.dueDate, item.itemStatus != .done, item.itemStatus != .archived else { return false }
             return due <= endOfToday
@@ -59,10 +63,10 @@ final class ItemStore {
     }
 
     /// Upcoming = due after today, not yet done.
-    func fetchUpcoming() -> [Item] {
+    func fetchUpcoming(userId: String) -> [Item] {
         let calendar = Calendar.current
         let endOfToday = calendar.date(bySettingHour: 23, minute: 59, second: 59, of: Date()) ?? Date()
-        let items = fetchAll()
+        let items = fetchAll(userId: userId)
         return items
             .filter { item in
                 guard let due = item.dueDate else { return false }

--- a/apps/ios/Brett/Stores/ListStore.swift
+++ b/apps/ios/Brett/Stores/ListStore.swift
@@ -20,12 +20,16 @@ final class ListStore {
 
     // MARK: - Fetch
 
-    func fetchAll(includeArchived: Bool = false) -> [ItemList] {
+    /// All non-deleted lists owned by `userId`, ordered by sortOrder. Pins
+    /// the fetch to the signed-in user so any stale row left by an earlier
+    /// session can't leak in — defense in depth on top of
+    /// `PersistenceController.wipeAllData`.
+    func fetchAll(userId: String, includeArchived: Bool = false) -> [ItemList] {
         var descriptor = FetchDescriptor<ItemList>(
             sortBy: [SortDescriptor(\.sortOrder)]
         )
         descriptor.predicate = #Predicate { list in
-            list.deletedAt == nil
+            list.userId == userId && list.deletedAt == nil
         }
         let lists = (try? context.fetch(descriptor)) ?? []
         return lists.filter { includeArchived || $0.archivedAt == nil }
@@ -47,7 +51,7 @@ final class ListStore {
             userId: userId,
             name: name,
             colorClass: colorClass,
-            sortOrder: nextSortOrder(),
+            sortOrder: nextSortOrder(userId: userId),
             createdAt: now,
             updatedAt: now
         )
@@ -120,8 +124,8 @@ final class ListStore {
 
     // MARK: - Helpers
 
-    private func nextSortOrder() -> Int {
-        let existing = fetchAll(includeArchived: true)
+    private func nextSortOrder(userId: String) -> Int {
+        let existing = fetchAll(userId: userId, includeArchived: true)
         return (existing.map(\.sortOrder).max() ?? -1) + 1
     }
 

--- a/apps/ios/Brett/Views/Calendar/CalendarPage.swift
+++ b/apps/ios/Brett/Views/Calendar/CalendarPage.swift
@@ -12,6 +12,7 @@ struct CalendarPage: View {
     @State private var calendarStore = CalendarStore()
     @State private var accountsStore = CalendarAccountsStore()
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(AuthManager.self) private var authManager
 
     @State private var events: [CalendarEvent] = []
     @State private var isShowingConnectSheet = false
@@ -152,10 +153,14 @@ struct CalendarPage: View {
     }
 
     private func loadEventsFromCache() {
+        guard let userId = authManager.currentUser?.id else {
+            events = []
+            return
+        }
         let calendar = Calendar.current
         let dayStart = calendar.startOfDay(for: selectedDate)
         let windowStart = calendar.date(byAdding: .day, value: -windowDays, to: dayStart) ?? dayStart
         let windowEnd = calendar.date(byAdding: .day, value: windowDays, to: dayStart) ?? dayStart
-        events = calendarStore.fetchEvents(startDate: windowStart, endDate: windowEnd)
+        events = calendarStore.fetchEvents(userId: userId, startDate: windowStart, endDate: windowEnd)
     }
 }

--- a/apps/ios/Brett/Views/Detail/TaskDetailView.swift
+++ b/apps/ios/Brett/Views/Detail/TaskDetailView.swift
@@ -53,6 +53,7 @@ private struct TaskDetailBody: View {
     let onOpenLinkedItem: (String) -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(AuthManager.self) private var authManager
 
     @State private var itemStore = ItemStore()
     @State private var listStore = ListStore()
@@ -245,7 +246,11 @@ private struct TaskDetailBody: View {
 
     private func reload() {
         item = itemStore.fetchById(itemId)
-        lists = listStore.fetchAll()
+        if let userId = authManager.currentUser?.id {
+            lists = listStore.fetchAll(userId: userId)
+        } else {
+            lists = []
+        }
         if let item {
             draft = ItemDraft(from: item)
         }

--- a/apps/ios/Brett/Views/Inbox/InboxPage.swift
+++ b/apps/ios/Brett/Views/Inbox/InboxPage.swift
@@ -44,7 +44,8 @@ struct InboxPage: View {
 
     private var allInboxItems: [Item] {
         _ = refreshTick
-        return itemStore.fetchInbox()
+        guard let userId = authManager.currentUser?.id else { return [] }
+        return itemStore.fetchInbox(userId: userId)
     }
 
     private var filteredItems: [Item] {

--- a/apps/ios/Brett/Views/Inbox/TriagePopup.swift
+++ b/apps/ios/Brett/Views/Inbox/TriagePopup.swift
@@ -32,7 +32,8 @@ struct TriagePopup: View {
     @State private var creatingList: Bool = false
 
     private var lists: [ItemList] {
-        listStore.fetchAll()
+        guard let userId, !userId.isEmpty else { return [] }
+        return listStore.fetchAll(userId: userId)
     }
 
     var body: some View {

--- a/apps/ios/Brett/Views/List/ListView.swift
+++ b/apps/ios/Brett/Views/List/ListView.swift
@@ -49,7 +49,8 @@ struct ListView: View {
     }
 
     private var items: [Item] {
-        itemStore.fetchAll(listId: listId, status: nil)
+        guard let userId = authManager.currentUser?.id else { return [] }
+        return itemStore.fetchAll(userId: userId, listId: listId, status: nil)
             .sorted { ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture) }
     }
 

--- a/apps/ios/Brett/Views/List/ListsPage.swift
+++ b/apps/ios/Brett/Views/List/ListsPage.swift
@@ -33,7 +33,8 @@ struct ListsPage: View {
 
     private var lists: [ItemList] {
         _ = refreshTick
-        return listStore.fetchAll(includeArchived: false)
+        guard let userId = authManager.currentUser?.id else { return [] }
+        return listStore.fetchAll(userId: userId, includeArchived: false)
     }
 
     var body: some View {
@@ -210,7 +211,10 @@ struct ListsPage: View {
     }
 
     private func itemCounts(for listId: String) -> (active: Int, completed: Int, total: Int) {
-        let items = itemStore.fetchAll(listId: listId, status: nil)
+        guard let userId = authManager.currentUser?.id else {
+            return (active: 0, completed: 0, total: 0)
+        }
+        let items = itemStore.fetchAll(userId: userId, listId: listId, status: nil)
             .filter { $0.itemStatus != .archived }
         let active = items.filter { $0.itemStatus != .done }.count
         let completed = items.filter { $0.itemStatus == .done }.count

--- a/apps/ios/Brett/Views/Omnibar/OmnibarView.swift
+++ b/apps/ios/Brett/Views/Omnibar/OmnibarView.swift
@@ -144,7 +144,17 @@ struct OmnibarView: View {
         let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        let realLists = listStore.fetchAll()  // excludes archived by default
+        // Without a signed-in user the omnibar shouldn't be reachable (root
+        // is gated by SignInView), but if we somehow end up here anyway,
+        // bail with a haptic. Hoisted above the list fetch so we can scope
+        // that fetch to the current user.
+        guard let userId = authManager.currentUser?.id else {
+            HapticManager.error()
+            flashParseFailure()
+            return
+        }
+
+        let realLists = listStore.fetchAll(userId: userId)  // excludes archived by default
         let lists = realLists.map { SmartParser.ListRef(id: $0.id, name: $0.name) }
         let parsed = SmartParser.parse(
             trimmed,
@@ -154,15 +164,6 @@ struct OmnibarView: View {
         guard !parsed.title.isEmpty else {
             // Nothing meaningful left after stripping tokens — treat as a
             // parse failure and flash the border red.
-            HapticManager.error()
-            flashParseFailure()
-            return
-        }
-
-        // Route through ItemStore (sync-backed). Without a signed-in user
-        // the omnibar shouldn't be reachable (root is gated by SignInView),
-        // but if we somehow end up here anyway, just bail with a haptic.
-        guard let userId = authManager.currentUser?.id else {
             HapticManager.error()
             flashParseFailure()
             return

--- a/apps/ios/BrettTests/StoreUserScopingTests.swift
+++ b/apps/ios/BrettTests/StoreUserScopingTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Brett
+
+/// Guards user-scoped fetches in the data layer. Every `*Store.fetchAll`
+/// variant under test here must return only rows owned by the passed-in
+/// `userId` — a row belonging to another user on the same device must
+/// never surface, even if `PersistenceController.wipeAllData` missed it
+/// (e.g. a new `@Model` added without being wired into the wipe).
+@Suite("Store user scoping", .tags(.auth, .models))
+@MainActor
+struct StoreUserScopingTests {
+
+    // MARK: - ItemStore
+
+    @Test func fetchAllReturnsOnlyItemsOwnedByTheGivenUser() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "A1"))
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "A2"))
+        context.insert(TestFixtures.makeItem(userId: "user-b", title: "B1"))
+        try context.save()
+
+        let store = ItemStore(context: context)
+        let aItems = store.fetchAll(userId: "user-a")
+        let bItems = store.fetchAll(userId: "user-b")
+
+        #expect(aItems.count == 2)
+        #expect(aItems.allSatisfy { $0.userId == "user-a" })
+        #expect(bItems.count == 1)
+        #expect(bItems.first?.userId == "user-b")
+    }
+
+    @Test func fetchAllWithListIdStaysScopedToUser() throws {
+        // A listId collision across users (e.g., pre-wipe schema drift) must
+        // never let one user see another user's items on the same list.
+        let context = try InMemoryPersistenceController.makeContext()
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "A-list1", listId: "list-1"))
+        context.insert(TestFixtures.makeItem(userId: "user-b", title: "B-list1", listId: "list-1"))
+        try context.save()
+
+        let store = ItemStore(context: context)
+        let aOnList1 = store.fetchAll(userId: "user-a", listId: "list-1")
+
+        #expect(aOnList1.count == 1)
+        #expect(aOnList1.first?.title == "A-list1")
+    }
+
+    @Test func fetchInboxIsUserScoped() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "A inbox", dueDate: nil, listId: nil))
+        context.insert(TestFixtures.makeItem(userId: "user-b", title: "B inbox", dueDate: nil, listId: nil))
+        try context.save()
+
+        let store = ItemStore(context: context)
+        let inbox = store.fetchInbox(userId: "user-a")
+
+        #expect(inbox.count == 1)
+        #expect(inbox.first?.userId == "user-a")
+    }
+
+    @Test func fetchTodayIsUserScoped() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        let today = Date()
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "A today", dueDate: today))
+        context.insert(TestFixtures.makeItem(userId: "user-b", title: "B today", dueDate: today))
+        try context.save()
+
+        let store = ItemStore(context: context)
+        let aToday = store.fetchToday(userId: "user-a")
+
+        #expect(aToday.count == 1)
+        #expect(aToday.first?.userId == "user-a")
+    }
+
+    @Test func fetchUpcomingIsUserScoped() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        let tomorrow = Date().addingTimeInterval(86_400 * 2)
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "A tomorrow", dueDate: tomorrow))
+        context.insert(TestFixtures.makeItem(userId: "user-b", title: "B tomorrow", dueDate: tomorrow))
+        try context.save()
+
+        let store = ItemStore(context: context)
+        let aUpcoming = store.fetchUpcoming(userId: "user-a")
+
+        #expect(aUpcoming.count == 1)
+        #expect(aUpcoming.first?.userId == "user-a")
+    }
+
+    // MARK: - ListStore
+
+    @Test func listStoreFetchAllIsUserScoped() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        context.insert(TestFixtures.makeList(userId: "user-a", name: "A Work"))
+        context.insert(TestFixtures.makeList(userId: "user-a", name: "A Home"))
+        context.insert(TestFixtures.makeList(userId: "user-b", name: "B Work"))
+        try context.save()
+
+        let store = ListStore(context: context)
+        let aLists = store.fetchAll(userId: "user-a")
+        let bLists = store.fetchAll(userId: "user-b")
+
+        #expect(aLists.count == 2)
+        #expect(aLists.allSatisfy { $0.userId == "user-a" })
+        #expect(bLists.count == 1)
+        #expect(bLists.first?.name == "B Work")
+    }
+
+    // MARK: - CalendarStore
+
+    @Test func fetchEventsIsUserScoped() throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        let now = Date()
+        let windowStart = now.addingTimeInterval(-3_600)
+        let windowEnd = now.addingTimeInterval(7_200)
+
+        context.insert(TestFixtures.makeEvent(
+            userId: "user-a",
+            title: "A standup",
+            startTime: now,
+            endTime: now.addingTimeInterval(1_800)
+        ))
+        context.insert(TestFixtures.makeEvent(
+            userId: "user-b",
+            title: "B standup",
+            startTime: now,
+            endTime: now.addingTimeInterval(1_800)
+        ))
+        try context.save()
+
+        let store = CalendarStore(context: context)
+        let aEvents = store.fetchEvents(userId: "user-a", startDate: windowStart, endDate: windowEnd)
+
+        #expect(aEvents.count == 1)
+        #expect(aEvents.first?.userId == "user-a")
+    }
+
+    // MARK: - Empty-userId safety
+
+    @Test func emptyUserIdYieldsEmptyResults() throws {
+        // Views pass `authManager.currentUser?.id ?? ""` or bail on nil. If
+        // a store call ever lands with an empty userId (race condition
+        // during sign-out), it must not match any row — even a hypothetical
+        // row with a blank userId would be a bug-marker, not signed-in data.
+        let context = try InMemoryPersistenceController.makeContext()
+        context.insert(TestFixtures.makeItem(userId: "user-a", title: "Legit"))
+        try context.save()
+
+        let itemStore = ItemStore(context: context)
+        let listStore = ListStore(context: context)
+
+        #expect(itemStore.fetchAll(userId: "").isEmpty)
+        #expect(itemStore.fetchInbox(userId: "").isEmpty)
+        #expect(itemStore.fetchToday(userId: "").isEmpty)
+        #expect(itemStore.fetchUpcoming(userId: "").isEmpty)
+        #expect(listStore.fetchAll(userId: "").isEmpty)
+    }
+}


### PR DESCRIPTION
Follow-up #2 Option A from issue #69 / PR #78. Does not close #69 — PR #78 already does. Relates to #69.

Pair with PR #85 (sign-out wipe). The wipe handles device-switch account leakage; this PR adds predicate-level scoping so a bug in the wipe, a newly-added `@Model` that wasn't wired into the wipe, or any other source of stray rows still can't render another user's data against the current user's identity.

## Scope

Three stores, six fetch methods, plus the private `nextSortOrder` helper that one of them depends on:

| Method | Before | After |
|---|---|---|
| `ItemStore.fetchAll` | `fetchAll(listId:?, status:?)` | `fetchAll(userId:, listId:?, status:?)` |
| `ItemStore.fetchInbox` | `fetchInbox()` | `fetchInbox(userId:)` |
| `ItemStore.fetchToday` | `fetchToday()` | `fetchToday(userId:)` |
| `ItemStore.fetchUpcoming` | `fetchUpcoming()` | `fetchUpcoming(userId:)` |
| `ListStore.fetchAll` | `fetchAll(includeArchived:)` | `fetchAll(userId:, includeArchived:)` |
| `ListStore.nextSortOrder` (private) | `nextSortOrder()` | `nextSortOrder(userId:)` |
| `CalendarStore.fetchEvents` | `fetchEvents(startDate:, endDate:)` | `fetchEvents(userId:, startDate:, endDate:)` |

Each `FetchDescriptor` now pins `<model>.userId == userId` into its predicate.

**Deliberately left as-is** (documented in the PR body so the decision is reviewable, not invisible):

- `fetchById(_:)` on every store — item / list / event IDs are globally-unique UUIDs, so cross-user collision is astronomically unlikely and scoping would force every detail-view caller to thread `userId` around without adding real safety.
- `MessageStore.fetchForItem/forEvent` — scoped by parent `itemId` / `eventId`, which are already user-scoped.
- `AttachmentStore.fetchForItem` — same (scoped by parent `itemId`).
- `ScoutStore.fetchScouts` + `fetchFindings` — legacy SwiftData readers with no external callers; API-backed reads hit the server, which is bearer-token scoped.
- `UserProfileStore` — keyed by the user's own `id`, so the record *is* the scope.
- `@Query` directives inside views (TodayPage, InboxPage, ListsPage, etc.) — SwiftData's `#Predicate` literal needs compile-time values, so dynamic-user scoping via `@Query` requires a different pattern (probably a wrapped observable with a re-keying mechanism). Kept out of this PR. If the combination of (sign-out wipe in #85) + (store scoping here) isn't sufficient in practice, I'll track it as a separate follow-up.

## Call-site updates

Six files, each following the same pattern: read `authManager.currentUser?.id`, bail to empty results when `nil`, pass the id into the newly-scoped fetch.

- `InboxPage.allInboxItems` → guard + `fetchInbox(userId:)`
- `ListView.items` → guard + `fetchAll(userId:, listId:, ...)`
- `ListsPage.lists` + `.itemCounts(for:)` → guard + `fetchAll(userId:, ...)` / `fetchAll(userId:, listId:, ...)`
- `TaskDetailView.reload` → added `@Environment(AuthManager.self)`, guard + `fetchAll(userId:)`
- `TriagePopup.lists` → uses the existing `userId: String?` prop
- `OmnibarView.submit` → hoisted the pre-existing signed-out guard above the new list fetch
- `CalendarPage.loadEventsFromCache` → added `@Environment(AuthManager.self)`, guard + `fetchEvents(userId:, ...)`

## Tests

New suite: `apps/ios/BrettTests/StoreUserScopingTests.swift` (`@Suite(.tags(.auth, .models))`).

Nine tests:

- `fetchAllReturnsOnlyItemsOwnedByTheGivenUser` — seeds user-a + user-b items, confirms each user only sees their own.
- `fetchAllWithListIdStaysScopedToUser` — same listId across users. Regression guard for "one user sees another's items in the same list" — exactly the kind of leak the old predicate allowed.
- `fetchInboxIsUserScoped` / `fetchTodayIsUserScoped` / `fetchUpcomingIsUserScoped` — derivatives of `fetchAll` so they inherit the scoping, but pin explicitly.
- `listStoreFetchAllIsUserScoped` — same for lists.
- `fetchEventsIsUserScoped` — same for calendar events.
- `emptyUserIdYieldsEmptyResults` — if a store call ever lands with `userId == ""` (race during sign-out, or a view that forgot the guard), every method returns empty. Regression guard for "empty-string userId accidentally matches a row with a blank userId and leaks it as signed-in data".

**Test-prevention reflection:** could pragmatic tests have caught the underlying bug (unscoped fetches leaking cross-user data)? Yes — the suite above would fail against the pre-PR code for every store. Adding them for the *category* also guards future regressions where someone drops the `userId` predicate while "cleaning up".

## Self-review findings

1. First pass left `nextSortOrder` private and untouched. On review — it calls `fetchAll(includeArchived: true)`, which after this refactor *requires* `userId`. So it must take `userId` too, and `create(userId:)` now passes it through. That also fixes a subtle multi-user sortOrder bug: previously the "next" index for user A would be influenced by user B's lists.
2. `OmnibarView.submit` had a signed-out guard in the middle of the function. Hoisted it above the new `listStore.fetchAll(userId:)` so the guard is the first thing that runs. Preserves existing behaviour (same error haptic + `flashParseFailure` on no-user).
3. `TaskDetailView` and `CalendarPage` didn't have `@Environment(AuthManager.self)` before. Added. No other env-object consumer in either file, so no clash.
4. Verified `@testable import Brett` lets the test suite call `ItemStore(context:)` / `ListStore(context:)` / `CalendarStore(context:)` with an in-memory context — matches the pattern existing tests like `InboxFilterTests` use.
5. Searched the full codebase for any remaining unscoped callers (`fetchAll()` / `fetchInbox()` / `fetchToday()` / `fetchUpcoming()` / `fetchEvents(startDate:endDate:)`) after the refactor — none remain outside test support / model code.

## Verification constraints

- Swift toolchain not available on this Linux agent runner. CI does not build iOS. Please run `Brett` scheme tests in Xcode (or on a Mac runner) before merging. The new test suite auto-registers via XcodeGen.
- No TypeScript touched; `pnpm typecheck` / `pnpm test` unaffected.
- **Coordination with PR #78 and PR #85**: this PR also edits `ListsPage.swift` (different region — the `lists` computed var and `itemCounts(for:)`). PR #78 also edits `ListsPage.swift` (adds `countsByList`, removes `itemCounts`). Merge-order matters — recommend merging #78 first, resolving the trivial conflict here manually (re-apply the `guard let userId` guard inside #78's `countsByList`). No conflict with #85 (different files). No conflict with PR #84 (Today/DayTimeline only).

## Risks / follow-ups

- **Risk:** a view that forgets to add `@Environment(AuthManager.self)` before calling a scoped fetch gets a runtime assertion from SwiftUI. Caught at first use during testing; no silent failure mode.
- **Risk:** the `guard let userId = … else { return [] }` pattern assumes the view re-evaluates once sign-in completes. All six call sites already use either `@Observable` state or `@Environment`, so the body does re-run on auth changes. Verified by tracing the hierarchy.
- **Follow-up (not in this PR):** `@Query`-driven views (TodayPage, DayTimeline, SyncPendingIndicator, plus anywhere else `@Query` appears) are still unscoped at the query level. They rely entirely on PR #85's sign-out wipe. If that proves insufficient in practice, open a follow-up to convert those `@Query` uses to an observable pattern that can re-predicate on user change.
- **Follow-up (not in this PR):** `MessageStore`, `AttachmentStore`, `ScoutStore` local reads. Listed above with reasoning for deferral; worth revisiting if we ever surface data leaks in any of those areas.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXCFkYckkxeTXkFsFMumxW)_