### PR TITLE
fix: add global cmd+n shortcut for new task (#80 #81 #82)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -583,8 +583,9 @@ export function App() {
     };
   }, [awakening.status]);
 
-  // Track whether spotlight should open with search pre-selected (Cmd+F)
-  const [spotlightInitialAction, setSpotlightInitialAction] = useState<"search" | null>(null);
+  // Track whether spotlight should open with a specific action pre-selected
+  // (Cmd+F → search, Cmd+N → create). null = normal open.
+  const [spotlightInitialAction, setSpotlightInitialAction] = useState<"search" | "create" | null>(null);
 
   // Global Cmd+K / Ctrl+K listener for spotlight.
   // Destructures actions so the effect doesn't re-run on every SSE text
@@ -611,6 +612,23 @@ export function App() {
           omnibarClose();
         } else {
           setSpotlightInitialAction("search");
+          omnibarOpen("spotlight");
+          setSelectedItem(null);
+          setIsDetailOpen(false);
+        }
+      }
+      // Cmd+N / Ctrl+N opens spotlight with create-task pre-selected.
+      // No activeElement guard — unlike per-view shortcuts, a global
+      // "new task" shortcut must fire regardless of where focus is (including
+      // inside the Omnibar input, which is why the legacy InboxView plain-`n`
+      // handler was scoping us out of reach). The task destination is
+      // routed through createTask's contextual `currentView` logic.
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "n") {
+        e.preventDefault();
+        if (omnibarIsOpen && omnibarMode === "spotlight") {
+          omnibarClose();
+        } else {
+          setSpotlightInitialAction("create");
           omnibarOpen("spotlight");
           setSelectedItem(null);
           setIsDetailOpen(false);

--- a/packages/ui/src/InboxView.tsx
+++ b/packages/ui/src/InboxView.tsx
@@ -341,8 +341,12 @@ export function InboxView({
         return;
       }
 
-      // Quick add
-      if (key === "n") {
+      // Quick add — plain `n` only. cmd/ctrl+n is reserved for the global
+      // "open Spotlight with create preselected" shortcut registered in
+      // App.tsx; without this guard the single-letter handler shadows it and
+      // scrolls to the quick-add input instead (regression covered in
+      // InboxView.test.tsx).
+      if (key === "n" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
         quickAddRef.current?.focus();
         return;

--- a/packages/ui/src/__tests__/InboxView.test.tsx
+++ b/packages/ui/src/__tests__/InboxView.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { Thing, NavList } from "@brett/types";
 import { InboxView } from "../InboxView";
 
@@ -63,5 +63,52 @@ describe("InboxView empty state", () => {
     expect(screen.getByText(/Caught up/i)).toBeInTheDocument();
     // First-time copy must NOT render once the user has proven they know the surface
     expect(screen.queryByText(/Your inbox is ready/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("InboxView keyboard shortcuts", () => {
+  it("focuses the quick-add input when the user presses plain `n`", () => {
+    renderInbox([]);
+    const quickAdd = screen.getByPlaceholderText(/Add to inbox/i) as HTMLInputElement;
+    expect(document.activeElement).not.toBe(quickAdd);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "n" });
+    });
+
+    expect(document.activeElement).toBe(quickAdd);
+  });
+
+  // Regression guard for issues #80/#81/#82: the InboxView `n` shortcut
+  // used to match without checking modifiers, which meant cmd+n on the
+  // inbox scrolled to and focused the quick-add input — shadowing the
+  // global cmd+n shortcut that should open the Spotlight with create
+  // preselected. This test prevents the category of bug where a
+  // single-letter keyboard handler accidentally shadows a cmd+letter
+  // global shortcut.
+  it("does NOT focus the quick-add input when the user presses cmd+n (leaves it to the global shortcut)", () => {
+    renderInbox([]);
+    const quickAdd = screen.getByPlaceholderText(/Add to inbox/i) as HTMLInputElement;
+    // Start with focus somewhere else to prove we didn't accidentally focus via the test setup
+    (document.body as HTMLElement).focus();
+    expect(document.activeElement).not.toBe(quickAdd);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "n", metaKey: true });
+    });
+
+    expect(document.activeElement).not.toBe(quickAdd);
+  });
+
+  it("does NOT focus the quick-add input when the user presses ctrl+n", () => {
+    renderInbox([]);
+    const quickAdd = screen.getByPlaceholderText(/Add to inbox/i) as HTMLInputElement;
+    (document.body as HTMLElement).focus();
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "n", ctrlKey: true });
+    });
+
+    expect(document.activeElement).not.toBe(quickAdd);
   });
 });


### PR DESCRIPTION
Closes #80
Closes #81
Closes #82

## Root cause

All three issues are the same bug, observed from different angles. There was **no global cmd+n handler anywhere in the app**. The only thing that responded to cmd+n at all was a plain single-letter `n` handler in `InboxView` (packages/ui/src/InboxView.tsx) — `e.key === "n"` matches whether or not meta/ctrl are pressed, so on the inbox cmd+n scrolled to and focused the quick-add input (#82). On every other screen cmd+n was a no-op (#80 and #81 just described that no-op from two angles — "after using the omnibar" and "while the omnibar is focused").

## Approach

Three options were considered:

1. **Add global cmd+n handler in App.tsx** (alongside the existing cmd+k and cmd+f handlers) that opens the Spotlight modal with "create task" pre-selected. `SpotlightModal` already accepts `initialForcedAction` and handles `"create"` correctly (placeholder, forced suggestion, create flow). Contextual destination routing already works via `useOmnibar.createTask(currentView)` — on `/today` the task gets `dueDate=today`, on `/lists/:id` it gets that `listId`, otherwise inbox. ✅ picked.
2. **Repurpose the inbox plain-`n` shortcut to open the spotlight everywhere**. Breaks a useful muscle-memory shortcut for inbox regulars who do `n` to focus the add bar. Rejected.
3. **Bind cmd+n to focus the quick-add input on the current view** (not Spotlight). Doesn't match the #82 spec ("should be like cmd+f and open the spotlight"). Rejected.

## Changes

- `apps/desktop/src/App.tsx`
  - Widen `spotlightInitialAction` state from `"search" | null` to `"search" | "create" | null`.
  - Add cmd/ctrl+n branch to the existing global keydown handler. Same pattern as cmd+k / cmd+f: `preventDefault`, toggle close if Spotlight already open with this action, otherwise open Spotlight with `setSpotlightInitialAction("create")`. Blocks on cmd+shift+n and cmd+alt+n so system shortcuts (e.g. "new folder") aren't intercepted.
  - No `activeElement` guard on the global handler — that's deliberate and commented. #80/#81 were specifically the "cmd+n doesn't work when an input is focused" cases; a global shortcut needs to fire regardless of focus.

- `packages/ui/src/InboxView.tsx`
  - Tighten the plain-`n` handler to `key === "n" && !e.metaKey && !e.ctrlKey && !e.altKey` so cmd+n no longer shadows the global shortcut. Plain `n` behavior unchanged.
  - Shift modifier isn't in the guard because `e.key === "n"` only matches lowercase; shift+n is `"N"`.

- `packages/ui/src/__tests__/InboxView.test.tsx`
  - New regression tests: plain `n` focuses the quick-add input (existing behavior preserved); cmd+n and ctrl+n do NOT (the category of bug — a single-letter handler shadowing a cmd+letter global — is now guarded).

## Tests

Added three tests in `InboxView.test.tsx`:

1. Plain `n` → focuses quick-add (existing behavior regression guard).
2. cmd+n → does NOT focus quick-add (new regression guard; directly catches the #82 bug).
3. ctrl+n → does NOT focus quick-add (same as #2 for Windows/Linux).

The global cmd+n handler in `App.tsx` isn't tested directly — `App.tsx` has no existing keyboard-shortcut tests, and the handler is a near-identical clone of the proven cmd+k / cmd+f handlers right above it. Wiring it up for isolated testing would mean extracting the matcher into a pure helper that's trivial to eyeball. Not worth the abstraction for a 3-line handler. Visual verification required.

**Test-prevention reflection:** yes — the two new cmd-modifier tests in `InboxView.test.tsx` directly catch the category of bug (a single-letter keyboard handler shadowing a cmd+letter global) for any future view that adds similar shortcuts. If someone adds a plain-`k` or plain-`f` handler to a list view without a modifier guard, they'll want the same tests — the patterns are now in one place to copy from.

## Self-review findings

1. First pass guarded only `metaKey`/`ctrlKey` on the InboxView handler. Added `altKey` for completeness — alt+n is a macOS system shortcut for `ñ` and we shouldn't eat it either.
2. Considered adding `altKey` guard to the global handler too; did so. Cmd+alt+n has no established meaning in the app; reserving it.
3. Verified SpotlightModal already handles `initialForcedAction === "create"` (line 128-135 applies it, line 218-224 renders the forced-create suggestion, line 379 uses the `"New task..."` placeholder). No changes needed there.
4. Verified createTask's contextual routing is already correct: `currentView` is derived in App.tsx from `useLocation().pathname` and passed through to `omnibar.createTask` — #82's "task lands contextually" requirement is already satisfied.
5. Confirmed the new handler coexists with cmd+k / cmd+f in the same `useEffect` — same deps array, same cleanup, no identity churn.

## Verification

```
$ pnpm --filter=@brett/ui test
Test Files  6 passed (6)
     Tests  71 passed (71)   # 68 → 71 (+3 new InboxView regression tests)

$ pnpm --filter=@brett/desktop test
Test Files  13 passed (13)
     Tests  155 passed (155)

$ pnpm --filter=@brett/ui typecheck      # clean
$ pnpm --filter=@brett/desktop typecheck # clean
```

## Risks / follow-ups

- **Electron File menu:** Electron's default application menu typically includes File → New with accelerator cmd+n. Our `preventDefault()` should suppress it, but if the default menu's accelerator runs in a different phase we might see a blip. The app currently has no custom menu (`apps/desktop/electron/main.ts`), so there's no user-configurable command being intercepted. Flagging for visual verification.
- **Alt/Shift+n combinations:** not handled — intentional. If the user presses cmd+shift+n or cmd+alt+n, the handler does nothing and Electron can fall through to any system default.

Visual verification pending — `gh pr checkout 88` (or whatever #) and try:

- cmd+n on /today → Spotlight opens with "New task..." placeholder, typing a task creates it with today's due date, toast says "Added to Today" (after #87 lands).
- cmd+n on /lists/<id> → same, task gets that `listId`, toast says "Added to <list name>".
- cmd+n on /inbox → Spotlight opens with create preselected; plain `n` still focuses the legacy inbox quick-add input (not broken).
- cmd+n while typing into the Omnibar → Spotlight opens (the original #80/#81 failure mode).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMNXbb2Uqw411Pft8uuJ9Z)_