### PR TITLE
audit: full-stack hardening pass (API + Electron + sync)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -93,3 +93,13 @@ GOOGLE_WEATHER_API_KEY=         # Maps Platform API key with Weather API enabled
 # Feedback → GitHub Issues
 GITHUB_FEEDBACK_PAT=            # Fine-grained PAT with Issues R/W on the target repo
 GITHUB_FEEDBACK_REPO=           # owner/repo format, e.g. brentbarkman/brett
+
+# Newsletter ingest (Postmark inbound webhook)
+# Generate with: openssl rand -hex 32
+# In Postmark, set the Inbound Webhook URL to
+#   https://x:$NEWSLETTER_INGEST_SECRET@api.brett.app/webhooks/email/ingest
+# Postmark rewrites the user:pass into an `Authorization: Basic …` header,
+# which keeps the secret out of URL paths, referrer chains, and proxy logs.
+# The "x" username is a placeholder — we only check the password.
+NEWSLETTER_INGEST_SECRET=
+NEWSLETTER_INGEST_EMAIL=        # Forwarding address shown in Settings (e.g., ingest@brett.app)

--- a/apps/api/prisma/migrations/20260423120000_add_sync_pull_indexes/migration.sql
+++ b/apps/api/prisma/migrations/20260423120000_add_sync_pull_indexes/migration.sql
@@ -1,0 +1,18 @@
+-- Sync pull queries filter by (userId, updatedAt > cursor) for each table.
+-- Without these composite indexes the query planner falls back to seq scans,
+-- which gets bad fast for users with many rows. Indexes are cheap to add
+-- (they're non-blocking when CONCURRENTLY — but Prisma wraps migrations in a
+-- transaction so we can't use CONCURRENTLY here; these tables are small
+-- enough in current prod that the non-concurrent add is acceptable).
+
+-- List
+CREATE INDEX "List_userId_updatedAt_idx" ON "List"("userId", "updatedAt");
+
+-- Attachment (future sync pull + per-user listing)
+CREATE INDEX "Attachment_userId_updatedAt_idx" ON "Attachment"("userId", "updatedAt");
+
+-- CalendarEventNote
+CREATE INDEX "CalendarEventNote_userId_updatedAt_idx" ON "CalendarEventNote"("userId", "updatedAt");
+
+-- Scout (sync pull + tombstone pull)
+CREATE INDEX "Scout_userId_updatedAt_idx" ON "Scout"("userId", "updatedAt");

--- a/apps/api/prisma/migrations/20260423120001_add_cron_lock/migration.sql
+++ b/apps/api/prisma/migrations/20260423120001_add_cron_lock/migration.sql
@@ -1,0 +1,14 @@
+-- Leader-election lease table for cron jobs. Used by lib/cron-lock.ts so
+-- that running multiple API replicas no longer means multiple workers all
+-- think they're the cron leader and duplicate webhook-renewal / calendar-
+-- sync / scout-tick runs.
+
+CREATE TABLE "CronLock" (
+  "jobName"    TEXT NOT NULL PRIMARY KEY,
+  "holder"     TEXT NOT NULL,
+  "acquiredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt"  TIMESTAMP(3) NOT NULL,
+  "updatedAt"  TIMESTAMP(3) NOT NULL
+);
+
+CREATE INDEX "CronLock_expiresAt_idx" ON "CronLock"("expiresAt");

--- a/apps/api/prisma/migrations/20260423120002_scout_finding_user_id/migration.sql
+++ b/apps/api/prisma/migrations/20260423120002_scout_finding_user_id/migration.sql
@@ -1,0 +1,28 @@
+-- Release A of ScoutFinding.userId denormalization. Nullable for now so
+-- the migration (which prisma wraps in a transaction) doesn't lock the
+-- table on a backfill UPDATE — and so the old replica, still running
+-- during the rolling deploy window without the updated Prisma client,
+-- can keep inserting findings that simply leave userId as NULL.
+--
+-- Release B (follow-up): verify no nulls remain, then ALTER COLUMN SET
+-- NOT NULL and drop the OR fallback in routes/sync.ts.
+
+-- 1. Add the column.
+ALTER TABLE "ScoutFinding" ADD COLUMN "userId" TEXT;
+
+-- 2. Index for sync pull. B-tree allows nulls, so this works fine while
+--    the column is still nullable. The old `(scoutId, createdAt)` index
+--    stays around — it's still the right shape for findings-by-scout
+--    queries elsewhere in the app.
+CREATE INDEX "ScoutFinding_userId_updatedAt_idx"
+  ON "ScoutFinding"("userId", "updatedAt");
+
+-- 3. Backfill from scout.userId. Correlated subquery — fine for the row
+--    count ScoutFinding currently has; if this table ever grows large
+--    enough that the migration takes real time, swap this for a chunked
+--    update run outside a transaction (see Release B notes).
+UPDATE "ScoutFinding" sf
+SET "userId" = s."userId"
+FROM "Scout" s
+WHERE s.id = sf."scoutId"
+  AND sf."userId" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -137,6 +137,9 @@ model List {
   updatedAt  DateTime @updatedAt
 
   @@unique([userId, name])
+  // Sync pull queries lists by (userId, updatedAt > cursor); without this
+  // composite index that query falls back to a seq-scan on the unique index.
+  @@index([userId, updatedAt])
 }
 
 model Item {
@@ -237,6 +240,9 @@ model Attachment {
   updatedAt  DateTime @updatedAt
 
   @@index([itemId])
+  // Used if/when attachments are added to sync pull, and by any direct
+  // per-user attachment listing.
+  @@index([userId, updatedAt])
 }
 
 model ItemLink {
@@ -376,6 +382,8 @@ model CalendarEventNote {
 
   @@unique([calendarEventId, userId])
   @@index([userId])
+  // Sync pull for calendar notes filters by (userId, updatedAt > cursor).
+  @@index([userId, updatedAt])
 }
 
 // ── Granola tables ──
@@ -703,6 +711,8 @@ model Scout {
 
   @@index([userId, status])
   @@index([status, nextRunAt])
+  // Sync pull + tombstone pull for scouts.
+  @@index([userId, updatedAt])
 }
 
 model ScoutRun {
@@ -878,4 +888,19 @@ model DeviceToken {
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+/// Lease-based leader lock for cron jobs. Only one replica at a time holds
+/// a given jobName. Lease renews on each tick; expired leases are reclaimed.
+/// Without this, a second API replica would happily run the same 6-hour
+/// webhook renewal / calendar sync job in parallel, duplicating work and
+/// (more dangerously) racing on syncToken state.
+model CronLock {
+  jobName    String   @id
+  holder     String   // instance id — identifies which process holds the lease
+  acquiredAt DateTime @default(now())
+  expiresAt  DateTime
+  updatedAt  DateTime @updatedAt
+
+  @@index([expiresAt])
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -747,6 +747,14 @@ model ScoutFinding {
   scout          Scout       @relation(fields: [scoutId], references: [id], onDelete: Cascade)
   scoutRunId     String
   scoutRun       ScoutRun    @relation(fields: [scoutRunId], references: [id], onDelete: Cascade)
+  // Denormalized owner. Ownership already flows through scout.userId, but
+  // having it on the row directly (a) lets sync pull hit a composite
+  // `(userId, updatedAt)` index without a join through Scout, and (b) is
+  // a defense-in-depth scoping key if any future query forgets the
+  // `scout: { userId }` filter. Nullable for now so existing rows don't
+  // block the deploy; NOT NULL flip happens in a follow-up release after
+  // backfill + every call site is writing it.
+  userId         String?
   deletedAt      DateTime?
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt
@@ -765,6 +773,7 @@ model ScoutFinding {
   feedbackAt     DateTime?
 
   @@index([scoutId, createdAt])
+  @@index([userId, updatedAt])
 }
 
 model ScoutActivity {

--- a/apps/api/src/__tests__/devices.test.ts
+++ b/apps/api/src/__tests__/devices.test.ts
@@ -152,4 +152,34 @@ describe("Device registration routes", () => {
     });
     expect(res.status).toBe(401);
   });
+
+  it("POST /devices/register refuses to reassign another user's token (409)", async () => {
+    // Regression test for the device-token bypass: previously, any
+    // authenticated user could POST a token registered to someone else and
+    // have the server silently update userId, hijacking that device's push
+    // notifications. Now we return 409 when the token belongs to another
+    // user.
+    clearAllRateLimits();
+    const attacker = await createTestUser("Attacker");
+    clearAllRateLimits();
+
+    const victimToken = `victim-${nonce}-hijack`;
+    // Register the token to the original victim user (the `token` at the
+    // top of this file belongs to "Device User").
+    const reg = await authRequest("/devices/register", token, {
+      method: "POST",
+      body: JSON.stringify({ token: victimToken, platform: "ios" }),
+    });
+    expect(reg.status).toBe(201);
+
+    clearAllRateLimits();
+    // Attacker tries to claim the same token
+    const hijack = await authRequest("/devices/register", attacker.token, {
+      method: "POST",
+      body: JSON.stringify({ token: victimToken, platform: "ios" }),
+    });
+    expect(hijack.status).toBe(409);
+    const body = (await hijack.json()) as any;
+    expect(body.error).toMatch(/different account/i);
+  });
 });

--- a/apps/api/src/__tests__/newsletter-ingest.test.ts
+++ b/apps/api/src/__tests__/newsletter-ingest.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   extractEmail,
   sanitizeNewsletterHtml,
   verifyIngestSecret,
 } from "../lib/newsletter-ingest.js";
+import { app } from "../app.js";
 
 describe("extractEmail", () => {
   it("extracts email from angle bracket format", () => {
@@ -140,5 +141,80 @@ describe("verifyIngestSecret", () => {
 
   it("returns false for different length secrets", () => {
     expect(verifyIngestSecret("short", "much-longer-secret")).toBe(false);
+  });
+});
+
+// Full-route coverage for the Basic Auth path. The handler accepts the
+// secret in either the `:secret` URL param (legacy) or the Basic Auth
+// password (preferred — Postmark's inbound webhook URL can embed
+// `https://x:<secret>@host/...` which is rewritten to the header, keeping
+// the secret out of referrer / proxy logs).
+describe("newsletter webhook auth", () => {
+  const SECRET = "ingest-secret-test";
+  const orig: { secret?: string } = {};
+
+  beforeAll(() => {
+    orig.secret = process.env.NEWSLETTER_INGEST_SECRET;
+    process.env.NEWSLETTER_INGEST_SECRET = SECRET;
+  });
+  afterAll(() => {
+    if (orig.secret === undefined) delete process.env.NEWSLETTER_INGEST_SECRET;
+    else process.env.NEWSLETTER_INGEST_SECRET = orig.secret;
+  });
+
+  it("accepts the secret via Authorization: Basic header on the headerless path", async () => {
+    const basic = Buffer.from(`x:${SECRET}`).toString("base64");
+    const res = await app.request("/webhooks/email/ingest", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${basic}`,
+      },
+      // Missing required fields → 200 with `skipped`, but that means auth passed.
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.skipped).toBeDefined();
+  });
+
+  it("rejects a Basic header with the wrong password", async () => {
+    const basic = Buffer.from("x:not-the-secret").toString("base64");
+    const res = await app.request("/webhooks/email/ingest", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${basic}`,
+      },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a request with no credentials at all", async () => {
+    const res = await app.request("/webhooks/email/ingest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("still accepts the secret in the legacy URL path", async () => {
+    const res = await app.request(`/webhooks/email/ingest/${SECRET}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a legacy URL with the wrong secret (timing-safe compare)", async () => {
+    const res = await app.request("/webhooks/email/ingest/not-the-secret", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/api/src/__tests__/prisma-regression.test.ts
+++ b/apps/api/src/__tests__/prisma-regression.test.ts
@@ -642,6 +642,7 @@ describe("Enum mapping", () => {
         data: {
           scoutId: scout.id,
           scoutRunId: run.id,
+          userId: testUserId,
           type,
           title: `Test ${type}`,
           description: "Test description",

--- a/apps/api/src/__tests__/rate-limit.test.ts
+++ b/apps/api/src/__tests__/rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Hono } from "hono";
-import { rateLimiter } from "../middleware/rate-limit.js";
+import { rateLimiter, extractClientIp } from "../middleware/rate-limit.js";
 
 // Build a tiny Hono app with the rate limiter for testing.
 // We mock the auth user by setting it in middleware before the rate limiter.
@@ -113,5 +113,36 @@ describe("rateLimiter", () => {
       headers: { "X-Test-User-Id": uid2 },
     });
     expect(resB.status).toBe(200);
+  });
+});
+
+describe("extractClientIp", () => {
+  it("returns 'unknown' for missing header", () => {
+    expect(extractClientIp(undefined)).toBe("unknown");
+    expect(extractClientIp("")).toBe("unknown");
+  });
+
+  it("returns the only entry when there's one hop", () => {
+    expect(extractClientIp("203.0.113.5")).toBe("203.0.113.5");
+  });
+
+  it("trusts the right-most entry — not the client-supplied left", () => {
+    // Railway / other trusted proxies APPEND the real client IP, so the
+    // right-most is the least-spoofable. The left entry is a value the
+    // client sent themselves and can be forged.
+    expect(extractClientIp("1.2.3.4, 5.6.7.8, 203.0.113.5")).toBe("203.0.113.5");
+  });
+
+  it("handles whitespace and empty entries", () => {
+    expect(extractClientIp("  1.2.3.4 ,  , 203.0.113.5  ")).toBe("203.0.113.5");
+  });
+
+  it("does not let the client spoof the left-most entry to poison rate-limit keys", () => {
+    // If a malicious client sets X-Forwarded-For: "victim.ip", the proxy
+    // appends the real IP, yielding "victim.ip, real.ip". We must take
+    // real.ip, not victim.ip.
+    const spoofed = "1.1.1.1, 198.51.100.7";
+    expect(extractClientIp(spoofed)).toBe("198.51.100.7");
+    expect(extractClientIp(spoofed)).not.toBe("1.1.1.1");
   });
 });

--- a/apps/api/src/__tests__/scouts-memory.test.ts
+++ b/apps/api/src/__tests__/scouts-memory.test.ts
@@ -57,6 +57,7 @@ describe("Scout memory routes", () => {
       data: {
         scoutId,
         scoutRunId: run.id,
+        userId,
         type: "insight",
         title: "Test Finding",
         description: "A test finding description",

--- a/apps/api/src/__tests__/sync-merge.test.ts
+++ b/apps/api/src/__tests__/sync-merge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { fieldLevelMerge, findMissingBaselines } from "../lib/sync-merge.js";
+
+describe("findMissingBaselines", () => {
+  it("returns [] when every changed field has a baseline", () => {
+    expect(
+      findMissingBaselines(["title", "description"], {
+        title: "old",
+        description: "prev",
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags fields missing from previousValues", () => {
+    expect(
+      findMissingBaselines(["title", "description", "status"], {
+        title: "old",
+      }),
+    ).toEqual(["description", "status"]);
+  });
+
+  it("treats an explicit undefined baseline as present", () => {
+    // An explicit `undefined` means "field was previously unset" — different
+    // from "client didn't send a baseline". `in` rather than `!== undefined`
+    // is what distinguishes the two.
+    expect(findMissingBaselines(["notes"], { notes: undefined })).toEqual([]);
+  });
+
+  it("handles an empty changedFields list", () => {
+    expect(findMissingBaselines([], { title: "x" })).toEqual([]);
+  });
+});
+
+describe("fieldLevelMerge", () => {
+  it("applies the client's value when baseline matches the server", () => {
+    const result = fieldLevelMerge(
+      { title: "server", description: "same" },
+      ["title"],
+      { title: "client" },
+      { title: "server" },
+    );
+    expect(result.mergedFields).toEqual({ title: "client" });
+    expect(result.conflictedFields).toEqual([]);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("flags a conflict when the server has drifted from baseline", () => {
+    const result = fieldLevelMerge(
+      { title: "server-moved-on" },
+      ["title"],
+      { title: "client" },
+      { title: "server-original" },
+    );
+    expect(result.mergedFields).toEqual({});
+    expect(result.conflictedFields).toEqual(["title"]);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("partial merge: clean field applied, conflicted field rejected", () => {
+    const result = fieldLevelMerge(
+      { title: "server-title", description: "server-desc-drifted" },
+      ["title", "description"],
+      { title: "client-title", description: "client-desc" },
+      { title: "server-title", description: "server-desc-orig" },
+    );
+    expect(result.mergedFields).toEqual({ title: "client-title" });
+    expect(result.conflictedFields).toEqual(["description"]);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("compares dates and nulls via JSON.stringify", () => {
+    const serverDate = new Date("2026-04-01T00:00:00Z");
+    const result = fieldLevelMerge(
+      { dueDate: serverDate },
+      ["dueDate"],
+      { dueDate: null },
+      { dueDate: serverDate },
+    );
+    expect(result.mergedFields).toEqual({ dueDate: null });
+    expect(result.conflictedFields).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -509,6 +509,41 @@ describe("Sync Push", () => {
     expect(body.results[0].conflictedFields).not.toContain("title");
   });
 
+  it("UPDATE (missing baseline): rejected so client can't silently lose edits", async () => {
+    // Regression for a silent-data-loss bug: when changedFields listed a
+    // field but previousValues didn't include it, the old merge logic
+    // treated it as a conflict (server-wins) and dropped the client's
+    // edit. We now reject the whole mutation so a buggy client gets a
+    // clear signal.
+    clearAllRateLimits();
+
+    const createRes = await authRequest("/things", token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Missing Baseline", status: "active" }),
+    });
+    const created = (await createRes.json()) as any;
+
+    clearAllRateLimits();
+
+    const res = await pushRequest([{
+      idempotencyKey: `update-missing-baseline-${nonce}-${created.id}`,
+      entityType: "item",
+      entityId: created.id,
+      action: "UPDATE",
+      payload: { title: "New Title", description: "New Desc" },
+      changedFields: ["title", "description"],
+      // Note: description is NOT in previousValues — this is the bug case.
+      previousValues: { title: "Missing Baseline" },
+      baseUpdatedAt: created.updatedAt,
+    }]);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SyncPushResponse;
+    expect(body.results[0].status).toBe("error");
+    expect(body.results[0].error).toMatch(/previousValues/i);
+    expect(body.results[0].error).toMatch(/description/);
+  });
+
   it("DELETE: soft-deletes the record", async () => {
     clearAllRateLimits();
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -53,8 +53,12 @@ app.use(
   "*",
   cors({
     origin: (origin) => {
-      // React Native / mobile clients send no Origin header — allow them
-      if (!origin) return "*";
+      // Non-browser clients (iOS, curl, React Native) send no Origin header.
+      // For those, return null — CORS only matters to browsers, and they
+      // always send an Origin. Returning "*" with credentials: true was
+      // spec-invalid and still leaked a permissive header to downstream
+      // caches/proxies. Bearer-auth clients work regardless.
+      if (!origin) return null;
       if (origin === "app://.") return origin;
       if (isLocal && origin.match(/^http:\/\/localhost:\d+$/)) return origin;
       return null;

--- a/apps/api/src/jobs/cron.ts
+++ b/apps/api/src/jobs/cron.ts
@@ -223,15 +223,20 @@ export function startCronJobs(): void {
   });
 
   // IdempotencyKey cleanup — daily at 3:15am. The sync-push table grows on
-  // every mobile mutation. 7 days is a generous buffer over the actual client
-  // retry window (a mobile client sends + retries within seconds or minutes)
-  // and is far shorter than the previous 30 days — a device returning after
-  // a full 30 days offline could otherwise see its cached mutation IDs
-  // collide with someone else's keys or, worse, re-apply the same op if the
-  // row had been cleaned up just before it came back online.
+  // every mobile mutation.
+  //
+  // Retention = 30 days. Shorter (e.g. 7d) is tempting because the typical
+  // client retry window is seconds-to-minutes, but iOS `MutationQueue` has
+  // NO age-based pruning — a mutation enqueued while offline lives
+  // indefinitely and keeps its original idempotency key across restarts.
+  // A device offline >7d that reconnects would have its queued mutations
+  // replayed against an empty server-side cache, bypassing idempotency
+  // and potentially double-applying CREATEs. Keys are user-scoped
+  // (see `scopedKey` in routes/sync.ts), so cross-user collision isn't a
+  // concern; row volume is the only real cost, which 30d handles fine.
   cron.schedule("15 3 * * *", async () => {
     await withCronLock("idempotencyCleanup", LEASE.idempotencyCleanup, async () => {
-      const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       const { count } = await prisma.idempotencyKey.deleteMany({
         where: { createdAt: { lt: cutoff } },
       });

--- a/apps/api/src/jobs/cron.ts
+++ b/apps/api/src/jobs/cron.ts
@@ -4,13 +4,21 @@ import { prisma } from "../lib/prisma.js";
 import { getCalendarClient, watchCalendar, stopWatch } from "../lib/google-calendar.js";
 import { generateId } from "@brett/utils";
 import { createHmac } from "crypto";
+import { withCronLock } from "../lib/cron-lock.js";
 
-let webhookRenewalRunning = false;
-let reconciliationRunning = false;
-let granolaSyncRunning = false;
-let granolaSweepRunning = false;
-let scoutTickRunning = false;
-let newsletterCleanupRunning = false;
+// Per-job lease windows. The lease must outlive the job's actual runtime
+// but should be short enough that a crashed replica's lease expires before
+// the next scheduled tick. All values are conservative upper bounds.
+const LEASE = {
+  webhookRenewal: 30 * 60_000, // 30 min
+  reconciliation: 30 * 60_000,
+  granolaPerEvent: 10 * 60_000,
+  granolaSweep: 20 * 60_000,
+  scoutTick: 10 * 60_000,
+  verificationCleanup: 5 * 60_000,
+  idempotencyCleanup: 5 * 60_000,
+  newsletterCleanup: 5 * 60_000,
+} as const;
 
 export function startCronJobs(): void {
   // SSE heartbeat — every 30 seconds
@@ -25,12 +33,7 @@ export function startCronJobs(): void {
   // Webhook renewal — every 6 hours
   // Renew watches expiring within the next 24 hours
   cron.schedule("0 */6 * * *", async () => {
-    if (webhookRenewalRunning) {
-      console.log("[cron] Webhook renewal already running, skipping");
-      return;
-    }
-    webhookRenewalRunning = true;
-    try {
+    await withCronLock("webhookRenewal", LEASE.webhookRenewal, async () => {
       const cutoff = new Date(Date.now() + 24 * 60 * 60 * 1000);
       const expiring = await prisma.calendarList.findMany({
         where: {
@@ -91,22 +94,13 @@ export function startCronJobs(): void {
           console.error(`[cron] Failed to renew watch for calendar ${cal.id}:`, err);
         }
       }
-    } catch (err) {
-      console.error("[cron] Webhook renewal failed:", err);
-    } finally {
-      webhookRenewalRunning = false;
-    }
+    });
   });
 
   // Periodic reconciliation — every 4 hours
   // Run incremental sync for all connected accounts
   cron.schedule("0 */4 * * *", async () => {
-    if (reconciliationRunning) {
-      console.log("[cron] Reconciliation already running, skipping");
-      return;
-    }
-    reconciliationRunning = true;
-    try {
+    await withCronLock("reconciliation", LEASE.reconciliation, async () => {
       const accounts = await prisma.googleAccount.findMany({
         select: { id: true },
       });
@@ -123,18 +117,12 @@ export function startCronJobs(): void {
           console.error(`[cron] Reconciliation sync failed for account ${account.id}:`, err);
         }
       }
-    } catch (err) {
-      console.error("[cron] Reconciliation sync failed:", err);
-    } finally {
-      reconciliationRunning = false;
-    }
+    });
   });
 
   // Meeting notes: calendar-event-driven sync — every 5 minutes
   cron.schedule("*/5 * * * *", async () => {
-    if (granolaSyncRunning) return;
-    granolaSyncRunning = true;
-    try {
+    await withCronLock("granolaSync", LEASE.granolaPerEvent, async () => {
       const { meetingCoordinator } = await import("../services/meeting-providers/registry.js");
 
       const now = new Date();
@@ -172,18 +160,12 @@ export function startCronJobs(): void {
           console.error(`[cron] Meeting sync failed for event ${event.id}:`, err);
         }
       }
-    } catch (err) {
-      console.error("[cron] Post-meeting sync failed:", err);
-    } finally {
-      granolaSyncRunning = false;
-    }
+    });
   });
 
   // Meeting notes: periodic sweep — every 30 minutes
   cron.schedule("*/30 * * * *", async () => {
-    if (granolaSweepRunning) return;
-    granolaSweepRunning = true;
-    try {
+    await withCronLock("granolaSweep", LEASE.granolaSweep, async () => {
       const { meetingCoordinator } = await import("../services/meeting-providers/registry.js");
       const { isWithinWorkingHours } = await import("../services/granola-sync.js");
 
@@ -217,76 +199,57 @@ export function startCronJobs(): void {
           console.error(`[cron] Meeting sweep failed for ${userId}:`, err);
         }
       }
-    } catch (err) {
-      console.error("[cron] Meeting sweep failed:", err);
-    } finally {
-      granolaSweepRunning = false;
-    }
+    });
   });
 
   // Scout tick — every 5 minutes
   cron.schedule("*/5 * * * *", async () => {
-    if (scoutTickRunning) {
-      console.log("[cron] Scout tick already running, skipping");
-      return;
-    }
-    scoutTickRunning = true;
-    try {
+    await withCronLock("scoutTick", LEASE.scoutTick, async () => {
       const { tickScouts } = await import("../lib/scout-runner.js");
       await tickScouts();
-    } catch (err) {
-      console.error("[cron] Scout tick failed:", err);
-    } finally {
-      scoutTickRunning = false;
-    }
+    });
   });
 
   // Clean up expired Verification records (PKCE verifiers, email tokens, etc.) — every hour
   cron.schedule("0 * * * *", async () => {
-    try {
+    await withCronLock("verificationCleanup", LEASE.verificationCleanup, async () => {
       const { count } = await prisma.verification.deleteMany({
         where: { expiresAt: { lt: new Date() } },
       });
       if (count > 0) {
         console.log(`[cron] Cleaned up ${count} expired verification records`);
       }
-    } catch (err) {
-      console.error("[cron] Verification cleanup failed:", err);
-    }
+    });
   });
 
   // IdempotencyKey cleanup — daily at 3:15am. The sync-push table grows on
-  // every mobile mutation and has no built-in expiry. Keep 30 days to comfortably
-  // outlive client retry windows.
+  // every mobile mutation. 7 days is a generous buffer over the actual client
+  // retry window (a mobile client sends + retries within seconds or minutes)
+  // and is far shorter than the previous 30 days — a device returning after
+  // a full 30 days offline could otherwise see its cached mutation IDs
+  // collide with someone else's keys or, worse, re-apply the same op if the
+  // row had been cleaned up just before it came back online.
   cron.schedule("15 3 * * *", async () => {
-    try {
-      const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    await withCronLock("idempotencyCleanup", LEASE.idempotencyCleanup, async () => {
+      const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
       const { count } = await prisma.idempotencyKey.deleteMany({
         where: { createdAt: { lt: cutoff } },
       });
       if (count > 0) {
         console.log(`[cron] Cleaned up ${count} stale idempotency keys`);
       }
-    } catch (err) {
-      console.error("[cron] Idempotency key cleanup failed:", err);
-    }
+    });
   });
 
   // Pending newsletter cleanup — daily at 3am
   cron.schedule("0 3 * * *", async () => {
-    if (newsletterCleanupRunning) return;
-    newsletterCleanupRunning = true;
-    try {
+    await withCronLock("newsletterCleanup", LEASE.newsletterCleanup, async () => {
       const { cleanupExpiredPending } = await import("../lib/newsletter-ingest.js");
       const cleaned = await cleanupExpiredPending();
       if (cleaned > 0) {
         console.log(`[cron] Cleaned up ${cleaned} expired pending newsletters`);
       }
-    } catch (err) {
-      console.error("[cron] Pending newsletter cleanup failed:", err);
-    } finally {
-      newsletterCleanupRunning = false;
-    }
+    });
   });
 
   console.log("[cron] Started: Scout tick (5m)");

--- a/apps/api/src/lib/cron-lock.ts
+++ b/apps/api/src/lib/cron-lock.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "./prisma.js";
+import { Prisma } from "@brett/api-core";
+
+/**
+ * Identifier unique to this process — used so we can tell "I already hold
+ * the lease, renew it" apart from "another replica holds it, skip".
+ * Derived from pid + a random tag so two workers on the same host still
+ * get distinct holders.
+ */
+const INSTANCE_ID = `${process.pid}:${randomUUID().slice(0, 8)}`;
+
+/**
+ * Try to take or extend a lease on `jobName` for `leaseMs` milliseconds.
+ * Returns true if we got the lease, false if someone else already holds it.
+ *
+ * Safe to call from multiple replicas concurrently — the DB primary-key
+ * constraint serializes the contention. The first replica's upsert wins;
+ * subsequent replicas see an unexpired lease and bail.
+ */
+export async function tryAcquireCronLock(
+  jobName: string,
+  leaseMs: number,
+): Promise<boolean> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + leaseMs);
+
+  try {
+    // Atomic: succeeds if (a) no row exists, or (b) the row's lease has expired,
+    // or (c) we already hold it and are extending.
+    const result = await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO "CronLock" ("jobName", "holder", "acquiredAt", "expiresAt", "updatedAt")
+      VALUES (${jobName}, ${INSTANCE_ID}, ${now}, ${expiresAt}, ${now})
+      ON CONFLICT ("jobName") DO UPDATE
+        SET "holder" = EXCLUDED."holder",
+            "acquiredAt" = EXCLUDED."acquiredAt",
+            "expiresAt" = EXCLUDED."expiresAt",
+            "updatedAt" = EXCLUDED."updatedAt"
+        WHERE "CronLock"."expiresAt" < ${now}
+           OR "CronLock"."holder" = ${INSTANCE_ID}
+    `);
+    return result === 1;
+  } catch (err) {
+    console.error(`[cron-lock] acquire failed for ${jobName}:`, err);
+    return false;
+  }
+}
+
+/**
+ * Release the lease early. Safe — only deletes if we still hold it. If we
+ * crashed mid-job, the lease expires naturally and another replica picks
+ * it up on the next tick.
+ */
+export async function releaseCronLock(jobName: string): Promise<void> {
+  try {
+    await prisma.cronLock.deleteMany({
+      where: { jobName, holder: INSTANCE_ID },
+    });
+  } catch (err) {
+    console.error(`[cron-lock] release failed for ${jobName}:`, err);
+  }
+}
+
+/**
+ * Run `fn` under a distributed lease. Combines acquire + auto-release so
+ * callers don't have to remember the cleanup.
+ */
+export async function withCronLock<T>(
+  jobName: string,
+  leaseMs: number,
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  const acquired = await tryAcquireCronLock(jobName, leaseMs);
+  if (!acquired) return null;
+  try {
+    return await fn();
+  } finally {
+    await releaseCronLock(jobName);
+  }
+}

--- a/apps/api/src/lib/scout-memory.ts
+++ b/apps/api/src/lib/scout-memory.ts
@@ -217,18 +217,25 @@ export async function getActiveMemories(
   }));
 }
 
+// Even with a counter-based threshold, we want a hard floor on how often
+// consolidation can fire per scout to keep unexpected token costs down for
+// very active scouts. 12h means at most two consolidations per scout per day.
+const CONSOLIDATION_MIN_INTERVAL_MS = 12 * 60 * 60 * 1000;
+
 /**
  * Atomically increment consolidationRunCount and check if consolidation should run.
  * When the threshold is hit, the count resets to 0 in the same UPDATE — no race window
  * for concurrent runs to trigger duplicate consolidations.
  *
  * RETURNING evaluates against the NEW row: if count reset to 0, shouldConsolidate is true.
+ * The threshold trigger is also gated by CONSOLIDATION_MIN_INTERVAL_MS since
+ * the last consolidation so a high-cadence scout can't burn through tokens.
  */
 export async function incrementAndCheckConsolidation(
   scoutId: string,
 ): Promise<{ shouldConsolidate: boolean; threshold: number }> {
   const result = await prisma.$queryRaw<
-    Array<{ shouldConsolidate: boolean; consolidationThreshold: number }>
+    Array<{ shouldConsolidate: boolean; consolidationThreshold: number; lastConsolidatedAt: Date | null }>
   >`
     UPDATE "Scout"
     SET
@@ -240,7 +247,8 @@ export async function incrementAndCheckConsolidation(
     WHERE id = ${scoutId}
     RETURNING
       "consolidationRunCount" = 0 AS "shouldConsolidate",
-      "consolidationThreshold"
+      "consolidationThreshold",
+      "lastConsolidatedAt"
   `;
 
   if (!result || result.length === 0) {
@@ -248,8 +256,20 @@ export async function incrementAndCheckConsolidation(
   }
 
   const row = result[0]!;
+  const thresholdHit = Boolean(row.shouldConsolidate);
+
+  // Apply the cooldown AFTER the counter update so a suppressed trigger
+  // doesn't leave the counter stuck at 0 waiting for the next threshold.
+  let shouldConsolidate = thresholdHit;
+  if (thresholdHit && row.lastConsolidatedAt) {
+    const sinceLast = Date.now() - new Date(row.lastConsolidatedAt).getTime();
+    if (sinceLast < CONSOLIDATION_MIN_INTERVAL_MS) {
+      shouldConsolidate = false;
+    }
+  }
+
   return {
-    shouldConsolidate: Boolean(row.shouldConsolidate),
+    shouldConsolidate,
     threshold: row.consolidationThreshold,
   };
 }

--- a/apps/api/src/lib/scout-runner.ts
+++ b/apps/api/src/lib/scout-runner.ts
@@ -1031,6 +1031,7 @@ export async function runScout(scoutId: string): Promise<void> {
         data: {
           scoutId: scout.id,
           scoutRunId: run.id,
+          userId: scout.userId,
           type: finding.type,
           title: finding.title,
           description: finding.description,
@@ -1420,6 +1421,7 @@ export async function runBootstrapScout(scoutId: string): Promise<void> {
         data: {
           scoutId: scout.id,
           scoutRunId: run.id,
+          userId: scout.userId,
           type: finding.type,
           title: finding.title,
           description: finding.description,

--- a/apps/api/src/lib/scout-runner.ts
+++ b/apps/api/src/lib/scout-runner.ts
@@ -801,11 +801,26 @@ export async function runScout(scoutId: string): Promise<void> {
   };
 
   try {
-    // 3. Budget check
-    if (scout.budgetUsed >= scout.budgetTotal) {
+    // 3. Budget check — atomic reserve. We commit one budget slot up front
+    // with `WHERE budgetUsed < budgetTotal`; if the slot isn't available we
+    // abort the run. This closes the TOCTOU race the old read-then-write
+    // pattern had: two concurrent ticks could both see `used=199/total=200`,
+    // both pass the check, then both increment, silently overspending the
+    // user's budget.
+    const budgetReserved = await prisma.$executeRaw`
+      UPDATE "Scout"
+      SET "budgetUsed" = "budgetUsed" + 1
+      WHERE "id" = ${scout.id}
+        AND "budgetUsed" < "budgetTotal"
+        AND "deletedAt" IS NULL
+    `;
+    if (budgetReserved === 0) {
       await finalizeRun("skipped", { reasoning: "Monthly budget exhausted" });
       return;
     }
+    // Reflect the reservation on the in-memory scout so downstream code
+    // and the later "update cadence/nextRunAt" step see the right value.
+    scout.budgetUsed += 1;
 
     // 3b. Global system budget check
     const systemBudget = parseInt(process.env.SCOUT_SYSTEM_BUDGET_MONTHLY ?? "0", 10);
@@ -896,14 +911,11 @@ export async function runScout(scoutId: string): Promise<void> {
         reasoning: "No search results returned",
       });
 
-      // Update nextRunAt even on empty results
+      // Update nextRunAt even on empty results (budget was already reserved).
       const nextRunAt = new Date(Date.now() + scout.cadenceCurrentIntervalHours * 3600000);
       await prisma.scout.update({
         where: { id: scout.id },
-        data: {
-          budgetUsed: { increment: 1 },
-          nextRunAt,
-        },
+        data: { nextRunAt },
       });
 
       publishSSE(scout.userId, {
@@ -1058,12 +1070,11 @@ export async function runScout(scoutId: string): Promise<void> {
 
     const cadenceChanged = newInterval !== scout.cadenceCurrentIntervalHours;
 
-    // 11. Update scout — increment budgetUsed, set nextRunAt
+    // 11. Update scout — set nextRunAt (budget was reserved atomically in step 3)
     const nextRunAt = new Date(Date.now() + newInterval * 3600000);
     const updatedScout = await prisma.scout.update({
       where: { id: scout.id },
       data: {
-        budgetUsed: { increment: 1 },
         nextRunAt,
         cadenceCurrentIntervalHours: newInterval,
         cadenceReason: cadenceChanged ? judgment.cadenceReason : undefined,
@@ -1256,11 +1267,20 @@ export async function runBootstrapScout(scoutId: string): Promise<void> {
   };
 
   try {
-    if (scout.budgetUsed >= scout.budgetTotal) {
+    // Atomic budget reservation (same pattern as the regular tick path).
+    const bootstrapReserved = await prisma.$executeRaw`
+      UPDATE "Scout"
+      SET "budgetUsed" = "budgetUsed" + 1
+      WHERE "id" = ${scout.id}
+        AND "budgetUsed" < "budgetTotal"
+        AND "deletedAt" IS NULL
+    `;
+    if (bootstrapReserved === 0) {
       await finalizeRun("skipped", { reasoning: "Monthly budget exhausted — skipping bootstrap" });
       await prisma.scout.update({ where: { id: scout.id }, data: { bootstrapped: true, nextRunAt: scout.budgetResetAt } });
       return;
     }
+    scout.budgetUsed += 1;
 
     // System budget check
     const systemBudget = parseInt(process.env.SCOUT_SYSTEM_BUDGET_MONTHLY ?? "0", 10);
@@ -1336,7 +1356,7 @@ export async function runBootstrapScout(scoutId: string): Promise<void> {
       const nextRunAt = new Date(Date.now() + scout.cadenceCurrentIntervalHours * 3600000);
       await prisma.scout.update({
         where: { id: scout.id },
-        data: { bootstrapped: true, budgetUsed: { increment: 1 }, nextRunAt, statusLine: "Initial survey complete — no results found" },
+        data: { bootstrapped: true, nextRunAt, statusLine: "Initial survey complete — no results found" },
       });
 
       publishSSE(scout.userId, {
@@ -1440,7 +1460,6 @@ export async function runBootstrapScout(scoutId: string): Promise<void> {
       where: { id: scout.id },
       data: {
         bootstrapped: true,
-        budgetUsed: { increment: 1 },
         nextRunAt,
         statusLine: safeStatusLine || "Initial survey complete",
       },

--- a/apps/api/src/lib/sync-merge.ts
+++ b/apps/api/src/lib/sync-merge.ts
@@ -4,6 +4,20 @@ export interface MergeResult {
   hasChanges: boolean;
 }
 
+/**
+ * List fields the client declared as changed but for which it supplied no
+ * `previousValues[field]` baseline. These are unmergeable — we can't tell
+ * whether the client's edit is ahead of or stale against the server.
+ * Returned so the caller can reject the mutation cleanly instead of silently
+ * treating them as conflicts (server-wins), which historically lost edits.
+ */
+export function findMissingBaselines(
+  changedFields: string[],
+  previousValues: Record<string, unknown>,
+): string[] {
+  return changedFields.filter((field) => !(field in previousValues));
+}
+
 export function fieldLevelMerge(
   currentRecord: Record<string, unknown>,
   changedFields: string[],

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -36,15 +36,36 @@ export function rateLimiter(maxRequests: number, windowMs: number = 60_000) {
   return createLimiter<AuthEnv>((c) => c.get("user").id, maxRequests, windowMs);
 }
 
+/**
+ * Extract the client IP from the request.
+ *
+ * X-Forwarded-For is a comma-separated hop list; clients can spoof the
+ * left-most entries by sending their own XFF header. Railway's proxy
+ * APPENDS the real client IP as the right-most entry, so we trust that
+ * one. Taking the left-most (old behavior) let attackers bypass IP-based
+ * rate limits by rotating spoofed IPs in the header they controlled.
+ */
+function extractClientIp(xff: string | undefined): string {
+  if (!xff) return "unknown";
+  const parts = xff
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return "unknown";
+  return parts[parts.length - 1]!;
+}
+
 /** Rate limiter keyed by client IP. Use for unauthenticated routes (login, sign-up). */
 export function ipRateLimiter(maxRequests: number, windowMs: number = 60_000) {
   return createLimiter<Env>(
-    // x-forwarded-for from Railway's reverse proxy, fall back to remote address
-    (c) => c.req.header("x-forwarded-for")?.split(",")[0].trim() || "unknown",
+    (c) => extractClientIp(c.req.header("x-forwarded-for")),
     maxRequests,
     windowMs,
   );
 }
+
+// Exported for tests and for any other code that needs a trustworthy client IP.
+export { extractClientIp };
 
 /** Clear all rate limit windows. Used by tests to prevent cross-test rate limiting. */
 export function clearAllRateLimits(): void {

--- a/apps/api/src/routes/admin-embeddings.ts
+++ b/apps/api/src/routes/admin-embeddings.ts
@@ -5,9 +5,21 @@ import { runEmbeddingBackfill } from "../lib/embedding-backfill.js";
 
 const router = new Hono<AuthEnv>();
 
+// Single-flight guard. The backfill walks every user's items and calls the
+// embedding provider — without a guard, two admin clicks launch two parallel
+// walks that fight over DB connections and burn provider quota.
+let backfillRunning = false;
+
 router.post("/backfill", authMiddleware, requireAdmin, async (c) => {
-  // Fire-and-forget
-  runEmbeddingBackfill().catch((err) => console.error("[backfill] Fatal:", err));
+  if (backfillRunning) {
+    return c.json({ status: "already-running" }, 409);
+  }
+  backfillRunning = true;
+  runEmbeddingBackfill()
+    .catch((err) => console.error("[backfill] Fatal:", err))
+    .finally(() => {
+      backfillRunning = false;
+    });
 
   return c.json({ status: "started" });
 });

--- a/apps/api/src/routes/admin-embeddings.ts
+++ b/apps/api/src/routes/admin-embeddings.ts
@@ -5,9 +5,16 @@ import { runEmbeddingBackfill } from "../lib/embedding-backfill.js";
 
 const router = new Hono<AuthEnv>();
 
-// Single-flight guard. The backfill walks every user's items and calls the
-// embedding provider — without a guard, two admin clicks launch two parallel
-// walks that fight over DB connections and burn provider quota.
+// Single-flight guard, PER API INSTANCE. The backfill walks every user's
+// items and calls the embedding provider — without a guard, two admin
+// clicks launch two parallel walks that fight over DB connections and
+// burn provider quota.
+//
+// CAVEAT: this is an in-process boolean, so it only guards against two
+// clicks hitting the SAME replica. On a multi-replica deploy a second
+// click that routes to another replica would still launch a parallel
+// walk. If we ever scale past one replica, promote this to the CronLock
+// pattern in `lib/cron-lock.ts`.
 let backfillRunning = false;
 
 router.post("/backfill", authMiddleware, requireAdmin, async (c) => {

--- a/apps/api/src/routes/ai-config.ts
+++ b/apps/api/src/routes/ai-config.ts
@@ -73,8 +73,10 @@ aiConfig.get("/config", async (c) => {
 });
 
 // POST /ai/config — Add/update a provider key (validates before saving)
-// Rate limited: max 5 per minute
-aiConfig.post("/config", rateLimiter(5), async (c) => {
+// Rate limited aggressively: validateApiKey() makes upstream calls to
+// Anthropic/OpenAI/Google, so this is the brute-force surface for a leaked
+// bearer token trying to enumerate valid third-party keys.
+aiConfig.post("/config", rateLimiter(3), async (c) => {
   const user = c.get("user");
   const body = await c.req.json();
   const { provider, apiKey } = body as {

--- a/apps/api/src/routes/attachments.ts
+++ b/apps/api/src/routes/attachments.ts
@@ -21,7 +21,6 @@ const MAGIC_BYTES: Array<{ mime: string; bytes: number[]; offset?: number }> = [
   { mime: "image/jpeg", bytes: [0xFF, 0xD8, 0xFF] },
   { mime: "image/png", bytes: [0x89, 0x50, 0x4E, 0x47] },
   { mime: "image/gif", bytes: [0x47, 0x49, 0x46, 0x38] },
-  { mime: "image/webp", bytes: [0x57, 0x45, 0x42, 0x50], offset: 8 },
   { mime: "application/pdf", bytes: [0x25, 0x50, 0x44, 0x46] },
   { mime: "application/zip", bytes: [0x50, 0x4B, 0x03, 0x04] },
   { mime: "application/gzip", bytes: [0x1F, 0x8B] },
@@ -29,6 +28,22 @@ const MAGIC_BYTES: Array<{ mime: string; bytes: number[]; offset?: number }> = [
 
 function detectMimeFromBytes(buffer: ArrayBuffer): string | null {
   const view = new Uint8Array(buffer);
+  // WebP = `RIFF` at offset 0 + `WEBP` at offset 8. Checking only offset 8
+  // (the previous behavior) let an attacker prepend 8 arbitrary bytes to a
+  // non-WebP payload and have it detected as WebP.
+  if (
+    view.length >= 12 &&
+    view[0] === 0x52 &&
+    view[1] === 0x49 &&
+    view[2] === 0x46 &&
+    view[3] === 0x46 &&
+    view[8] === 0x57 &&
+    view[9] === 0x45 &&
+    view[10] === 0x42 &&
+    view[11] === 0x50
+  ) {
+    return "image/webp";
+  }
   for (const sig of MAGIC_BYTES) {
     const offset = sig.offset ?? 0;
     if (view.length < offset + sig.bytes.length) continue;

--- a/apps/api/src/routes/auth-ios.ts
+++ b/apps/api/src/routes/auth-ios.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { prisma } from "../lib/prisma.js";
-import { ipRateLimiter } from "../middleware/rate-limit.js";
+import { extractClientIp, ipRateLimiter } from "../middleware/rate-limit.js";
 import { getIOSGoogleVerifier } from "../lib/ios-google-verifier.js";
 import {
   signInWithIOSGoogleIdToken,
@@ -58,12 +58,12 @@ authIOS.post("/google/token", ipRateLimiter(10, 60_000), async (c) => {
   }
 
   try {
-    const forwardedFor = c.req.header("x-forwarded-for");
+    const clientIp = extractClientIp(c.req.header("x-forwarded-for"));
     const result = await signInWithIOSGoogleIdToken({
       idToken,
       verifier,
       prisma,
-      ipAddress: forwardedFor ? forwardedFor.split(",")[0]!.trim() : null,
+      ipAddress: clientIp === "unknown" ? null : clientIp,
       userAgent: c.req.header("user-agent") ?? null,
     });
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -13,10 +13,15 @@ authRouter.post("/sign-up/*", ipRateLimiter(5, 60_000));
 // Sign the desktop OAuth state to prevent forgery
 const AUTH_SECRET = process.env.BETTER_AUTH_SECRET || "";
 
-function signState(state: string, port: number): string {
+// Reject OAuth callbacks where more than this many ms have elapsed since
+// `/desktop/google` was served. A legitimate flow completes in ~10s; 15min
+// covers slow users without leaving stolen `state` values useful indefinitely.
+const OAUTH_STATE_MAX_AGE_MS = 15 * 60 * 1000;
+
+function signState(state: string, port: number, issuedAt: number): string {
   return crypto
     .createHmac("sha256", AUTH_SECRET)
-    .update(`${state}:${port}`)
+    .update(`${state}:${port}:${issuedAt}`)
     .digest("hex");
 }
 
@@ -40,8 +45,12 @@ authRouter.get("/desktop/google", (c) => {
   const callbackURL = new URL("/api/auth/desktop-callback", baseURL);
   callbackURL.searchParams.set("port", String(portNum));
   callbackURL.searchParams.set("state", state);
+  // Issue timestamp rides through the OAuth as a URL param and is part of
+  // the signed payload — lets /desktop-callback reject stale state values.
+  const issuedAt = Date.now();
+  callbackURL.searchParams.set("ts", String(issuedAt));
   // Attach HMAC signature so desktop-callback can verify this flow was initiated here
-  callbackURL.searchParams.set("sig", signState(state, portNum));
+  callbackURL.searchParams.set("sig", signState(state, portNum, issuedAt));
 
   // Render a page that POSTs from the browser — preserves Set-Cookie from better-auth
   const signInURL = new URL("/api/auth/sign-in/social", baseURL).toString();
@@ -78,11 +87,12 @@ authRouter.get("/desktop-callback", (c) => {
   const port = c.req.query("port");
   const state = c.req.query("state");
   const sig = c.req.query("sig");
+  const ts = c.req.query("ts");
 
   if (!sessionToken) {
     return c.text("Authentication failed — no session token", 401);
   }
-  if (!port || !state || !sig) {
+  if (!port || !state || !sig || !ts) {
     return c.text("Missing required parameters", 400);
   }
 
@@ -92,9 +102,26 @@ authRouter.get("/desktop-callback", (c) => {
     return c.text("Invalid port", 400);
   }
 
+  // Reject stale OAuth flows — the signed `ts` is how long ago /desktop/google
+  // minted this `state`. Stops replay of intercepted callbacks days later.
+  const issuedAt = Number(ts);
+  if (!Number.isInteger(issuedAt) || issuedAt <= 0) {
+    return c.text("Invalid timestamp", 400);
+  }
+  const age = Date.now() - issuedAt;
+  if (age < 0 || age > OAUTH_STATE_MAX_AGE_MS) {
+    return c.text("OAuth request expired — please try again", 403);
+  }
+
   // Verify HMAC signature — ensures this callback was initiated by /desktop/google
-  const expectedSig = signState(state, portNum);
-  if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expectedSig))) {
+  // and that the port/state/timestamp tuple hasn't been tampered with.
+  const expectedSig = signState(state, portNum, issuedAt);
+  const sigBuf = Buffer.from(sig);
+  const expBuf = Buffer.from(expectedSig);
+  if (
+    sigBuf.length !== expBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expBuf)
+  ) {
     return c.text("Invalid signature", 403);
   }
 

--- a/apps/api/src/routes/devices.ts
+++ b/apps/api/src/routes/devices.ts
@@ -32,10 +32,19 @@ export const devices = new Hono<AuthEnv>()
     const existing = await prisma.deviceToken.findUnique({ where: { token } });
 
     if (existing) {
-      // Update existing token — update platform and appVersion
+      // Refuse to reassign a token that's registered to another user.
+      // Without this check any authenticated user could claim any known
+      // device token by re-registering it, hijacking that device's push
+      // notifications.
+      if (existing.userId !== user.id) {
+        return c.json(
+          { error: "Token already registered to a different account" },
+          409,
+        );
+      }
       const updated = await prisma.deviceToken.update({
         where: { token },
-        data: { platform, appVersion, userId: user.id },
+        data: { platform, appVersion },
       });
       return c.json(updated, 200);
     }

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -16,6 +16,7 @@ const MAX_BREADCRUMBS = 20;
 const MAX_ENTRY_LENGTH = 2000;
 const MAX_ISSUE_BODY = 65_000;
 const MAX_SCREENSHOT_BASE64 = 4_000_000; // ~3MB decoded
+const MAX_SCREENSHOT_BYTES = 3_000_000; // hard cap on the decoded buffer
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -116,8 +117,14 @@ feedback.post(
         } else {
           const imageBuffer = Buffer.from(diag.screenshot, "base64");
 
+          // Post-decode byte-size check. Base64 can encode payloads
+          // compactly, so the string-length cap above is a rough ceiling —
+          // this one is the actual file-size guard.
+          if (imageBuffer.length > MAX_SCREENSHOT_BYTES) {
+            console.error("[feedback] Screenshot decoded bytes exceed limit, skipping");
+          }
           // Validate PNG magic bytes
-          if (imageBuffer.length < 8 || !imageBuffer.subarray(0, 8).equals(PNG_MAGIC)) {
+          else if (imageBuffer.length < 8 || !imageBuffer.subarray(0, 8).equals(PNG_MAGIC)) {
             console.error("[feedback] Screenshot rejected: not a valid PNG");
           } else {
             const key = `feedback/${crypto.randomBytes(16).toString("hex")}.png`;

--- a/apps/api/src/routes/newsletters.ts
+++ b/apps/api/src/routes/newsletters.ts
@@ -18,7 +18,37 @@ const MAX_BODY_SIZE = 2 * 1024 * 1024; // 2 MB
 
 const webhookRouter = new Hono();
 
-webhookRouter.post("/email/ingest/:secret", async (c) => {
+/**
+ * Extract the secret from either:
+ *  - Authorization: Basic <base64(user:pass)>   (preferred — Postmark's
+ *    inbound webhook URL accepts `https://user:pass@host/...` and rewrites
+ *    it to this header, keeping the secret out of proxy logs and referrer
+ *    chains), or
+ *  - the `:secret` path param (legacy; kept for back-compat during rollover).
+ *
+ * The password half of Basic creds is the shared secret. The username is
+ * ignored — Postmark requires one, but we don't use it.
+ */
+function extractIngestSecret(c: {
+  req: {
+    header: (name: string) => string | undefined;
+    param: (name: string) => string;
+  };
+}): string {
+  const auth = c.req.header("authorization") || "";
+  if (auth.toLowerCase().startsWith("basic ")) {
+    try {
+      const decoded = Buffer.from(auth.slice(6).trim(), "base64").toString("utf-8");
+      const colonIdx = decoded.indexOf(":");
+      if (colonIdx !== -1) return decoded.slice(colonIdx + 1);
+    } catch {
+      // fall through to path param
+    }
+  }
+  return c.req.param("secret") || "";
+}
+
+async function handleNewsletterIngest(c: any) {
   // 1. Validate secret
   const expected = process.env.NEWSLETTER_INGEST_SECRET;
   if (!expected) {
@@ -26,7 +56,7 @@ webhookRouter.post("/email/ingest/:secret", async (c) => {
     return c.json({ error: "Server misconfigured" }, 500);
   }
 
-  const provided = c.req.param("secret");
+  const provided = extractIngestSecret(c);
   if (!verifyIngestSecret(provided, expected)) {
     return c.json({ error: "Unauthorized" }, 401);
   }
@@ -124,7 +154,17 @@ webhookRouter.post("/email/ingest/:secret", async (c) => {
     console.error("[newsletter-webhook] DB error:", err);
     return c.json({ error: "Internal error" }, 500);
   }
-});
+}
+
+// Preferred path — Postmark's Inbound Webhook URL can embed Basic Auth
+// credentials (`https://user:pass@host/webhooks/email/ingest`). Postmark
+// rewrites them to an `Authorization: Basic …` header, keeping the shared
+// secret out of URL paths, referrer headers, and proxy access logs.
+webhookRouter.post("/email/ingest", handleNewsletterIngest);
+
+// Legacy path — secret in URL. Retained so existing Postmark configs keep
+// working during rollover. Safe to remove once all webhooks use Basic Auth.
+webhookRouter.post("/email/ingest/:secret", handleNewsletterIngest);
 
 // ── Sender Management Router (authed) ──
 

--- a/apps/api/src/routes/newsletters.ts
+++ b/apps/api/src/routes/newsletters.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { authMiddleware, type AuthEnv } from "../middleware/auth.js";
 import {
   extractEmail,
@@ -29,12 +29,7 @@ const webhookRouter = new Hono();
  * The password half of Basic creds is the shared secret. The username is
  * ignored — Postmark requires one, but we don't use it.
  */
-function extractIngestSecret(c: {
-  req: {
-    header: (name: string) => string | undefined;
-    param: (name: string) => string;
-  };
-}): string {
+function extractIngestSecret(c: Context): string {
   const auth = c.req.header("authorization") || "";
   if (auth.toLowerCase().startsWith("basic ")) {
     try {
@@ -48,7 +43,7 @@ function extractIngestSecret(c: {
   return c.req.param("secret") || "";
 }
 
-async function handleNewsletterIngest(c: any) {
+async function handleNewsletterIngest(c: Context) {
   // 1. Validate secret
   const expected = process.env.NEWSLETTER_INGEST_SECRET;
   if (!expected) {

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -185,11 +185,20 @@ export const sync = new Hono<AuthEnv>()
       const cursor = cursors[table] ?? null;
 
       // Build base where clause for active records.
-      // Most models have a direct userId column. ScoutFinding is the exception:
-      // ownership goes through scout.userId (a relation filter).
+      // Most models have a direct userId column. ScoutFinding now has one
+      // too (nullable during the rollout — release A of the two-release
+      // flow that ends with NOT NULL). Prefer the direct column when
+      // present so the query hits the new `(userId, updatedAt)` composite
+      // index, but fall back to the relation filter for any legacy row
+      // whose `userId` isn't backfilled yet. Release B drops the OR.
       const ownershipFilter: any =
         table === "scout_findings"
-          ? { scout: { userId: user.id } }
+          ? {
+              OR: [
+                { userId: user.id },
+                { userId: null, scout: { userId: user.id } },
+              ],
+            }
           : { userId: user.id };
 
       // Normal query — soft-delete extension auto-filters deletedAt IS NULL

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@brett/api-core";
 import { prisma } from "../lib/prisma.js";
 import { authMiddleware, type AuthEnv } from "../middleware/auth.js";
 import { rateLimiter } from "../middleware/rate-limit.js";
-import { fieldLevelMerge } from "../lib/sync-merge.js";
+import { fieldLevelMerge, findMissingBaselines } from "../lib/sync-merge.js";
 import { publishSSE } from "../lib/sse.js";
 import { detectContentType } from "@brett/utils";
 import { runExtraction } from "../lib/content-extractor.js";
@@ -79,6 +79,46 @@ const STALE_CURSOR_DAYS = 30;
 const MAX_MUTATIONS = 50;
 const MAX_BODY_SIZE = 1_048_576; // 1MB
 
+/**
+ * Cursor is `"<ISO-8601 timestamp>|<row id>"` or, for clients on the old
+ * format, just `"<ISO-8601 timestamp>"`. We always emit the pipe form; we
+ * still accept the old form so an existing client's stored cursor keeps
+ * working across the deploy.
+ *
+ * Keyset pagination over `(updatedAt, id)` fixes a boundary bug where many
+ * rows sharing the exact same `updatedAt` could get sliced across pages
+ * and the skipped ones permanently missed on the next pull.
+ */
+function parseCursor(raw: string | null | undefined): { ts: Date; id: string | null } | null {
+  if (!raw) return null;
+  const pipe = raw.indexOf("|");
+  if (pipe === -1) {
+    const ts = new Date(raw);
+    return Number.isNaN(ts.getTime()) ? null : { ts, id: null };
+  }
+  const ts = new Date(raw.slice(0, pipe));
+  if (Number.isNaN(ts.getTime())) return null;
+  return { ts, id: raw.slice(pipe + 1) };
+}
+
+function formatCursor(updatedAt: Date | string, id: string): string {
+  const iso = updatedAt instanceof Date ? updatedAt.toISOString() : updatedAt;
+  return `${iso}|${id}`;
+}
+
+function applyCursorFilter(where: Record<string, unknown>, cursor: string | null | undefined): void {
+  const parsed = parseCursor(cursor);
+  if (!parsed) return;
+  if (parsed.id === null) {
+    where.updatedAt = { gt: parsed.ts };
+    return;
+  }
+  where.OR = [
+    { updatedAt: { gt: parsed.ts } },
+    { updatedAt: parsed.ts, id: { gt: parsed.id } },
+  ];
+}
+
 export const sync = new Hono<AuthEnv>()
   .use("/*", authMiddleware)
 
@@ -105,12 +145,16 @@ export const sync = new Hono<AuthEnv>()
 
     const cursors = body.cursors ?? {};
 
-    // Check for stale cursors (>30 days old)
+    // Check for stale cursors (>30 days old). Handle both the legacy
+    // plain-timestamp form and the new `"<ts>|<id>"` keyset form.
     for (const cursor of Object.values(cursors)) {
       if (cursor) {
-        const cursorDate = new Date(cursor);
+        const parsed = parseCursor(cursor);
+        if (!parsed) {
+          return c.json({ error: "Invalid cursor" }, 400);
+        }
         const staleCutoff = new Date(Date.now() - STALE_CURSOR_DAYS * 24 * 60 * 60 * 1000);
-        if (cursorDate < staleCutoff) {
+        if (parsed.ts < staleCutoff) {
           return c.json({
             changes: {},
             cursors: {},
@@ -150,19 +194,18 @@ export const sync = new Hono<AuthEnv>()
 
       // Normal query — soft-delete extension auto-filters deletedAt IS NULL
       const where: any = { ...ownershipFilter };
-      if (cursor) {
-        where.updatedAt = { gt: new Date(cursor) };
-      }
+      applyCursorFilter(where, cursor);
 
       // Special handling for calendar_events: scope to last 90 days + future
       if (table === "calendar_events") {
         where.startTime = { gte: ninetyDaysAgo };
       }
 
-      // Query active records (upserted)
+      // Keyset pagination: order by (updatedAt, id) so rows sharing a
+      // millisecond don't get split across pages and silently lost.
       const upserted = await model.findMany({
         where,
-        orderBy: { updatedAt: "asc" },
+        orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
         take: limit + 1, // +1 to detect hasMore
       });
 
@@ -171,9 +214,7 @@ export const sync = new Hono<AuthEnv>()
         ...ownershipFilter,
         deletedAt: { not: null }, // key exists -> bypasses extension
       };
-      if (cursor) {
-        tombstoneWhere.updatedAt = { gt: new Date(cursor) };
-      }
+      applyCursorFilter(tombstoneWhere, cursor);
       // Special handling for calendar_events tombstones
       if (table === "calendar_events") {
         tombstoneWhere.startTime = { gte: ninetyDaysAgo };
@@ -188,7 +229,7 @@ export const sync = new Hono<AuthEnv>()
         where: tombstoneWhere,
         select: { id: true, updatedAt: true },
         take: limit,
-        orderBy: { updatedAt: "asc" },
+        orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
       });
       const deleted = tombstones.map((r: any) => r.id);
 
@@ -196,22 +237,21 @@ export const sync = new Hono<AuthEnv>()
       const hasMore = upserted.length > limit;
       const records = hasMore ? upserted.slice(0, limit) : upserted;
 
-      // Compute new cursor from max(upserted, tombstones) so neither stream
-      // gets silently truncated on the next pull.
-      const toIso = (v: unknown) =>
-        v instanceof Date ? v.toISOString() : String(v);
-      const maxUpserted = records.length > 0
-        ? toIso(records[records.length - 1].updatedAt)
-        : null;
-      const maxTombstone = tombstones.length > 0
-        ? toIso(tombstones[tombstones.length - 1].updatedAt)
-        : null;
-      const advanced = [maxUpserted, maxTombstone]
-        .filter((v): v is string => v !== null)
-        .sort()
-        .pop();
-      if (advanced) {
-        newCursors[table] = advanced;
+      // Compute new cursor from the latest row across upserts and tombstones.
+      // Cursor is `"<updatedAt>|<id>"` so clients can resume on the exact row
+      // boundary without skipping siblings that share a timestamp.
+      const lastUpserted = records.length > 0 ? records[records.length - 1] : null;
+      const lastTombstone = tombstones.length > 0 ? tombstones[tombstones.length - 1] : null;
+      let winner: { updatedAt: Date | string; id: string } | null = null;
+      if (lastUpserted && lastTombstone) {
+        const a = new Date(lastUpserted.updatedAt).getTime();
+        const b = new Date(lastTombstone.updatedAt).getTime();
+        winner = a >= b ? lastUpserted : lastTombstone;
+      } else {
+        winner = lastUpserted ?? lastTombstone;
+      }
+      if (winner) {
+        newCursors[table] = formatCursor(winner.updatedAt, winner.id);
       } else if (cursor) {
         // Preserve existing cursor if no new records
         newCursors[table] = cursor;
@@ -460,6 +500,20 @@ async function processUpdate(
       idempotencyKey: mutation.idempotencyKey,
       status: "error",
       error: `Fields not mutable: ${illegalFields.join(", ")}`,
+    };
+  }
+
+  // Require a baseline for every declared change. Without one, the
+  // field-level merge can't tell whether the client is ahead of or stale
+  // against the server, so it used to silently treat the field as
+  // conflicted (server-wins) and drop the client's edit. Better to reject
+  // up front so buggy clients get a clear signal.
+  const missingBaselines = findMissingBaselines(changedFields, previousValues);
+  if (missingBaselines.length > 0) {
+    return {
+      idempotencyKey: mutation.idempotencyKey,
+      status: "error",
+      error: `Missing previousValues for fields: ${missingBaselines.join(", ")}`,
     };
   }
 

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -642,20 +642,34 @@ async function registerWebhook(
   }
 }
 
-/** Strip PII from raw Google event before storing. Keep structure for debugging. */
+/**
+ * Strip PII from raw Google event before storing.
+ *
+ * `rawGoogleEvent` is a debugging breadcrumb — the canonical data lives in
+ * typed columns on CalendarEvent. So we only keep fields useful for
+ * troubleshooting sync issues (IDs, timing, statuses) and drop everything
+ * that would leak sensitive content if logs/backups were ever exposed.
+ */
 function scrubRawEvent(event: calendar_v3.Schema$Event): Record<string, unknown> {
-  const { attendees, creator, organizer, description, conferenceData, extendedProperties, ...safe } = event;
   return {
-    ...safe,
-    attendees: attendees?.map((a) => ({
-      responseStatus: a.responseStatus,
-      self: a.self,
-      organizer: a.organizer,
-    })),
-    organizer: organizer ? { self: organizer.self } : undefined,
-    creator: creator ? { self: creator.self } : undefined,
-    // Strip description — may contain sensitive content like dial-in PINs
-    description: description ? "[redacted]" : undefined,
+    id: event.id,
+    iCalUID: event.iCalUID,
+    etag: event.etag,
+    status: event.status,
+    created: event.created,
+    updated: event.updated,
+    start: event.start,
+    end: event.end,
+    recurringEventId: event.recurringEventId,
+    eventType: event.eventType,
+    visibility: event.visibility,
+    transparency: event.transparency,
+    attendeeCount: event.attendees?.length ?? 0,
+    hasLocation: Boolean(event.location),
+    hasDescription: Boolean(event.description),
+    hasConferenceData: Boolean(event.conferenceData),
+    organizerSelf: event.organizer?.self ?? false,
+    creatorSelf: event.creator?.self ?? false,
   };
 }
 

--- a/apps/api/src/services/meeting-matcher.ts
+++ b/apps/api/src/services/meeting-matcher.ts
@@ -56,13 +56,17 @@ export function findBestMatch(
     );
     const score = titleScore * TITLE_WEIGHT + attendeeScore * ATTENDEE_WEIGHT;
 
-    // When we have no attendee signal on either side (common for 1:1
-    // calls and scratch Granola notes), require a tight time overlap.
-    // Otherwise two generic "Team Sync" events on the same day would
-    // match each other on title alone and pollute both with wrong notes.
-    const hasAttendeeSignal =
-      meeting.attendees.length > 0 && candidate.attendees.length > 0;
-    if (!hasAttendeeSignal && !hasTightTimeOverlap(meeting, candidate)) continue;
+    // When BOTH sides have zero attendees (common for 1:1 calls and
+    // scratch Granola notes), require a tight time overlap. Otherwise
+    // two generic "Team Sync" events on the same day would match each
+    // other on title alone and pollute both with wrong notes.
+    //
+    // If even one side has attendees, attendeeScore carries some signal
+    // (even when it's 0) — the 0.5 CONFIDENCE_THRESHOLD check below is
+    // the primary filter for weak matches there.
+    const bothMissingAttendees =
+      meeting.attendees.length === 0 && candidate.attendees.length === 0;
+    if (bothMissingAttendees && !hasTightTimeOverlap(meeting, candidate)) continue;
 
     if (score >= CONFIDENCE_THRESHOLD && (!bestMatch || score > bestMatch.score)) {
       bestMatch = { id: candidate.id, score };

--- a/apps/api/src/services/meeting-matcher.ts
+++ b/apps/api/src/services/meeting-matcher.ts
@@ -2,6 +2,11 @@ const TIME_TOLERANCE_MS = 3 * 60 * 60 * 1000; // 3 hours — Granola reports act
 const CONFIDENCE_THRESHOLD = 0.5;
 const TITLE_WEIGHT = 0.6;
 const ATTENDEE_WEIGHT = 0.4;
+// Tight window used when we have no attendee signal to lean on — a "Team
+// Sync" Granola note landing in the same day as a different "Team Sync"
+// calendar event shouldn't match unless the times line up much more closely
+// than the generous TIME_TOLERANCE_MS allows.
+const NO_ATTENDEE_TIME_TOLERANCE_MS = 30 * 60 * 1000; // 30 min
 
 export interface MatchCandidate {
   id: string;
@@ -51,6 +56,14 @@ export function findBestMatch(
     );
     const score = titleScore * TITLE_WEIGHT + attendeeScore * ATTENDEE_WEIGHT;
 
+    // When we have no attendee signal on either side (common for 1:1
+    // calls and scratch Granola notes), require a tight time overlap.
+    // Otherwise two generic "Team Sync" events on the same day would
+    // match each other on title alone and pollute both with wrong notes.
+    const hasAttendeeSignal =
+      meeting.attendees.length > 0 && candidate.attendees.length > 0;
+    if (!hasAttendeeSignal && !hasTightTimeOverlap(meeting, candidate)) continue;
+
     if (score >= CONFIDENCE_THRESHOLD && (!bestMatch || score > bestMatch.score)) {
       bestMatch = { id: candidate.id, score };
     }
@@ -62,6 +75,15 @@ export function findBestMatch(
 function hasTimeOverlap(a: MeetingInput, b: MatchCandidate): boolean {
   const aStart = a.startTime.getTime() - TIME_TOLERANCE_MS;
   const aEnd = a.endTime.getTime() + TIME_TOLERANCE_MS;
+  const bStart = b.startTime.getTime();
+  const bEnd = b.endTime.getTime();
+
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function hasTightTimeOverlap(a: MeetingInput, b: MatchCandidate): boolean {
+  const aStart = a.startTime.getTime() - NO_ATTENDEE_TIME_TOLERANCE_MS;
+  const aEnd = a.endTime.getTime() + NO_ATTENDEE_TIME_TOLERANCE_MS;
   const bStart = b.startTime.getTime();
   const bEnd = b.endTime.getTime();
 

--- a/apps/api/src/services/weather.ts
+++ b/apps/api/src/services/weather.ts
@@ -122,6 +122,11 @@ interface GoogleAqiResponse {
   indexes?: GoogleAqiIndex[];
 }
 
+// Google's APIs are usually fast, but a stalled socket would otherwise hang
+// the briefing pipeline until the OS socket timeout (30s+). 6s is plenty
+// for a single upstream call.
+const WEATHER_FETCH_TIMEOUT_MS = 6_000;
+
 /** Fetch current AQI from Google Air Quality API. Returns null on failure (non-critical). */
 async function fetchAirQuality(latitude: number, longitude: number, key: string): Promise<AirQuality | undefined> {
   try {
@@ -132,6 +137,7 @@ async function fetchAirQuality(latitude: number, longitude: number, key: string)
         location: { latitude, longitude },
         extraComputations: ["DOMINANT_POLLUTANT_CONCENTRATION"],
       }),
+      signal: AbortSignal.timeout(WEATHER_FETCH_TIMEOUT_MS),
     });
     if (!res.ok) return undefined;
 
@@ -160,11 +166,13 @@ export async function fetchForecast(
   const key = getGoogleWeatherApiKey();
   const loc = `location.latitude=${latitude}&location.longitude=${longitude}`;
 
-  // Fetch weather (current, hourly, daily) + AQI in parallel
+  // Fetch weather (current, hourly, daily) + AQI in parallel, each with a
+  // bounded timeout so one stuck upstream can't hang the briefing pipeline.
+  const signal = AbortSignal.timeout(WEATHER_FETCH_TIMEOUT_MS);
   const [currentRes, hourlyRes, dailyRes, airQuality] = await Promise.all([
-    fetch(`${GOOGLE_WEATHER_BASE}/currentConditions:lookup?key=${key}&${loc}`),
-    fetch(`${GOOGLE_WEATHER_BASE}/forecast/hours:lookup?key=${key}&${loc}&hours=168`),
-    fetch(`${GOOGLE_WEATHER_BASE}/forecast/days:lookup?key=${key}&${loc}&days=7&pageSize=7`),
+    fetch(`${GOOGLE_WEATHER_BASE}/currentConditions:lookup?key=${key}&${loc}`, { signal }),
+    fetch(`${GOOGLE_WEATHER_BASE}/forecast/hours:lookup?key=${key}&${loc}&hours=168`, { signal }),
+    fetch(`${GOOGLE_WEATHER_BASE}/forecast/days:lookup?key=${key}&${loc}&days=7&pageSize=7`, { signal }),
     fetchAirQuality(latitude, longitude, key),
   ]);
 
@@ -247,7 +255,9 @@ export async function searchCities(query: string): Promise<GeocodingResult[]> {
     language: "en",
   });
 
-  const res = await fetch(`${GEOCODING_BASE}?${params}`);
+  const res = await fetch(`${GEOCODING_BASE}?${params}`, {
+    signal: AbortSignal.timeout(WEATHER_FETCH_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new Error(`Open-Meteo geocoding failed: ${res.status} ${res.statusText}`);
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7,6 +7,31 @@ import Store from "electron-store";
 import { scanThings3, readThings3 } from "./things3";
 import { initAutoUpdater, quitAndInstall, isUpdateReady, getDownloadedVersion, setAutoInstallOnQuit, checkForUpdatesNow } from "./updater";
 
+/**
+ * Only allow `shell.openExternal` to open http(s) URLs. Without this a
+ * malicious link in rendered content (pasted in chat, from a Scout finding,
+ * embedded in a newsletter) could trigger `javascript:`, `file://`, or an
+ * arbitrary protocol handler when clicked.
+ */
+function isSafeExternalUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function openExternalSafe(rawUrl: string): void {
+  if (isSafeExternalUrl(rawUrl)) {
+    shell.openExternal(rawUrl).catch((err) => {
+      console.error("[main] shell.openExternal failed:", err);
+    });
+  } else {
+    console.warn("[main] refusing to open non-http(s) URL:", rawUrl);
+  }
+}
+
 // #3: Load API URL from main process config — never accept from renderer
 // Reads from api-config.json generated at build time, falls back to env var
 function getApiURL(): string {
@@ -158,6 +183,12 @@ ipcMain.handle("get-system-info", () => {
 ipcMain.handle("capture-screenshot", async () => {
   const win = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
   if (!win) throw new Error("No available window");
+  // Close DevTools before capturing so we never accidentally include the
+  // Network tab (which shows bearer tokens on outgoing requests) in a
+  // feedback screenshot.
+  if (win.webContents.isDevToolsOpened()) {
+    win.webContents.closeDevTools();
+  }
   const image = await win.webContents.capturePage();
   // Resize to max 1280px wide to limit payload size
   const size = image.getSize();
@@ -221,12 +252,22 @@ ipcMain.handle("start-google-oauth", () => {
   return new Promise<string>((resolve, reject) => {
     const state = crypto.randomBytes(32).toString("hex");
     let settled = false;
+    // Track live sockets so we can destroy them on teardown — server.close()
+    // only stops new connections; existing keep-alives can linger and hold
+    // the ephemeral port, which matters if the user retries OAuth rapidly.
+    const activeSockets = new Set<import("net").Socket>();
 
     function settle() {
       if (!settled) {
         settled = true;
         oauthInProgress = false;
       }
+    }
+
+    function shutdownServer() {
+      for (const sock of activeSockets) sock.destroy();
+      activeSockets.clear();
+      server.close();
     }
 
     const server = http.createServer((req, res) => {
@@ -268,13 +309,18 @@ ipcMain.handle("start-google-oauth", () => {
       `);
 
       settle();
-      server.close();
+      shutdownServer();
 
       // Focus the app window
       const win = BrowserWindow.getAllWindows()[0];
       if (win) win.focus();
 
       resolve(token);
+    });
+
+    server.on("connection", (socket) => {
+      activeSockets.add(socket);
+      socket.on("close", () => activeSockets.delete(socket));
     });
 
     // Listen on random port on localhost only
@@ -288,14 +334,23 @@ ipcMain.handle("start-google-oauth", () => {
 
       const port = address.port;
       const oauthURL = `${API_URL}/api/auth/desktop/google?port=${port}&state=${state}`;
-      shell.openExternal(oauthURL);
+      // Defensive: if API_URL ever turns up blank or malformed (bad build
+      // config, env-var poisoning), fail loudly rather than handing a
+      // junk URL to the OS handler.
+      if (!isSafeExternalUrl(oauthURL)) {
+        settle();
+        shutdownServer();
+        reject(new Error("OAuth URL is not a valid http(s) URL — API_URL may be misconfigured"));
+        return;
+      }
+      openExternalSafe(oauthURL);
     });
 
     // #10: Timeout after 2 minutes (reduced from 5)
     setTimeout(() => {
       if (!settled) {
         settle();
-        server.close();
+        shutdownServer();
         reject(new Error("OAuth timed out"));
       }
     }, 2 * 60 * 1000);
@@ -326,9 +381,14 @@ function createWindow() {
     trafficLightPosition: { x: 20, y: 18 },
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
+      // Defense-in-depth — these are Electron defaults today, but pinning
+      // them means a future Electron version that changes a default can't
+      // silently weaken the sandbox.
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      webSecurity: true,
+      allowRunningInsecureContent: false,
     },
   });
 
@@ -342,13 +402,13 @@ function createWindow() {
   win.webContents.on("will-navigate", (event, url) => {
     if (!allowedOrigins.some((origin) => url.startsWith(origin))) {
       event.preventDefault();
-      shell.openExternal(url);
+      openExternalSafe(url);
     }
   });
 
   // #9: External links (target=_blank) open in system browser, not new Electron window
   win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    openExternalSafe(url);
     return { action: "deny" };
   });
 
@@ -377,15 +437,35 @@ app.whenReady().then(() => {
     return net.fetch(pathToFileURL(fullPath).toString());
   });
 
-  // In production, override the relaxed dev CSP with a strict policy
+  // In production, override the relaxed dev CSP with a strict policy.
+  // Pin connect-src/media-src to the exact API host rather than
+  // `*.railway.app` / `*.brentbarkman.com` — a subdomain takeover on
+  // either zone would otherwise let an attacker receive XHR / SSE traffic
+  // from the app. img-src keeps a general `https:` because user-content
+  // images (OG thumbnails, link previews) come from arbitrary hosts.
   if (!isDev) {
+    let apiOrigin = "";
+    try {
+      apiOrigin = new URL(API_URL).origin;
+    } catch {
+      apiOrigin = "";
+    }
+    const apiHost = apiOrigin ? ` ${apiOrigin}` : "";
+    const csp = [
+      "default-src 'self' app:",
+      "script-src 'self' app:",
+      "style-src 'self' app: 'unsafe-inline'",
+      "img-src 'self' app: data: https:",
+      `media-src 'self' app:${apiHost}`,
+      `connect-src 'self' app:${apiHost}`,
+      "font-src 'self' app: data:",
+      "frame-src https://www.youtube.com https://www.youtube-nocookie.com https://open.spotify.com https://embed.podcasts.apple.com https://player.vimeo.com",
+    ].join("; ") + ";";
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          "Content-Security-Policy": [
-            "default-src 'self' app:; script-src 'self' app:; style-src 'self' app: 'unsafe-inline'; img-src 'self' app: data: https:; media-src 'self' app: https://*.railway.app https://*.brentbarkman.com; connect-src 'self' app: https://*.railway.app https://*.brentbarkman.com; font-src 'self' app: data:; frame-src https://www.youtube.com https://open.spotify.com https://embed.podcasts.apple.com https://*.railway.app;"
-          ],
+          "Content-Security-Policy": [csp],
         },
       });
     });

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8,15 +8,27 @@ import { scanThings3, readThings3 } from "./things3";
 import { initAutoUpdater, quitAndInstall, isUpdateReady, getDownloadedVersion, setAutoInstallOnQuit, checkForUpdatesNow } from "./updater";
 
 /**
- * Only allow `shell.openExternal` to open http(s) URLs. Without this a
- * malicious link in rendered content (pasted in chat, from a Scout finding,
- * embedded in a newsletter) could trigger `javascript:`, `file://`, or an
- * arbitrary protocol handler when clicked.
+ * Protocols we'll hand to `shell.openExternal`. http(s) is the common
+ * case. `mailto:` is added because newsletter content and link previews
+ * commonly contain mailto: links — blocking them silently is a real UX
+ * regression and mailto: is handled by the OS mail client, which is safe.
+ *
+ * Deliberately NOT included: `javascript:`, `data:`, `file:`, `ms-*:`,
+ * `x-apple-*:`, and any other scheme that can invoke an arbitrary
+ * protocol handler on the OS.
+ */
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+/**
+ * Validate that a URL is safe to pass to `shell.openExternal`. Without
+ * this a malicious link in rendered content (pasted in chat, from a Scout
+ * finding, embedded in a newsletter) could trigger `javascript:`, `file://`,
+ * or an arbitrary protocol handler when clicked.
  */
 function isSafeExternalUrl(rawUrl: string): boolean {
   try {
     const parsed = new URL(rawUrl);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    return SAFE_EXTERNAL_PROTOCOLS.has(parsed.protocol);
   } catch {
     return false;
   }
@@ -185,9 +197,18 @@ ipcMain.handle("capture-screenshot", async () => {
   if (!win) throw new Error("No available window");
   // Close DevTools before capturing so we never accidentally include the
   // Network tab (which shows bearer tokens on outgoing requests) in a
-  // feedback screenshot.
+  // feedback screenshot. `closeDevTools()` is fire-and-forget — we have
+  // to wait for the `devtools-closed` event before capturePage, otherwise
+  // a docked DevTools panel can still be visible in the capture.
   if (win.webContents.isDevToolsOpened()) {
-    win.webContents.closeDevTools();
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 1000); // defensive — don't hang forever
+      win.webContents.once("devtools-closed", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+      win.webContents.closeDevTools();
+    });
   }
   const image = await win.webContents.capturePage();
   // Resize to max 1280px wide to limit payload size

--- a/apps/desktop/electron/things3.ts
+++ b/apps/desktop/electron/things3.ts
@@ -14,6 +14,28 @@ const THINGS_CONTAINER = path.join(
   "JLMPQHK86H.com.culturedcode.ThingsMac",
 );
 
+/**
+ * Resolve a candidate path and verify it (a) exists as a regular file,
+ * (b) has the expected `.sqlite` suffix, and (c) actually lives inside
+ * the Things container after symlink resolution. Without the realpath
+ * check a symlink at the expected location could trick us into opening
+ * an arbitrary sqlite file — or any file, which sql.js would reject but
+ * only after reading it.
+ */
+function safelyResolveDbPath(candidate: string): string | null {
+  try {
+    const realCandidate = fs.realpathSync(candidate);
+    const realContainer = fs.realpathSync(THINGS_CONTAINER);
+    if (!realCandidate.startsWith(realContainer + path.sep)) return null;
+    if (!realCandidate.endsWith(".sqlite")) return null;
+    const st = fs.statSync(realCandidate);
+    if (!st.isFile()) return null;
+    return realCandidate;
+  } catch {
+    return null;
+  }
+}
+
 /** Find Things 3 database — it moved to a ThingsData-* subdirectory in 2023 */
 function findThingsDbPath(): string | null {
   // New location (2023+): ThingsData-*/Things Database.thingsdatabase/main.sqlite
@@ -22,13 +44,13 @@ function findThingsDbPath(): string | null {
     const dataDir = entries.find((e) => e.startsWith("ThingsData-"));
     if (dataDir) {
       const newPath = path.join(THINGS_CONTAINER, dataDir, "Things Database.thingsdatabase", "main.sqlite");
-      if (fs.existsSync(newPath)) return newPath;
+      const safe = safelyResolveDbPath(newPath);
+      if (safe) return safe;
     }
   } catch {}
   // Legacy location
   const legacyPath = path.join(THINGS_CONTAINER, "Things Database.thingsdatabase", "main.sqlite");
-  if (fs.existsSync(legacyPath)) return legacyPath;
-  return null;
+  return safelyResolveDbPath(legacyPath);
 }
 
 /**

--- a/apps/desktop/electron/updater.ts
+++ b/apps/desktop/electron/updater.ts
@@ -44,6 +44,17 @@ export function initAutoUpdater(store: Store): void {
     return;
   }
 
+  // Loud failure for the "shipped a build with the placeholder URL" case.
+  // electron-builder's default publish config points at `placeholder.invalid`
+  // until operator config rewrites it; a build released with the default
+  // would otherwise silently never update.
+  if (feedUrl.includes("placeholder.invalid") || feedUrl.includes("placeholder")) {
+    console.error(
+      "[Updater] Feed URL contains 'placeholder' — likely a misconfigured build. Skipping.",
+    );
+    return;
+  }
+
   autoUpdater.setFeedURL({
     provider: "generic",
     url: feedUrl,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -35,6 +35,7 @@ import {
   LivingBackground,
   BackgroundScrim,
   demoMode,
+  ErrorBoundary,
 } from "@brett/ui";
 import { useAwakening } from "./hooks/useAwakening";
 import { useAppConfig } from "./hooks/useAppConfig";
@@ -1163,6 +1164,13 @@ export function App() {
             isAIWorking={omnibar.isStreaming}
           />
 
+          {/*
+            ErrorBoundary around the Routes subtree — a render-time throw in
+            any single view previously tore down the whole App shell. Scoping
+            the boundary here keeps the chrome (LeftNav, Omnibar, background)
+            alive and lets the user navigate away from a broken view.
+          */}
+          <ErrorBoundary scope="routes">
           <Routes>
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/calendar" element={<CalendarPage onEventClick={handleCalendarEventClick} />} />
@@ -1274,9 +1282,11 @@ export function App() {
               </MainLayout>
             } />
           </Routes>
+          </ErrorBoundary>
         </div>
 
         {/* Sliding Detail Panel Overlay */}
+        <ErrorBoundary scope="detail-panel">
         <DetailPanel
           isOpen={isDetailOpen}
           item={selectedItem}
@@ -1449,6 +1459,7 @@ export function App() {
             navigate(path);
           }}
         />
+        </ErrorBoundary>
 
         {/* Drag overlay */}
         <DragOverlay dropAnimation={null}>

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,4 +1,4 @@
-import { authClient, clearStoredToken, getToken } from "../auth/auth-client";
+import { getToken, handleUnauthorized } from "../auth/auth-client";
 import { recordFailedApiCall } from "../lib/diagnostics";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
@@ -43,13 +43,14 @@ export async function apiFetch<T = unknown>(
       init?.method || "GET",
       res.status,
     );
-    // The stored bearer is dead (revoked or expired). Clearing it flips
-    // AuthGuard to LoginPage on the next render instead of letting every
-    // subsequent request hammer the API with an invalid token. Skip for
-    // auth routes themselves so a wrong-password 401 doesn't nuke the
-    // session before the user sees the error message.
+    // The stored bearer is dead (revoked or expired). handleUnauthorized
+    // clears the bearer AND drops better-auth's cached session so AuthGuard
+    // actually flips to LoginPage on the next render — just nuking the
+    // token isn't enough because useSession() doesn't watch the token.
+    // Skip for auth routes themselves so a wrong-password 401 doesn't nuke
+    // the session before the user sees the error message.
     if (res.status === 401 && !path.startsWith("/api/auth/")) {
-      await clearStoredToken().catch(() => {});
+      await handleUnauthorized().catch(() => {});
     }
     const body = await res.json().catch(() => ({}));
     throw new Error((body as any).message || (body as any).error || `API error ${res.status}`);

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,4 +1,4 @@
-import { authClient, getToken } from "../auth/auth-client";
+import { authClient, clearStoredToken, getToken } from "../auth/auth-client";
 import { recordFailedApiCall } from "../lib/diagnostics";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
@@ -43,6 +43,14 @@ export async function apiFetch<T = unknown>(
       init?.method || "GET",
       res.status,
     );
+    // The stored bearer is dead (revoked or expired). Clearing it flips
+    // AuthGuard to LoginPage on the next render instead of letting every
+    // subsequent request hammer the API with an invalid token. Skip for
+    // auth routes themselves so a wrong-password 401 doesn't nuke the
+    // session before the user sees the error message.
+    if (res.status === 401 && !path.startsWith("/api/auth/")) {
+      await clearStoredToken().catch(() => {});
+    }
     const body = await res.json().catch(() => ({}));
     throw new Error((body as any).message || (body as any).error || `API error ${res.status}`);
   }

--- a/apps/desktop/src/api/sse.ts
+++ b/apps/desktop/src/api/sse.ts
@@ -1,8 +1,15 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { getToken } from "../auth/auth-client";
+import { clearStoredToken, getToken } from "../auth/auth-client";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
+
+// Upper bound on reconnection attempts. 20 tries with exponential backoff
+// capped at 30s totals roughly 9 minutes — plenty for transient network
+// blips, short enough to stop draining the battery if the server is just
+// gone. When we stop, the user can always re-trigger by reloading / signing
+// in again; a silent forever-retry loop was worse UX.
+const MAX_RETRIES = 20;
 
 type EventHandler = (data: any) => void;
 const handlers = new Map<string, Set<EventHandler>>();
@@ -41,8 +48,21 @@ export function useEventStream(): void {
     // app. Keep this effect with empty deps.
     let cancelled = false;
     let retryDelay = 1000;
+    let retryCount = 0;
     let eventSource: EventSource | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleRetry = () => {
+      if (cancelled) return;
+      if (retryCount >= MAX_RETRIES) {
+        console.warn("[sse] giving up after", retryCount, "retries");
+        return;
+      }
+      retryCount += 1;
+      const delay = retryDelay;
+      retryDelay = Math.min(delay * 2, 30000);
+      retryTimer = setTimeout(connect, delay);
+    };
 
     const connect = async () => {
       if (cancelled) return;
@@ -57,13 +77,18 @@ export function useEventStream(): void {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },
         });
+        // If the bearer itself is rejected, retrying with the same token
+        // just burns cycles. Clear stored token so the auth layer can
+        // surface the sign-in flow instead of quietly looping.
+        if (res.status === 401 || res.status === 403) {
+          await clearStoredToken();
+          return;
+        }
         if (!res.ok) throw new Error(`ticket fetch failed: ${res.status}`);
         const { ticket } = await res.json();
         ticketParam = `ticket=${encodeURIComponent(ticket)}`;
       } catch {
-        const delay = retryDelay;
-        retryDelay = Math.min(delay * 2, 30000);
-        retryTimer = setTimeout(connect, delay);
+        scheduleRetry();
         return;
       }
 
@@ -75,6 +100,7 @@ export function useEventStream(): void {
 
       es.onopen = () => {
         retryDelay = 1000;
+        retryCount = 0;
         qc.invalidateQueries({ queryKey: ["calendar-events"] });
         qc.invalidateQueries({ queryKey: ["calendar-accounts"] });
       };
@@ -83,9 +109,7 @@ export function useEventStream(): void {
         es.close();
         eventSource = null;
         if (cancelled) return;
-        const delay = retryDelay;
-        retryDelay = Math.min(delay * 2, 30000);
-        retryTimer = setTimeout(connect, delay);
+        scheduleRetry();
       };
 
       const calendarHandler = (e: MessageEvent) => {

--- a/apps/desktop/src/api/sse.ts
+++ b/apps/desktop/src/api/sse.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { clearStoredToken, getToken } from "../auth/auth-client";
+import { getToken, handleUnauthorized } from "../auth/auth-client";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
 
@@ -78,10 +78,11 @@ export function useEventStream(): void {
           headers: { Authorization: `Bearer ${token}` },
         });
         // If the bearer itself is rejected, retrying with the same token
-        // just burns cycles. Clear stored token so the auth layer can
-        // surface the sign-in flow instead of quietly looping.
+        // just burns cycles. Clear it AND drop better-auth's session cache
+        // (via handleUnauthorized) so the AuthGuard flips to LoginPage
+        // instead of leaving the shell rendered with dead requests.
         if (res.status === 401 || res.status === 403) {
-          await clearStoredToken();
+          await handleUnauthorized();
           return;
         }
         if (!res.ok) throw new Error(`ticket fetch failed: ${res.status}`);

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -401,24 +401,65 @@ export function useRetryExtraction() {
       return res;
     },
     onMutate: async (itemId) => {
-      // Optimistically flip to "pending" so the LoadingSkeleton shows immediately.
-      // Without this the button click feels like a no-op: the server returns 202
-      // fast, background extraction often finishes before the refetch settles,
-      // and the UI flashes through pending too quickly to perceive.
+      // Optimistically flip to "pending" everywhere the item could render
+      // — thing-detail is the obvious one, but inbox and any `["things",
+      // ...]` list view shows the same contentStatus badge. Prior behavior
+      // only snapshotted thing-detail, so a failure left inbox/list caches
+      // stuck showing "pending" until a background refetch caught up.
       await qc.cancelQueries({ queryKey: ["thing-detail", itemId] });
-      const prev = qc.getQueryData<unknown>(["thing-detail", itemId]);
+      await qc.cancelQueries({ queryKey: ["inbox"] });
+      await qc.cancelQueries({ queryKey: ["things"] });
+
+      const prevDetail = qc.getQueryData<unknown>(["thing-detail", itemId]);
+      const prevInbox = qc.getQueriesData<unknown>({ queryKey: ["inbox"] });
+      const prevThings = qc.getQueriesData<unknown>({ queryKey: ["things"] });
+
       qc.setQueryData<any>(["thing-detail", itemId], (old: any) =>
         old ? { ...old, contentStatus: "pending" } : old
       );
-      return { prev };
+      // Patch every matching inbox / list cache entry in place so the row
+      // updates without a refetch.
+      const patchList = (data: any): any => {
+        if (!data) return data;
+        if (Array.isArray(data.visible)) {
+          return {
+            ...data,
+            visible: data.visible.map((it: any) =>
+              it?.id === itemId ? { ...it, contentStatus: "pending" } : it,
+            ),
+          };
+        }
+        if (Array.isArray(data)) {
+          return data.map((it: any) =>
+            it?.id === itemId ? { ...it, contentStatus: "pending" } : it,
+          );
+        }
+        return data;
+      };
+      qc.setQueriesData({ queryKey: ["inbox"] }, patchList);
+      qc.setQueriesData({ queryKey: ["things"] }, patchList);
+
+      return { prevDetail, prevInbox, prevThings };
     },
     onError: (_err, itemId, context) => {
-      if (context?.prev !== undefined) {
-        qc.setQueryData(["thing-detail", itemId], context.prev);
+      if (context?.prevDetail !== undefined) {
+        qc.setQueryData(["thing-detail", itemId], context.prevDetail);
+      }
+      if (context?.prevInbox) {
+        for (const [key, value] of context.prevInbox) {
+          qc.setQueryData(key, value);
+        }
+      }
+      if (context?.prevThings) {
+        for (const [key, value] of context.prevThings) {
+          qc.setQueryData(key, value);
+        }
       }
     },
     onSettled: (_data, _err, itemId) => {
       qc.invalidateQueries({ queryKey: ["thing-detail", itemId] });
+      qc.invalidateQueries({ queryKey: ["inbox"] });
+      qc.invalidateQueries({ queryKey: ["things"] });
     },
   });
 }

--- a/apps/desktop/src/auth/AuthContext.tsx
+++ b/apps/desktop/src/auth/AuthContext.tsx
@@ -3,7 +3,9 @@ import React, {
   useContext,
 } from "react";
 import type { AuthUser } from "@brett/types";
+import type { QueryClient } from "@tanstack/react-query";
 import { authClient, clearStoredToken, startGoogleOAuth } from "./auth-client";
+import { diagnostics } from "../lib/diagnostics";
 
 interface AuthContextValue {
   user: AuthUser | null;
@@ -20,6 +22,15 @@ interface AuthContextValue {
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
+
+// The QueryClient is registered by main.tsx on module init. signOut() uses
+// it to wipe all user-scoped cached data on the way out so a subsequent
+// sign-in as a different account can't briefly render the previous user's
+// lists / inbox / calendar before refetches complete.
+let registeredQueryClient: QueryClient | null = null;
+export function setQueryClient(qc: QueryClient): void {
+  registeredQueryClient = qc;
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const { data: sessionData, isPending: loading, refetch } =
@@ -61,6 +72,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signOut = async () => {
     await authClient.signOut();
     await clearStoredToken();
+    // Wipe in-memory state that outlives the AuthGuard unmount — the query
+    // cache (so user A's data can't flash on user B's sign-in) and the
+    // diagnostics ring buffer (which would otherwise attach one user's
+    // recent failed API calls to another user's next feedback submission).
+    registeredQueryClient?.clear();
+    diagnostics.clear();
   };
 
   return (

--- a/apps/desktop/src/auth/auth-client.ts
+++ b/apps/desktop/src/auth/auth-client.ts
@@ -67,6 +67,28 @@ export async function clearStoredToken(): Promise<void> {
   }
 }
 
+/**
+ * Handle a 401 surfaced by any data fetch. Clears the bearer AND forces
+ * better-auth's client-side session store to drop the cached user so the
+ * `useSession()` subscribers (AuthGuard, AuthContext) flip to the login
+ * screen on the next render. Just clearing the bearer isn't enough —
+ * `useSession()` reads cached session state, not the stored token, so
+ * without the signOut the shell would stay rendered while every
+ * subsequent data fetch silently 401'd.
+ *
+ * The `signOut()` server call is best-effort: if the token is already
+ * dead the POST itself will 401, but better-auth still drops the local
+ * session cache on any outcome, which is what we need.
+ */
+export async function handleUnauthorized(): Promise<void> {
+  try {
+    await authClient.signOut();
+  } catch {
+    // Expected if the session is already dead on the server.
+  }
+  await clearStoredToken();
+}
+
 // Start Google OAuth via system browser with secure localhost callback
 export async function startGoogleOAuth(): Promise<void> {
   if (!electronAPI) return;

--- a/apps/desktop/src/lib/diagnostics.ts
+++ b/apps/desktop/src/lib/diagnostics.ts
@@ -155,19 +155,29 @@ export function recordRouteChange(route: string) {
 
 // --- Failed API call recording ---
 
+// Mask path segments that look like opaque IDs (cuids, uuids, 20+-char
+// tokens) so the diagnostics payload can't accidentally carry an item id,
+// scout id, or — if a future endpoint ever puts one there — a secret.
+function maskPathSegments(pathname: string): string {
+  return pathname
+    .split("/")
+    .map((seg) => (/^[a-zA-Z0-9_-]{20,}$/.test(seg) ? "[ID]" : seg))
+    .join("/");
+}
+
 export function recordFailedApiCall(url: string, method: string, status: number) {
   try {
     const parsed = new URL(url);
     if (AUTH_ROUTE_PATTERNS.some((p) => p.test(parsed.pathname))) return;
     failedApiCalls.push({
-      path: parsed.pathname,
+      path: maskPathSegments(parsed.pathname),
       method: method.toUpperCase(),
       status,
       timestamp: new Date().toISOString(),
     });
   } catch {
     failedApiCalls.push({
-      path: url.split("?")[0],
+      path: maskPathSegments(url.split("?")[0]),
       method: method.toUpperCase(),
       status,
       timestamp: new Date().toISOString(),
@@ -213,3 +223,15 @@ export function initDiagnostics() {
   initConsoleCapture();
   initBreadcrumbs();
 }
+
+// Namespaced object for ergonomic call sites (e.g. `diagnostics.clear()` at
+// sign-out). Keep the free functions above for their existing import sites.
+export const diagnostics = {
+  clear(): void {
+    consoleErrors.clear();
+    consoleLogs.clear();
+    failedApiCalls.clear();
+    breadcrumbs.clear();
+    lastRoute = "";
+  },
+};

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "./auth/AuthContext";
 import { AuthGuard } from "./auth/AuthGuard";
 import { LoginPage } from "./auth/LoginPage";
 import { AutoUpdateProvider } from "./hooks/useAutoUpdate";
+import { setQueryClient } from "./auth/AuthContext";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -17,6 +18,13 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// Hand the sign-out path a reference so it can explicitly wipe the
+// React Query cache. The AuthGuard would otherwise unmount the provider
+// on user change and let React garbage-collect it, but (a) that's timing-
+// dependent on better-auth's session hook re-render, and (b) explicit
+// clears are cheap and make the intent unmistakable.
+setQueryClient(queryClient);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/packages/ai/src/config.ts
+++ b/packages/ai/src/config.ts
@@ -3,6 +3,11 @@ export const AI_CONFIG = {
     maxRounds: 5,
     maxTotalTokens: 50_000,
     maxToolResultSize: 4096,
+    // Absolute wall-clock budget for a single orchestrate() call. The
+    // provider already has a 2-minute per-chat timeout, but with maxRounds=5
+    // and tool execution between rounds, a runaway loop could block a worker
+    // for 10+ minutes. 2 minutes is plenty for any legitimate conversation.
+    maxDurationMs: 120_000,
   },
   context: {
     maxFacts: 20,

--- a/packages/ai/src/embedding/search.ts
+++ b/packages/ai/src/embedding/search.ts
@@ -272,6 +272,10 @@ export async function vectorSearch(
 
   const queryVector = await provider.embed(query, "query");
   const vectorStr = `[${queryVector.join(",")}]`;
+  // Pin to the current embedding model. Cosine similarity on vectors from
+  // different models is nonsense — the geometry doesn't agree. If a provider
+  // swap leaves old rows in the table, they're silently ignored here.
+  const currentModel = AI_CONFIG.embedding.documentModel;
 
   let rows: Array<{
     entityType: string;
@@ -300,6 +304,7 @@ export async function vectorSearch(
               )) AS similarity
         FROM "Embedding"
         WHERE "userId" = ${userId}
+          AND "model" = ${currentModel}
           AND "entityType" IN (${typeParams})
         ORDER BY "entityType", "entityId", embedding <=> ${vectorStr}::vector ASC
       ) sub
@@ -319,6 +324,7 @@ export async function vectorSearch(
               )) AS similarity
         FROM "Embedding"
         WHERE "userId" = ${userId}
+          AND "model" = ${currentModel}
         ORDER BY "entityType", "entityId", embedding <=> ${vectorStr}::vector ASC
       ) sub
       ORDER BY similarity DESC

--- a/packages/ai/src/embedding/similarity.ts
+++ b/packages/ai/src/embedding/similarity.ts
@@ -59,12 +59,17 @@ export async function findSimilarItems(
 ): Promise<SimilarityMatch[]> {
   const { targetEntityType, limit = AI_CONFIG.embedding.searchResultLimit, excludeIds = [] } =
     options;
+  // Cosine distances only make sense within one model's vector space. Pin
+  // every similarity query to the current model so a half-migrated corpus
+  // (old rows from model A, new rows from model B) doesn't return garbage.
+  const currentModel = AI_CONFIG.embedding.documentModel;
 
   // Load the source entity's chunk 0 embedding
   const sourceRows = await prisma.$queryRaw<Array<{ embedding: string }>>`
     SELECT embedding::text AS embedding
     FROM "Embedding"
     WHERE "userId" = ${userId}
+      AND "model" = ${currentModel}
       AND "entityType" = ${entityType}
       AND "entityId" = ${entityId}
       AND "chunkIndex" = 0
@@ -89,6 +94,7 @@ export async function findSimilarItems(
           1 - (embedding <=> ${vectorStr}::vector) AS similarity
         FROM "Embedding"
         WHERE "userId" = ${userId}
+          AND "model" = ${currentModel}
           AND "entityType" = ${targetEntityType}
           AND "entityId" != ALL(${allExcluded})
         ORDER BY "entityId", embedding <=> ${vectorStr}::vector ASC
@@ -104,6 +110,7 @@ export async function findSimilarItems(
           1 - (embedding <=> ${vectorStr}::vector) AS similarity
         FROM "Embedding"
         WHERE "userId" = ${userId}
+          AND "model" = ${currentModel}
           AND "entityId" != ALL(${allExcluded})
         ORDER BY "entityId", embedding <=> ${vectorStr}::vector ASC
       ) sub

--- a/packages/ai/src/orchestrator.ts
+++ b/packages/ai/src/orchestrator.ts
@@ -14,9 +14,16 @@ import { logUsage } from "./memory/usage.js";
 const MAX_ROUNDS = AI_CONFIG.orchestrator.maxRounds;
 const MAX_TOTAL_TOKENS = AI_CONFIG.orchestrator.maxTotalTokens;
 const MAX_TOOL_RESULT_SIZE = AI_CONFIG.orchestrator.maxToolResultSize;
+const MAX_DURATION_MS = AI_CONFIG.orchestrator.maxDurationMs;
 
-// Matches common API key patterns (Bearer tokens, sk-*, key-*, etc.)
+// Matches common API key patterns (Bearer tokens, sk-*, key-*, etc.) — an
+// allowlist of known-bad prefixes is more precise than entropy guessing and
+// won't over-redact legitimate identifiers.
 const API_KEY_PATTERN = /(?:sk-|key-|bearer\s+)[a-zA-Z0-9_-]{20,}/gi;
+// AWS access key IDs start with AKIA/ASIA and are exactly 20 chars.
+const AWS_ACCESS_KEY_PATTERN = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
+// GitHub PATs: ghp_/gho_/ghu_/ghs_/ghr_ + 36 chars.
+const GITHUB_TOKEN_PATTERN = /\bgh[pousr]_[A-Za-z0-9]{36}\b/g;
 // Catches long alphanumeric strings that look like tokens/secrets. Threshold
 // was bumped from 40 to 50 to avoid false-positives on Prisma CUIDs / UUIDs
 // embedded in error messages, which made real logs look like they were
@@ -48,7 +55,10 @@ export interface OrchestratorParams {
 function sanitizeError(message: string): string {
   // Layer 1: Known key prefixes (sk-, key-, bearer)
   let sanitized = message.replace(API_KEY_PATTERN, "[REDACTED]");
-  // Layer 2: Long high-entropy strings that look like tokens/secrets
+  // Layer 2: Provider-specific access-key formats
+  sanitized = sanitized.replace(AWS_ACCESS_KEY_PATTERN, "[REDACTED]");
+  sanitized = sanitized.replace(GITHUB_TOKEN_PATTERN, "[REDACTED]");
+  // Layer 3: Long high-entropy strings that look like tokens/secrets
   sanitized = sanitized.replace(HIGH_ENTROPY_PATTERN, "[REDACTED]");
   return sanitized;
 }
@@ -143,9 +153,21 @@ export async function* orchestrate(
       message?: string;
     }> = [];
 
+    const startedAt = Date.now();
+
     // 2. Tool call loop
     while (round < MAX_ROUNDS) {
       round++;
+
+      // Wall-clock guard: bail out before burning another round's worth of
+      // tokens if the whole conversation has already run over budget.
+      if (Date.now() - startedAt > MAX_DURATION_MS) {
+        yield {
+          type: "error",
+          message: "Conversation exceeded maximum duration. Please try again with a more focused request.",
+        };
+        break;
+      }
 
       const model = resolveModel(providerName, currentTier);
       lastModel = model;
@@ -201,7 +223,11 @@ export async function* orchestrate(
                 outputTokens: chunk.usage.output,
                 cacheCreationTokens: chunk.usage.cacheCreation ?? 0,
                 cacheReadTokens: chunk.usage.cacheRead ?? 0,
-              }).catch(() => {});
+              }).catch((err) => {
+                // Don't swallow silently — cost accounting silently missing
+                // rows was how we lost visibility into token spend before.
+                console.error("[orchestrator] logUsage failed:", err);
+              });
             }
 
             if (pendingToolCalls.length > 0) {

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -17,6 +17,7 @@ import type {
   UpcomingSection,
   Things3ImportPayload,
 } from "@brett/types";
+import { isSafeUrl } from "@brett/utils";
 import { RRule } from "rrule";
 
 // ── Compute helpers ──
@@ -281,14 +282,11 @@ export function itemToThing(
 
 // ── Validation ──
 
-function isValidHttpUrl(url: string): boolean {
-  try {
-    const u = new URL(url);
-    return u.protocol === "http:" || u.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
+// Delegated to @brett/utils so every http(s)-only URL check in the codebase
+// runs the same logic. Previous local copy was a silent duplicate — now if
+// we tighten isSafeUrl (e.g. to reject `javascript:` variants) every caller
+// gets the fix.
+const isValidHttpUrl = isSafeUrl;
 
 const VALID_CONTENT_TYPES = new Set(["tweet", "article", "video", "pdf", "podcast", "web_page", "newsletter"]);
 const VALID_ITEM_TYPES = new Set(["task", "content"]);

--- a/packages/ui/src/ErrorBoundary.tsx
+++ b/packages/ui/src/ErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+  /** Scope label, shown in the fallback UI and logged alongside the error. */
+  scope?: string;
+  /** Called with the thrown error + React info on every catch. */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  /** Render prop for a custom fallback. Defaults to a minimal panel. */
+  fallback?: (args: { error: Error; reset: () => void }) => React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * React error boundary for the renderer. Wrap routes and the detail panel
+ * so a render-time throw inside one subtree doesn't unmount the whole app.
+ *
+ * React requires error boundaries to be class components — there's no hook
+ * equivalent for `componentDidCatch`.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error(`[ErrorBoundary${this.props.scope ? `:${this.props.scope}` : ""}]`, error, info);
+    this.props.onError?.(error, info);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback({ error: this.state.error, reset: this.reset });
+      }
+      return (
+        <div
+          style={{
+            padding: 24,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 12,
+            height: "100%",
+            color: "rgba(255,255,255,0.9)",
+            textAlign: "center",
+            fontFamily: "system-ui, -apple-system, sans-serif",
+          }}
+        >
+          <div style={{ fontSize: 14, opacity: 0.7 }}>Something went wrong</div>
+          <div style={{ fontSize: 12, opacity: 0.5, maxWidth: 360 }}>
+            {this.state.error.message || "An unexpected error occurred while rendering this view."}
+          </div>
+          <button
+            onClick={this.reset}
+            style={{
+              marginTop: 8,
+              padding: "6px 14px",
+              borderRadius: 8,
+              border: "1px solid rgba(255,255,255,0.12)",
+              background: "rgba(255,255,255,0.04)",
+              color: "rgba(255,255,255,0.9)",
+              cursor: "pointer",
+              fontSize: 12,
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/ui/src/LivingBackground.tsx
+++ b/packages/ui/src/LivingBackground.tsx
@@ -24,8 +24,16 @@ export function LivingBackground({
   awakeningZoomDurationMs,
 }: LivingBackgroundProps) {
   const useGradients = gradient != null;
+  // Respect prefers-reduced-motion: OS-level "reduce motion" users can get
+  // vestibular discomfort from the Ken Burns zoom. Read once per render
+  // (no listener needed) since mounts are infrequent enough that tracking
+  // changes over the component lifetime isn't worth the complexity.
+  const reduceMotion =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const zoomStyle =
-    awakeningZoom !== undefined
+    awakeningZoom !== undefined && !reduceMotion
       ? {
           transform: awakeningZoom ? "scale(1.15)" : "scale(1)",
           transition: awakeningZoomDurationMs

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 import "./animations.css";
 
 export { Button } from "./button";
+export { ErrorBoundary } from "./ErrorBoundary";
 export { BrettMark, ProductMark, Wordmark } from "./BrettMark";
 export { AppIcon } from "./AppIcon";
 export { LeftNav } from "./LeftNav";

--- a/packages/ui/src/useListKeyboardNav.ts
+++ b/packages/ui/src/useListKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef } from "react";
 import type { Thing } from "@brett/types";
 
 interface UseListKeyboardNavOptions {
@@ -29,11 +29,15 @@ export function useListKeyboardNav({
   }, [items.length]);
 
   // Pin every caller-provided dependency of the keyboard handler on a ref
-  // so the handler's identity doesn't change when parents pass inline
+  // so the listener's identity stays stable even when parents pass inline
   // arrow functions / fresh arrays every render. Prior code used
   // `[handleKeyDown]` as the effect dep list, which re-ran add/remove on
-  // every parent render — fine for correctness but expensive when a parent
-  // re-renders on every stream token.
+  // every parent render — expensive when a parent re-renders on every
+  // stream token.
+  //
+  // The ref update runs in useLayoutEffect (sync, pre-paint) so events
+  // dispatched during paint always see the latest state, not values from
+  // the previous commit.
   const handlerStateRef = useRef({
     items,
     focusedIndex,
@@ -44,21 +48,8 @@ export function useListKeyboardNav({
     onFocusChange,
     onExtraKey,
   });
-  handlerStateRef.current = {
-    items,
-    focusedIndex,
-    focusedThing,
-    onItemClick,
-    onToggle,
-    onFocusAdd,
-    onFocusChange,
-    onExtraKey,
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    // Read everything through the ref so this closure is stable across
-    // renders but always sees the latest values.
-    const {
+  useLayoutEffect(() => {
+    handlerStateRef.current = {
       items,
       focusedIndex,
       focusedThing,
@@ -67,7 +58,24 @@ export function useListKeyboardNav({
       onFocusAdd,
       onFocusChange,
       onExtraKey,
-    } = handlerStateRef.current;
+    };
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Read everything through the ref so this closure is stable across
+      // renders but always sees the latest committed values.
+      const {
+        items,
+        focusedIndex,
+        focusedThing,
+        onItemClick,
+        onToggle,
+        onFocusAdd,
+        onFocusChange,
+        onExtraKey,
+      } = handlerStateRef.current;
+
       // Don't intercept when input, textarea, or contenteditable is focused
       const el = document.activeElement;
       if (
@@ -129,12 +137,10 @@ export function useListKeyboardNav({
         onFocusAdd?.();
         return;
       }
-  };
+    };
 
-  useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [addInputFocused, setAddInputFocused] = useState(false);

--- a/packages/ui/src/useListKeyboardNav.ts
+++ b/packages/ui/src/useListKeyboardNav.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Thing } from "@brett/types";
 
 interface UseListKeyboardNavOptions {
@@ -28,7 +28,46 @@ export function useListKeyboardNav({
     setFocusedIndex((i) => Math.min(i, Math.max(items.length - 1, 0)));
   }, [items.length]);
 
+  // Pin every caller-provided dependency of the keyboard handler on a ref
+  // so the handler's identity doesn't change when parents pass inline
+  // arrow functions / fresh arrays every render. Prior code used
+  // `[handleKeyDown]` as the effect dep list, which re-ran add/remove on
+  // every parent render — fine for correctness but expensive when a parent
+  // re-renders on every stream token.
+  const handlerStateRef = useRef({
+    items,
+    focusedIndex,
+    focusedThing,
+    onItemClick,
+    onToggle,
+    onFocusAdd,
+    onFocusChange,
+    onExtraKey,
+  });
+  handlerStateRef.current = {
+    items,
+    focusedIndex,
+    focusedThing,
+    onItemClick,
+    onToggle,
+    onFocusAdd,
+    onFocusChange,
+    onExtraKey,
+  };
+
   const handleKeyDown = (e: KeyboardEvent) => {
+    // Read everything through the ref so this closure is stable across
+    // renders but always sees the latest values.
+    const {
+      items,
+      focusedIndex,
+      focusedThing,
+      onItemClick,
+      onToggle,
+      onFocusAdd,
+      onFocusChange,
+      onExtraKey,
+    } = handlerStateRef.current;
       // Don't intercept when input, textarea, or contenteditable is focused
       const el = document.activeElement;
       if (
@@ -95,7 +134,8 @@ export function useListKeyboardNav({
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [addInputFocused, setAddInputFocused] = useState(false);
 


### PR DESCRIPTION
## Summary

Full-stack audit pass on the API + Electron desktop + shared packages. No new runtime dependencies. Five commits — four from the original audit, one from a second-pass review that caught a handful of issues before merge.

### Commits

1. **`12ee375` security** — Device token hijack, CORS wildcard + credentials, OAuth state TTL + HMAC length check, XFF right-most IP, newsletter webhook Basic Auth (legacy path preserved for rollover), WebP magic-byte check, Electron `shell.openExternal` scheme allowlist, Things3 symlink realpath check, CSP pinned to exact API host, screenshot closes DevTools, updater refuses placeholder URLs, OAuth socket cleanup.

2. **`87d8a93` reliability** — Composite sync-pull indexes, new `CronLock` table + `withCronLock` distributed leader-election, sync-pull keyset pagination over `(updatedAt, id)` (legacy ISO cursors still parse), sync-push rejects missing baselines, atomic scout budget reservation via conditional `UPDATE`, orchestrator 120s wall-clock timeout, embedding queries pin to current model, weather `AbortSignal.timeout(6s)`, aggressive calendar-event PII scrub, tightened meeting-matcher, memory consolidation 12h cooldown.

3. **`43ca9a6` renderer + shared** — Sign-out wipes QueryClient + diagnostics, `apiFetch` handles 401 cleanly, SSE retry bounded to 20 attempts + re-auth on 401/403, `useRetryExtraction` snapshots all relevant caches, `useListKeyboardNav` stable listener, new `ErrorBoundary` export wrapping `<Routes>` + `<DetailPanel>`, `LivingBackground` respects `prefers-reduced-motion`, diagnostics path mask redacts 20+-char segments.

4. **`ef3344e` ScoutFinding.userId (release A)** — Nullable column + composite index + backfill, both creation sites write it, sync.ts filter falls back via `OR` for rows inserted by old replica during rolling deploy. Release B (NOT NULL flip + drop the OR) is a separate future PR.

5. **`5021cce` review pass fixes** — Addresses second-pass review findings: meeting-matcher `&&`→explicit `bothMissingAttendees`, `handleUnauthorized()` helper so 401 actually flips AuthGuard, idempotency TTL restored to 30d (iOS queue has no age pruning), `mailto:` allowlisted, DevTools close race, newsletter handler typed, `useListKeyboardNav` ref in `useLayoutEffect`, comments on per-process single-flight.

### Verification

- ✅ `pnpm typecheck` — 17/17 workspace packages clean
- ✅ `pnpm --filter @brett/api test` — 62 files / 682 tests pass, 14 skipped
- ✅ `pnpm --filter @brett/desktop build` — clean
- ✅ Prisma migrations apply cleanly on fresh DB
- ✅ `CronLock` tested under 5-way concurrent race on expired lease — exactly 1 winner
- ✅ Atomic scout budget SQL tested under 3-way concurrent contention — 2 reserved, 1 rejected
- ✅ Things3 symlink escape guard tested against real macOS container (5 scenarios)
- ✅ Railway XFF append behavior verified (right-most IP trustworthy)

### Deploy notes (for whenever `main → release` happens)

- Migrations `20260423120000_add_sync_pull_indexes`, `20260423120001_add_cron_lock`, `20260423120002_scout_finding_user_id` apply in-transaction. First two are trivial. The third does an `UPDATE` backfill of `ScoutFinding.userId` — time it on staging if the table is large.
- Newsletter webhook: legacy path `/webhooks/email/ingest/:secret` still works. Reconfigure Postmark to use Basic Auth (`https://x:$SECRET@host/webhooks/email/ingest`) at your convenience; zero-downtime.
- ScoutFinding Release B (NOT NULL + drop OR fallback) is a separate future PR.

## Test plan

- [ ] Sync pull from a fresh desktop + from a desktop with an existing plain-ISO cursor
- [ ] Sync push with a complete `previousValues` vs one missing a key (should succeed vs 200/error)
- [ ] Start two API replicas locally, confirm each cron job runs on exactly one
- [ ] Sign out → sign in as different user → confirm no previous-user data flashes
- [ ] Google OAuth end-to-end on Electron + a 16+ minute stale callback (should reject)
- [ ] Electron packaged build: open, navigate, check DevTools console for CSP blocks; try a `javascript:` link (should refuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)