### PR TITLE
sync: ScoutFinding.userId NOT NULL (release B)

### DIFF
--- a/apps/api/prisma/migrations/20260424200000_scout_finding_user_id_not_null/migration.sql
+++ b/apps/api/prisma/migrations/20260424200000_scout_finding_user_id_not_null/migration.sql
@@ -1,0 +1,18 @@
+-- Release B of ScoutFinding.userId denormalization. Release A (migration
+-- 20260423120002_scout_finding_user_id) added the column nullable, indexed
+-- it, and backfilled existing rows from Scout.userId. Release A shipped
+-- with sync pull's OR fallback so old replicas mid-rolling-deploy could
+-- keep inserting rows with userId=NULL.
+--
+-- By the time this migration runs:
+--   1. Every replica is on the new Prisma client and every finding writer
+--      sets userId (verified: scout-runner.ts lines 1034 and 1424 both
+--      include `userId: scout.userId` on create).
+--   2. Production ScoutFinding.userId is fully backfilled (verified: at
+--      ship time there were 0 rows total in the table, so no legacy data).
+--
+-- Safety: if somehow a NULL slipped through between release A and B, this
+-- ALTER will abort the deploy. That's the desired failure mode — better
+-- to fail the migration than to silently mis-scope a row.
+
+ALTER TABLE "ScoutFinding" ALTER COLUMN "userId" SET NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -751,10 +751,8 @@ model ScoutFinding {
   // having it on the row directly (a) lets sync pull hit a composite
   // `(userId, updatedAt)` index without a join through Scout, and (b) is
   // a defense-in-depth scoping key if any future query forgets the
-  // `scout: { userId }` filter. Nullable for now so existing rows don't
-  // block the deploy; NOT NULL flip happens in a follow-up release after
-  // backfill + every call site is writing it.
-  userId         String?
+  // `scout: { userId }` filter.
+  userId         String
   deletedAt      DateTime?
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -184,25 +184,9 @@ export const sync = new Hono<AuthEnv>()
 
       const cursor = cursors[table] ?? null;
 
-      // Build base where clause for active records.
-      // Most models have a direct userId column. ScoutFinding now has one
-      // too (nullable during the rollout — release A of the two-release
-      // flow that ends with NOT NULL). Prefer the direct column when
-      // present so the query hits the new `(userId, updatedAt)` composite
-      // index, but fall back to the relation filter for any legacy row
-      // whose `userId` isn't backfilled yet. Release B drops the OR.
-      const ownershipFilter: any =
-        table === "scout_findings"
-          ? {
-              OR: [
-                { userId: user.id },
-                { userId: null, scout: { userId: user.id } },
-              ],
-            }
-          : { userId: user.id };
-
-      // Normal query — soft-delete extension auto-filters deletedAt IS NULL
-      const where: any = { ...ownershipFilter };
+      // Every syncable model has a direct userId column, so sync pull
+      // hits the composite `(userId, updatedAt)` index without a join.
+      const where: any = { userId: user.id };
       applyCursorFilter(where, cursor);
 
       // Special handling for calendar_events: scope to last 90 days + future
@@ -220,7 +204,7 @@ export const sync = new Hono<AuthEnv>()
 
       // Query tombstone IDs only (bypasses soft-delete extension via key existence)
       const tombstoneWhere: any = {
-        ...ownershipFilter,
+        userId: user.id,
         deletedAt: { not: null }, // key exists -> bypasses extension
       };
       applyCursorFilter(tombstoneWhere, cursor);


### PR DESCRIPTION
## Summary

- Flip `ScoutFinding.userId` from nullable to NOT NULL (migration `20260424200000_scout_finding_user_id_not_null`)
- Drop the OR fallback in `routes/sync.ts` — every writer sets `userId` now, so the fallback is dead weight (and noise in query plans)
- Retire the transition comment in `schema.prisma`

This completes the two-phase rollout started in migration `20260423120002_scout_finding_user_id` (release A), which shipped with the previous merge-to-release.

## Prod state at time of writing

Queried inside the Railway private network:

```
{"total":0,"with_user":0,"null_user":0}
```

Zero `ScoutFinding` rows in production → zero backfill risk, zero chance of the NOT NULL flip aborting on stale data.

## Safety

- Migration is a single `ALTER TABLE ... SET NOT NULL`. Fail-closed: if a NULL snuck in between release A and B, the deploy aborts instead of silently mis-scoping rows.
- Old replicas running during the rolling deploy window already write `userId` (release A deployed with the updated client).
- No destructive column drop or rename — additive-style change.

## Test plan

- [x] Typecheck: 17/17 pass
- [x] API tests: 62 files, 682 passed
- [x] Migration applies clean to local dev DB
- [ ] CI green
- [ ] After merge + `main → release` PR: watch Railway deploy logs for clean migration apply

## Follow-up

None. This closes the two-phase series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)