### PR TITLE
fix: show real task destination in omnibar + spotlight toast (#79)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef, useMemo } from "react";
 import { Routes, Route, Navigate, useNavigate, useLocation } from "react-router-dom";
-import { slugify, getEventGlassColor } from "@brett/utils";
+import { slugify, getEventGlassColor, getTaskDestinationLabel } from "@brett/utils";
 import { useAutoUpdate } from "./hooks/useAutoUpdate";
 import { useTodayKey } from "./hooks/useTodayKey";
 import { usePinnedDate } from "./hooks/usePinnedDate";
@@ -679,6 +679,10 @@ export function App() {
     return undefined;
   })();
 
+  // Destination shown in the "Added to …" confirmation on both Omnibar and
+  // SpotlightModal. Matches the actual landing spot chosen by createTask().
+  const taskDestinationLabel = getTaskDestinationLabel(currentView, lists);
+
   const omnibarProps = {
     isOpen: omnibar.isOpen && omnibar.mode === "bar",
     input: omnibar.input,
@@ -760,6 +764,7 @@ export function App() {
     showWeatherExpanded,
     onWeatherClick: () => setShowWeatherExpanded((prev) => !prev),
     assistantName,
+    destinationLabel: taskDestinationLabel,
   };
 
   const scoutsOmnibarProps = {
@@ -1534,6 +1539,7 @@ export function App() {
           initialForcedAction={spotlightInitialAction}
           showScoutAction={true}
           assistantName={assistantName}
+          destinationLabel={taskDestinationLabel}
         />
 
         {/* Calendar connect interstitial — meeting notes opt-in */}

--- a/packages/ui/src/Omnibar.tsx
+++ b/packages/ui/src/Omnibar.tsx
@@ -65,6 +65,8 @@ export interface OmnibarProps {
   assistantName?: string;
   isMinimized?: boolean;
   onMinimize?: () => void;
+  /** Where a newly-created task will actually land (e.g. "Inbox", "Today", "Shopping"). */
+  destinationLabel?: string;
 }
 
 type Suggestion = {
@@ -110,6 +112,7 @@ export function Omnibar({
   assistantName = "Brett",
   isMinimized,
   onMinimize,
+  destinationLabel = "Inbox",
 }: OmnibarProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -588,7 +591,7 @@ export function Omnibar({
               <Check size={14} className="text-brett-teal/70 flex-shrink-0 mt-0.5" />
               <div className="min-w-0">
                 <div className="text-sm text-white/70 truncate">{confirmedTask}</div>
-                <div className="text-[11px] text-white/30">Added to Inbox</div>
+                <div className="text-[11px] text-white/30">Added to {destinationLabel}</div>
               </div>
             </div>
           )}

--- a/packages/ui/src/SpotlightModal.tsx
+++ b/packages/ui/src/SpotlightModal.tsx
@@ -46,6 +46,8 @@ export interface SpotlightModalProps {
   initialForcedAction?: "search" | "create" | null;
   showScoutAction?: boolean;
   assistantName?: string;
+  /** Where a newly-created task will actually land (e.g. "Inbox", "Today", "Shopping"). */
+  destinationLabel?: string;
 }
 
 export function SpotlightModal({
@@ -74,6 +76,7 @@ export function SpotlightModal({
   initialForcedAction,
   showScoutAction,
   assistantName = "Brett",
+  destinationLabel = "Inbox",
 }: SpotlightModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
@@ -442,7 +445,7 @@ export function SpotlightModal({
               <Check size={14} className="text-brett-teal flex-shrink-0" />
               <div className="min-w-0">
                 <div className="text-sm text-white/85 font-medium truncate">{confirmedTask}</div>
-                <div className="text-[11px] text-white/40">Added to Inbox</div>
+                <div className="text-[11px] text-white/40">Added to {destinationLabel}</div>
               </div>
             </div>
           </div>

--- a/packages/utils/src/__tests__/task-destination-label.test.ts
+++ b/packages/utils/src/__tests__/task-destination-label.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { NavList } from "@brett/types";
+import { getTaskDestinationLabel } from "../index";
+
+const list = (id: string, name: string): NavList => ({
+  id,
+  name,
+  count: 0,
+  completedCount: 0,
+  colorClass: "",
+  sortOrder: 0,
+});
+
+describe("getTaskDestinationLabel", () => {
+  const lists: NavList[] = [
+    list("abc123", "Shopping"),
+    list("def456", "Work"),
+  ];
+
+  it("returns Inbox when currentView is undefined", () => {
+    expect(getTaskDestinationLabel(undefined, lists)).toBe("Inbox");
+  });
+
+  it("returns Inbox for the inbox view", () => {
+    expect(getTaskDestinationLabel("inbox", lists)).toBe("Inbox");
+  });
+
+  it("returns Today for the today view (matches dueDate=today behavior in createTask)", () => {
+    expect(getTaskDestinationLabel("today", lists)).toBe("Today");
+  });
+
+  it("returns the list name for a list: view when the id is known", () => {
+    expect(getTaskDestinationLabel("list:abc123", lists)).toBe("Shopping");
+    expect(getTaskDestinationLabel("list:def456", lists)).toBe("Work");
+  });
+
+  it("falls back to Inbox when list id cannot be resolved", () => {
+    expect(getTaskDestinationLabel("list:unknown", lists)).toBe("Inbox");
+    expect(getTaskDestinationLabel("list:abc123", [])).toBe("Inbox");
+  });
+
+  it("returns Inbox for views that createTask doesn't specialize (upcoming, calendar, scouts, settings)", () => {
+    // These views fall through createTask's defaults → the task lands in the inbox.
+    // The label must reflect where the task actually goes, not which screen the user is on.
+    expect(getTaskDestinationLabel("upcoming", lists)).toBe("Inbox");
+    expect(getTaskDestinationLabel("calendar", lists)).toBe("Inbox");
+    expect(getTaskDestinationLabel("scouts", lists)).toBe("Inbox");
+    expect(getTaskDestinationLabel("settings", lists)).toBe("Inbox");
+  });
+
+  it("handles a malformed list: view with no id", () => {
+    expect(getTaskDestinationLabel("list:", lists)).toBe("Inbox");
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,4 @@
-import type { CalendarGlassColor, ContentType } from "@brett/types";
+import type { CalendarGlassColor, ContentType, NavList } from "@brett/types";
 
 // ── URL content type detection ──
 
@@ -162,6 +162,28 @@ export function humanizeCadence(hours: number): string {
 
 export { resolveTempUnit, convertTemp } from "./weather.js";
 export { generateCuid } from "./cuid.js";
+
+/**
+ * Where a new task created from the current view will actually land.
+ * Keep aligned with `useOmnibar.createTask(currentView)` in
+ * `apps/desktop/src/api/omnibar.ts`: Today adds a due date, `list:<id>` sets
+ * `listId`, everything else falls through to inbox. The label must reflect
+ * the destination, not the screen the user is on.
+ */
+export function getTaskDestinationLabel(
+  currentView: string | undefined,
+  lists: ReadonlyArray<Pick<NavList, "id" | "name">>,
+): string {
+  if (currentView === "today") return "Today";
+  if (currentView?.startsWith("list:")) {
+    const listId = currentView.slice(5);
+    if (listId) {
+      const match = lists.find((l) => l.id === listId);
+      if (match) return match.name;
+    }
+  }
+  return "Inbox";
+}
 
 // ── Password validation ──
 


### PR DESCRIPTION
Closes #79

## Root cause

Both `Omnibar.tsx` and `SpotlightModal.tsx` hardcoded "Added to Inbox" in their task-created confirmation, even though `useOmnibar.createTask` (in `apps/desktop/src/api/omnibar.ts`) already routes new tasks to different destinations based on `currentView`:

- `today` → tagged with `dueDate: today`
- `list:<id>` → tagged with that `listId`
- everything else → inbox (default)

So creating a task from Today or a custom list put the task in the right place but told the user it went to Inbox.

## Approach

Considered three options:

1. **Inline the label logic in both components** — duplicates the mapping between `Omnibar.tsx` and `SpotlightModal.tsx` (and re-duplicates the list-lookup every time the toast renders). Skipped.
2. **Have `useOmnibar.createTask` return the destination and have the component read it from the hook** — ties rendering to hook internals and requires threading a second return value through the `onCreateTask` callback signature (breaking backwards-compat for any other consumer). Skipped.
3. **Extract a pure util `getTaskDestinationLabel(currentView, lists)` in `@brett/utils`, computed in `App.tsx`, passed as a prop** ✅ picked. Keeps the UI components dumb, centralizes the mapping next to the `createTask` routing logic it mirrors, and keeps the components backwards-compatible by defaulting the new prop to `"Inbox"`.

## Changes

- `packages/utils/src/index.ts` — add `getTaskDestinationLabel(currentView, lists)`. Uses `Pick<NavList, "id" | "name">` so the contract is minimal.
- `packages/utils/src/__tests__/task-destination-label.test.ts` — 7 tests covering all branches (inbox, today, known list, unknown list, empty lists array, malformed `list:` view, and pass-through views like `upcoming`/`calendar`/`scouts`/`settings` that fall through `createTask`'s defaults).
- `packages/ui/src/Omnibar.tsx` — add `destinationLabel?: string` prop (defaults to `"Inbox"`), swap the hardcoded string at the task-created card.
- `packages/ui/src/SpotlightModal.tsx` — same treatment; the two surfaces stay in lockstep as required by CLAUDE.md's Omnibar/Spotlight parity rule.
- `apps/desktop/src/App.tsx` — compute `taskDestinationLabel = getTaskDestinationLabel(currentView, lists)` once, wire it into both `omnibarProps` (which is spread into `scoutsOmnibarProps` + `TodayView`'s `<Omnibar {...omnibarProps} />`) and the `SpotlightModal` JSX.

## Tests

Added `getTaskDestinationLabel` unit tests — they would have caught the category of bug (label ≠ actual destination) for every view type.

Skipped adding snapshot/render tests for the confirmation UI text itself: the string is now trivially derived from the prop, and a test like `expect(screen.getByText('Added to Today')).toBeInTheDocument()` would just mirror the JSX. The logic that matters is the label derivation, which is tested in isolation.

**Test-prevention reflection:** yes — a pragmatic test on `getTaskDestinationLabel` catches this bug and every variation of it (new view type added to `createTask` without updating the label → test fails for that view).

## Self-review findings

1. First pass passed `NavList[]` as the lists arg. Narrowed to `ReadonlyArray<Pick<NavList, "id" | "name">>` so the util doesn't depend on fields it doesn't read (count, colorClass, etc.).
2. `list:` with empty id (malformed route) — added an explicit `if (listId)` check and a test case, so the util falls back to "Inbox" instead of matching the first list with an empty id.
3. Verified every Omnibar/Spotlight consumer. `omnibarProps` is spread into `scoutsOmnibarProps` and `<Omnibar {...omnibarProps} />` in `TodayView`, so the prop propagates automatically. Scouts view keeps destination = "Inbox" (matches `createTask` behavior — Scouts-scoped `onSend` is overridden separately, but `onCreateTask` uses the original `currentView`).
4. Default prop value = "Inbox" — anyone using `<Omnibar />` or `<SpotlightModal />` without the new prop keeps the prior behavior. No breaking change for unknown consumers.

## Verification

```
$ pnpm --filter=@brett/utils test
Test Files  7 passed (7)
     Tests  71 passed (71)

$ pnpm --filter=@brett/ui test
Test Files  6 passed (6)
     Tests  68 passed (68)

$ pnpm --filter=@brett/desktop test
Test Files  13 passed (13)
     Tests  155 passed (155)

$ pnpm --filter=@brett/utils typecheck   # clean
$ pnpm --filter=@brett/ui typecheck      # clean
$ pnpm --filter=@brett/desktop typecheck # clean
```

`pnpm typecheck` at the monorepo root fails on `@brett/api-core` with missing Prisma-generated files — pre-existing on `main`, unrelated to this PR.

## Risks / follow-ups

- If a list is archived while the user is on `/lists/:id`, the label falls back to "Inbox" while the task actually lands on the archived list. In practice the user would have navigated away, but worth noting.
- `createTask` still treats `upcoming` / `calendar` / `scouts` / `settings` as inbox. The label agrees with that, but it's not obvious what the "right" destination on those screens should be — consider a follow-up.

Visual verification pending — `gh pr checkout` and confirm "Added to Today" on `/today`, "Added to Shopping" on `/lists/<id>`, "Added to Inbox" everywhere else.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMNXbb2Uqw411Pft8uuJ9Z)_