### PR TITLE
Release: ScoutFinding.userId NOT NULL (release B)

### DIFF
--- a/apps/api/prisma/migrations/20260424200000_scout_finding_user_id_not_null/migration.sql
+++ b/apps/api/prisma/migrations/20260424200000_scout_finding_user_id_not_null/migration.sql
@@ -1,0 +1,18 @@
+-- Release B of ScoutFinding.userId denormalization. Release A (migration
+-- 20260423120002_scout_finding_user_id) added the column nullable, indexed
+-- it, and backfilled existing rows from Scout.userId. Release A shipped
+-- with sync pull's OR fallback so old replicas mid-rolling-deploy could
+-- keep inserting rows with userId=NULL.
+--
+-- By the time this migration runs:
+--   1. Every replica is on the new Prisma client and every finding writer
+--      sets userId (verified: scout-runner.ts lines 1034 and 1424 both
+--      include `userId: scout.userId` on create).
+--   2. Production ScoutFinding.userId is fully backfilled (verified: at
+--      ship time there were 0 rows total in the table, so no legacy data).
+--
+-- Safety: if somehow a NULL slipped through between release A and B, this
+-- ALTER will abort the deploy. That's the desired failure mode — better
+-- to fail the migration than to silently mis-scope a row.
+
+ALTER TABLE "ScoutFinding" ALTER COLUMN "userId" SET NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -751,10 +751,8 @@ model ScoutFinding {
   // having it on the row directly (a) lets sync pull hit a composite
   // `(userId, updatedAt)` index without a join through Scout, and (b) is
   // a defense-in-depth scoping key if any future query forgets the
-  // `scout: { userId }` filter. Nullable for now so existing rows don't
-  // block the deploy; NOT NULL flip happens in a follow-up release after
-  // backfill + every call site is writing it.
-  userId         String?
+  // `scout: { userId }` filter.
+  userId         String
   deletedAt      DateTime?
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -184,25 +184,9 @@ export const sync = new Hono<AuthEnv>()
 
       const cursor = cursors[table] ?? null;
 
-      // Build base where clause for active records.
-      // Most models have a direct userId column. ScoutFinding now has one
-      // too (nullable during the rollout — release A of the two-release
-      // flow that ends with NOT NULL). Prefer the direct column when
-      // present so the query hits the new `(userId, updatedAt)` composite
-      // index, but fall back to the relation filter for any legacy row
-      // whose `userId` isn't backfilled yet. Release B drops the OR.
-      const ownershipFilter: any =
-        table === "scout_findings"
-          ? {
-              OR: [
-                { userId: user.id },
-                { userId: null, scout: { userId: user.id } },
-              ],
-            }
-          : { userId: user.id };
-
-      // Normal query — soft-delete extension auto-filters deletedAt IS NULL
-      const where: any = { ...ownershipFilter };
+      // Every syncable model has a direct userId column, so sync pull
+      // hits the composite `(userId, updatedAt)` index without a join.
+      const where: any = { userId: user.id };
       applyCursorFilter(where, cursor);
 
       // Special handling for calendar_events: scope to last 90 days + future
@@ -220,7 +204,7 @@ export const sync = new Hono<AuthEnv>()
 
       // Query tombstone IDs only (bypasses soft-delete extension via key existence)
       const tombstoneWhere: any = {
-        ...ownershipFilter,
+        userId: user.id,
         deletedAt: { not: null }, // key exists -> bypasses extension
       };
       applyCursorFilter(tombstoneWhere, cursor);


### PR DESCRIPTION
## Summary

Closes the two-phase denormalization rollout. Release A (in the prior release) added `ScoutFinding.userId` as nullable + backfilled + indexed. This PR:

- Flips the column to NOT NULL
- Drops the OR fallback in sync pull (every writer sets `userId` now)
- Retires the transition comment in schema.prisma

## Migration

`20260424200000_scout_finding_user_id_not_null` — single `ALTER TABLE "ScoutFinding" ALTER COLUMN "userId" SET NOT NULL`. Fails closed if a NULL slipped in (desired failure mode).

Production check at authoring time: 0 ScoutFinding rows total → zero backfill risk.

## Test plan

- [ ] CI green on `release` (tests re-run before Railway deploys)
- [ ] Railway API deploy + health check pass
- [ ] Migration applies clean in prod (watch deploy logs)
- [ ] Smoke: sync pull on desktop + iOS still returns scout findings post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)