### PR TITLE
fix(sync): keyset-merge pagination, per-table page sizes, unified server core

### DIFF
--- a/apps/api/src/__tests__/paginated-pull.test.ts
+++ b/apps/api/src/__tests__/paginated-pull.test.ts
@@ -198,20 +198,24 @@ describe("paginatedPull", () => {
 
   // ── Coverage across many pages ──
 
-  it("walks all 200 rows across pages with no gaps and no duplicates", async () => {
-    const t0 = new Date("2026-04-25T10:00:00.000Z");
-    const seeded: string[] = [];
-    for (let i = 0; i < 200; i++) {
-      const r = await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
-      seeded.push(r.id);
-    }
-    const { allUpsertedIds, pages } = await walkAll(userId, 50);
-    expect(pages.length).toBe(4);
-    expect(allUpsertedIds.length).toBe(200);
-    expect(new Set(allUpsertedIds)).toEqual(new Set(seeded));
-    // No duplicates across pages.
-    expect(new Set(allUpsertedIds).size).toBe(allUpsertedIds.length);
-  });
+  it(
+    "walks all 200 rows across pages with no gaps and no duplicates",
+    { timeout: 30_000 },
+    async () => {
+      const t0 = new Date("2026-04-25T10:00:00.000Z");
+      const seeded: string[] = [];
+      for (let i = 0; i < 200; i++) {
+        const r = await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+        seeded.push(r.id);
+      }
+      const { allUpsertedIds, pages } = await walkAll(userId, 50);
+      expect(pages.length).toBe(4);
+      expect(allUpsertedIds.length).toBe(200);
+      expect(new Set(allUpsertedIds)).toEqual(new Set(seeded));
+      // No duplicates across pages.
+      expect(new Set(allUpsertedIds).size).toBe(allUpsertedIds.length);
+    },
+  );
 
   it("two consecutive fresh walks return identical id sets — determinism guard", async () => {
     // The "two iOS sign-ins disagree" bug is exactly this property failing

--- a/apps/api/src/__tests__/paginated-pull.test.ts
+++ b/apps/api/src/__tests__/paginated-pull.test.ts
@@ -1,0 +1,545 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { createTestUser } from "./helpers.js";
+import { prisma } from "../lib/prisma.js";
+import {
+  paginatedPull,
+  parseCursor,
+  formatCursor,
+  type PaginatedPullResult,
+} from "../lib/sync/paginated-pull.js";
+
+/**
+ * Tests for `paginatedPull` — the shared pagination core that both
+ * /sync/pull and /things route through. These pin every correctness
+ * invariant the sync engine relies on. If any of these fail, mobile
+ * clients are silently below water.
+ *
+ * All tests use the `Item` model since it's the most complex (largest
+ * row, most-frequent updates from server-side activity, the table that
+ * exposed the original bug). Other soft-delete-aware models share the
+ * exact same code path, so coverage transfers.
+ */
+
+/** Insert one item with explicit `updatedAt` so tests control ordering. */
+async function seedItem(opts: {
+  userId: string;
+  title: string;
+  /** Override the auto-generated `updatedAt`. */
+  updatedAt: Date;
+  deletedAt?: Date | null;
+  /** Override the cuid so tests can force `id` ordering for sibling timestamps. */
+  id?: string;
+  status?: string;
+}): Promise<{ id: string; updatedAt: Date; deletedAt: Date | null }> {
+  const created = await prisma.item.create({
+    data: {
+      ...(opts.id ? { id: opts.id } : {}),
+      userId: opts.userId,
+      type: "task",
+      status: opts.status ?? "active",
+      title: opts.title,
+    },
+  });
+  // Force exact `updatedAt` (and optional `deletedAt`) AFTER create — Prisma's
+  // `@updatedAt` ignores manual writes on create. updateMany bypasses the
+  // soft-delete extension, which is what we want when seeding tombstones too.
+  await prisma.item.updateMany({
+    where: { id: created.id },
+    data: { updatedAt: opts.updatedAt, deletedAt: opts.deletedAt ?? null },
+  });
+  return { id: created.id, updatedAt: opts.updatedAt, deletedAt: opts.deletedAt ?? null };
+}
+
+/** Walk paginatedPull until exhausted and collect every page's payload. */
+async function walkAll(
+  userId: string,
+  limit: number,
+  opts: { includeTombstones?: boolean; extraWhere?: Record<string, unknown> } = {},
+): Promise<{ pages: PaginatedPullResult[]; allUpsertedIds: string[]; allDeletedIds: string[] }> {
+  const pages: PaginatedPullResult[] = [];
+  const allUpsertedIds: string[] = [];
+  const allDeletedIds: string[] = [];
+  let cursor: string | null = null;
+  // Hard upper bound so a regression that broke `hasMore` doesn't hang the
+  // suite. 1,000 pages × a few seeded rows each is far above any test's
+  // legitimate page count.
+  const SAFETY_CAP = 1000;
+  for (let i = 0; i < SAFETY_CAP; i++) {
+    const page = await paginatedPull({
+      prismaModel: prisma.item,
+      userId,
+      cursor,
+      limit,
+      includeTombstones: opts.includeTombstones,
+      extraWhere: opts.extraWhere,
+    });
+    pages.push(page);
+    for (const row of page.upserted) allUpsertedIds.push(row.id);
+    for (const id of page.deleted) allDeletedIds.push(id);
+    if (!page.hasMore) break;
+    if (!page.nextCursor) {
+      throw new Error("hasMore=true but nextCursor=null — would infinite-loop");
+    }
+    if (cursor === page.nextCursor) {
+      throw new Error(`cursor did not advance (${cursor}) — would infinite-loop`);
+    }
+    cursor = page.nextCursor;
+  }
+  return { pages, allUpsertedIds, allDeletedIds };
+}
+
+describe("paginatedPull", () => {
+  let userId: string;
+
+  beforeAll(async () => {
+    const user = await createTestUser("paginatedPull suite");
+    userId = user.userId;
+  });
+
+  beforeEach(async () => {
+    // Each test starts with no items for this user. The soft-delete
+    // extension converts `prisma.item.deleteMany` into a soft-delete
+    // (sets deletedAt), which would leave tombstones around and break
+    // test isolation. Use raw SQL to hard-delete for a true wipe.
+    await prisma.$executeRaw`DELETE FROM "Item" WHERE "userId" = ${userId}`;
+  });
+
+  // ── Cursor parsing / formatting ──
+
+  describe("cursor parsing", () => {
+    it("parses pipe-separated keyset form", () => {
+      const c = parseCursor("2026-04-25T12:00:00.000Z|abc123");
+      expect(c).not.toBeNull();
+      expect(c!.id).toBe("abc123");
+      expect(c!.ts.toISOString()).toBe("2026-04-25T12:00:00.000Z");
+    });
+
+    it("parses legacy timestamp-only form with id=null", () => {
+      const c = parseCursor("2026-04-25T12:00:00.000Z");
+      expect(c).not.toBeNull();
+      expect(c!.id).toBeNull();
+    });
+
+    it("returns null for malformed input", () => {
+      expect(parseCursor("not-a-date")).toBeNull();
+      expect(parseCursor("")).toBeNull();
+      expect(parseCursor(null)).toBeNull();
+      expect(parseCursor(undefined)).toBeNull();
+      // Pipe with empty id half is malformed.
+      expect(parseCursor("2026-04-25T12:00:00.000Z|")).toBeNull();
+    });
+
+    it("formatCursor + parseCursor round-trips", () => {
+      const ts = new Date("2026-04-25T12:00:00.000Z");
+      const id = "row-id-xyz";
+      const cursor = formatCursor(ts, id);
+      const parsed = parseCursor(cursor);
+      expect(parsed!.id).toBe(id);
+      expect(parsed!.ts.getTime()).toBe(ts.getTime());
+    });
+  });
+
+  // ── Empty / edge counts ──
+
+  it("returns empty result on an empty table", async () => {
+    const page = await paginatedPull({
+      prismaModel: prisma.item,
+      userId,
+      cursor: null,
+      limit: 50,
+    });
+    expect(page.upserted).toEqual([]);
+    expect(page.deleted).toEqual([]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("returns single page when row count < limit", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 5; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    const { pages, allUpsertedIds } = await walkAll(userId, 50);
+    expect(pages.length).toBe(1);
+    expect(allUpsertedIds.length).toBe(5);
+    expect(pages[0].hasMore).toBe(false);
+  });
+
+  it("hasMore=false when row count exactly equals limit (no spurious extra round)", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 50; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    const page = await paginatedPull({
+      prismaModel: prisma.item,
+      userId,
+      cursor: null,
+      limit: 50,
+    });
+    expect(page.upserted.length).toBe(50);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  it("hasMore=true when row count is exactly limit + 1", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 51; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    const page = await paginatedPull({
+      prismaModel: prisma.item,
+      userId,
+      cursor: null,
+      limit: 50,
+    });
+    expect(page.upserted.length).toBe(50);
+    expect(page.hasMore).toBe(true);
+  });
+
+  // ── Coverage across many pages ──
+
+  it("walks all 200 rows across pages with no gaps and no duplicates", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    const seeded: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      const r = await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+      seeded.push(r.id);
+    }
+    const { allUpsertedIds, pages } = await walkAll(userId, 50);
+    expect(pages.length).toBe(4);
+    expect(allUpsertedIds.length).toBe(200);
+    expect(new Set(allUpsertedIds)).toEqual(new Set(seeded));
+    // No duplicates across pages.
+    expect(new Set(allUpsertedIds).size).toBe(allUpsertedIds.length);
+  });
+
+  it("two consecutive fresh walks return identical id sets — determinism guard", async () => {
+    // The "two iOS sign-ins disagree" bug is exactly this property failing
+    // when the underlying tail can shift due to mid-walk server writes.
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 75; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    const walk1 = await walkAll(userId, 25);
+    const walk2 = await walkAll(userId, 25);
+    expect(new Set(walk1.allUpsertedIds)).toEqual(new Set(walk2.allUpsertedIds));
+  });
+
+  // ── Sibling timestamp handling (the keyset stability invariant) ──
+
+  it("sibling timestamps do not split rows across pages — all 60 same-millisecond rows returned, ordered by id", async () => {
+    const sameTs = new Date("2026-04-25T10:00:00.000Z");
+    const seeded: string[] = [];
+    for (let i = 0; i < 60; i++) {
+      const r = await seedItem({ userId, title: `t${i}`, updatedAt: sameTs });
+      seeded.push(r.id);
+    }
+    const { allUpsertedIds, pages } = await walkAll(userId, 50);
+    expect(pages.length).toBe(2);
+    expect(allUpsertedIds.length).toBe(60);
+    // Pin the keyset ordering invariant: returned IDs must come back in
+    // lexicographic ascending order (the secondary sort key when updatedAt
+    // ties), matching `[...seeded].sort()`. This is the property that lets
+    // the next page resume on `(T, id)` without losing siblings.
+    expect(allUpsertedIds).toEqual([...seeded].sort());
+  });
+
+  // ── Tombstones ──
+
+  it("interleaved upserts and tombstones both surface, in keyset order — the merge fix", async () => {
+    // This is the regression guard for the original bug. With independent
+    // pagination of upserts vs tombstones, this exact shape lost rows.
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    const liveIds: string[] = [];
+    const deadIds: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      const isDeleted = i % 2 === 0;
+      const r = await seedItem({
+        userId,
+        title: `t${i}`,
+        updatedAt: new Date(t0.getTime() + i),
+        deletedAt: isDeleted ? new Date(t0.getTime() + i + 1000) : null,
+      });
+      if (isDeleted) deadIds.push(r.id);
+      else liveIds.push(r.id);
+    }
+    const { allUpsertedIds, allDeletedIds } = await walkAll(userId, 25);
+    expect(new Set(allUpsertedIds)).toEqual(new Set(liveIds));
+    expect(new Set(allDeletedIds)).toEqual(new Set(deadIds));
+    // Total coverage = total seeded.
+    expect(allUpsertedIds.length + allDeletedIds.length).toBe(100);
+  });
+
+  it("tombstones with later updatedAt than the upsert tail are not skipped", async () => {
+    // Mirror of the original bug shape: most rows live, a small clump of
+    // tombstones at the very end. The old code would race the cursor past
+    // the tombstones in some interleavings.
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    const liveIds: string[] = [];
+    const deadIds: string[] = [];
+    for (let i = 0; i < 95; i++) {
+      const r = await seedItem({ userId, title: `live${i}`, updatedAt: new Date(t0.getTime() + i) });
+      liveIds.push(r.id);
+    }
+    for (let i = 0; i < 5; i++) {
+      const r = await seedItem({
+        userId,
+        title: `dead${i}`,
+        updatedAt: new Date(t0.getTime() + 1000 + i),
+        deletedAt: new Date(t0.getTime() + 1000 + i),
+      });
+      deadIds.push(r.id);
+    }
+    const { allUpsertedIds, allDeletedIds } = await walkAll(userId, 20);
+    expect(new Set(allUpsertedIds)).toEqual(new Set(liveIds));
+    expect(new Set(allDeletedIds)).toEqual(new Set(deadIds));
+  });
+
+  it("upserts with later updatedAt than the tombstone tail are not skipped", async () => {
+    // The reverse hazard. Symmetric coverage.
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    const liveIds: string[] = [];
+    const deadIds: string[] = [];
+    for (let i = 0; i < 95; i++) {
+      const r = await seedItem({
+        userId,
+        title: `dead${i}`,
+        updatedAt: new Date(t0.getTime() + i),
+        deletedAt: new Date(t0.getTime() + i),
+      });
+      deadIds.push(r.id);
+    }
+    for (let i = 0; i < 5; i++) {
+      const r = await seedItem({
+        userId,
+        title: `live${i}`,
+        updatedAt: new Date(t0.getTime() + 1000 + i),
+      });
+      liveIds.push(r.id);
+    }
+    const { allUpsertedIds, allDeletedIds } = await walkAll(userId, 20);
+    expect(new Set(allUpsertedIds)).toEqual(new Set(liveIds));
+    expect(new Set(allDeletedIds)).toEqual(new Set(deadIds));
+  });
+
+  it("includeTombstones=false returns only live rows and never queries dead", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 10; i++) {
+      await seedItem({
+        userId,
+        title: `dead${i}`,
+        updatedAt: new Date(t0.getTime() + i),
+        deletedAt: new Date(t0.getTime() + i),
+      });
+    }
+    const liveIds: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const r = await seedItem({ userId, title: `live${i}`, updatedAt: new Date(t0.getTime() + 100 + i) });
+      liveIds.push(r.id);
+    }
+    const { allUpsertedIds, allDeletedIds } = await walkAll(userId, 50, { includeTombstones: false });
+    expect(new Set(allUpsertedIds)).toEqual(new Set(liveIds));
+    expect(allDeletedIds).toEqual([]);
+  });
+
+  // ── Resume / cursor correctness ──
+
+  it("cursor advances strictly monotonically across pages — no overlap", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 100; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    const { pages } = await walkAll(userId, 20);
+    let prevTs = -Infinity;
+    let prevId = "";
+    for (const page of pages) {
+      for (const row of page.upserted) {
+        const ts = row.updatedAt instanceof Date ? row.updatedAt.getTime() : new Date(row.updatedAt).getTime();
+        const sameTs = ts === prevTs;
+        const idAfter = row.id > prevId;
+        // (ts > prevTs) OR (ts === prevTs AND id > prevId).
+        expect(ts > prevTs || (sameTs && idAfter)).toBe(true);
+        prevTs = ts;
+        prevId = row.id;
+      }
+    }
+  });
+
+  it("server writes between pages don't drop unwalked rows or re-emit walked rows", async () => {
+    // Models the scenario the user hit: scout-runner / content-extraction /
+    // calendar-poller bumps `updatedAt` on rows mid-walk. With the merge fix
+    // and monotonic cursor, the bumped row may be RE-DELIVERED in a later
+    // page (which is correct — it has new content), but unwalked rows must
+    // not be lost and no row's removal is fabricated.
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    const all: { id: string; updatedAt: Date }[] = [];
+    for (let i = 0; i < 100; i++) {
+      const r = await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+      all.push({ id: r.id, updatedAt: r.updatedAt });
+    }
+
+    const seen = new Set<string>();
+    let cursor: string | null = null;
+    let didWriteback = false;
+    while (true) {
+      const page = await paginatedPull({
+        prismaModel: prisma.item,
+        userId,
+        cursor,
+        limit: 20,
+      });
+      for (const row of page.upserted) seen.add(row.id);
+
+      // Once we've consumed two pages, simulate a server-side writeback
+      // that bumps a row we've ALREADY pulled to a future updatedAt.
+      // The next page must still walk forward correctly.
+      if (!didWriteback && page.upserted.length > 0 && seen.size >= 40) {
+        didWriteback = true;
+        const target = all[5].id; // a row we definitely already pulled
+        await prisma.item.updateMany({
+          where: { id: target },
+          data: { updatedAt: new Date(t0.getTime() + 10_000) },
+        });
+      }
+
+      if (!page.hasMore) break;
+      cursor = page.nextCursor!;
+    }
+
+    // Every originally-seeded id must be in `seen` (no row lost). The
+    // bumped row is allowed to appear twice (which we don't enforce
+    // either way — caller idempotence handles it).
+    for (const row of all) {
+      expect(seen.has(row.id)).toBe(true);
+    }
+  });
+
+  // ── Filtering (extraWhere) ──
+
+  it("extraWhere filters apply to both live and tombstone streams", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 30; i++) {
+      await seedItem({ userId, title: `done${i}`, updatedAt: new Date(t0.getTime() + i), status: "done" });
+    }
+    const activeIds: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      const r = await seedItem({ userId, title: `active${i}`, updatedAt: new Date(t0.getTime() + 100 + i) });
+      activeIds.push(r.id);
+    }
+    const { allUpsertedIds } = await walkAll(userId, 50, { extraWhere: { status: "active" } });
+    expect(new Set(allUpsertedIds)).toEqual(new Set(activeIds));
+  });
+
+  it("rejects extraWhere containing reserved `deletedAt` key", async () => {
+    await expect(
+      paginatedPull({
+        prismaModel: prisma.item,
+        userId,
+        cursor: null,
+        limit: 50,
+        extraWhere: { deletedAt: null },
+      }),
+    ).rejects.toThrow(/deletedAt/);
+  });
+
+  it("rejects extraWhere containing reserved `userId` key — defense in depth against caller scoping override", async () => {
+    // If the spread merge ever silently let a caller override our own
+    // userId scoping, we'd cross-leak data. Fail loud at the boundary.
+    const otherUser = await createTestUser("paginatedPull userid-defense");
+    await seedItem({ userId: otherUser.userId, title: "leak-target", updatedAt: new Date() });
+
+    await expect(
+      paginatedPull({
+        prismaModel: prisma.item,
+        userId,
+        cursor: null,
+        limit: 50,
+        extraWhere: { userId: otherUser.userId },
+      }),
+    ).rejects.toThrow(/userId/);
+
+    // Belt-and-braces: even if the throw were bypassed, the row should
+    // not have been queryable via this user's paginatedPull. Confirm by
+    // pulling without extraWhere and asserting no foreign rows surface.
+    const page = await paginatedPull({ prismaModel: prisma.item, userId, cursor: null, limit: 50 });
+    expect(page.upserted.find((r: any) => r.title === "leak-target")).toBeUndefined();
+
+    await prisma.$executeRaw`DELETE FROM "Item" WHERE "userId" = ${otherUser.userId}`;
+  });
+
+  // ── User scoping ──
+
+  it("never returns rows belonging to a different user", async () => {
+    const otherUser = await createTestUser("paginatedPull other-user");
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    const myIds: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      const r = await seedItem({ userId, title: `mine${i}`, updatedAt: new Date(t0.getTime() + i) });
+      myIds.push(r.id);
+    }
+    for (let i = 0; i < 20; i++) {
+      await seedItem({ userId: otherUser.userId, title: `theirs${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    const { allUpsertedIds } = await walkAll(userId, 100);
+    expect(new Set(allUpsertedIds)).toEqual(new Set(myIds));
+    // Cleanup the other user too — beforeEach only wipes the suite user.
+    await prisma.$executeRaw`DELETE FROM "Item" WHERE "userId" = ${otherUser.userId}`;
+  });
+
+  // ── Validation ──
+
+  it("rejects invalid limit", async () => {
+    await expect(
+      paginatedPull({ prismaModel: prisma.item, userId, cursor: null, limit: 0 }),
+    ).rejects.toThrow(/limit/);
+    await expect(
+      paginatedPull({ prismaModel: prisma.item, userId, cursor: null, limit: -1 }),
+    ).rejects.toThrow(/limit/);
+    await expect(
+      // @ts-expect-error fractional limit
+      paginatedPull({ prismaModel: prisma.item, userId, cursor: null, limit: 1.5 }),
+    ).rejects.toThrow(/limit/);
+  });
+
+  it("rejects empty userId", async () => {
+    await expect(
+      paginatedPull({ prismaModel: prisma.item, userId: "", cursor: null, limit: 50 }),
+    ).rejects.toThrow(/userId/);
+  });
+
+  // ── Cursor formats ──
+
+  it("accepts a legacy timestamp-only cursor and resumes correctly", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 10; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i * 1000) });
+    }
+    // Cursor at t0 + 4500ms should leave 5 rows ahead (those at +5000 .. +9000).
+    const legacyCursor = new Date(t0.getTime() + 4500).toISOString();
+    const page = await paginatedPull({
+      prismaModel: prisma.item,
+      userId,
+      cursor: legacyCursor,
+      limit: 50,
+    });
+    expect(page.upserted.length).toBe(5);
+  });
+
+  it("returns nextCursor=null on an empty page so caller can preserve their cursor", async () => {
+    const t0 = new Date("2026-04-25T10:00:00.000Z");
+    for (let i = 0; i < 5; i++) {
+      await seedItem({ userId, title: `t${i}`, updatedAt: new Date(t0.getTime() + i) });
+    }
+    // Cursor past the latest row → empty page.
+    const past = new Date(t0.getTime() + 1_000_000).toISOString();
+    const page = await paginatedPull({
+      prismaModel: prisma.item,
+      userId,
+      cursor: `${past}|zzzzz`,
+      limit: 50,
+    });
+    expect(page.upserted).toEqual([]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+});

--- a/apps/api/src/__tests__/sync-pull-correctness.test.ts
+++ b/apps/api/src/__tests__/sync-pull-correctness.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { createTestUser, authRequest } from "./helpers.js";
+import { prisma } from "../lib/prisma.js";
+import { clearAllRateLimits } from "../middleware/rate-limit.js";
+
+/**
+ * Route-level guards for /sync/pull's per-table page sizing and
+ * multi-round walk semantics. The unit-level invariants live in
+ * `paginated-pull.test.ts`; this file exercises the same correctness
+ * properties through the actual HTTP route, so a future refactor that
+ * skips the shared core can't accidentally bypass them.
+ */
+describe("POST /sync/pull — pagination correctness", () => {
+  let token: string;
+  let userId: string;
+  let listId: string;
+
+  beforeAll(async () => {
+    const user = await createTestUser("Sync Pagination");
+    token = user.token;
+    userId = user.userId;
+
+    const listRes = await authRequest("/lists", token, {
+      method: "POST",
+      body: JSON.stringify({ name: "Pagination List", colorClass: "bg-blue-500" }),
+    });
+    listId = ((await listRes.json()) as any).id;
+  });
+
+  beforeEach(async () => {
+    clearAllRateLimits();
+    // Hard-delete to bypass the soft-delete extension. Wipe items + lists
+    // owned by THIS test user only; leave the seeded `listId` row alone.
+    await prisma.$executeRaw`DELETE FROM "Item" WHERE "userId" = ${userId}`;
+  });
+
+  /**
+   * Bulk-seed items directly via Prisma — much faster than the HTTP create
+   * path and avoids tripping route-level rate limits when run inside the
+   * full test suite. Uses `createMany` (extension-aware) since `Item`
+   * participates in soft-delete: `deletedAt` is implicitly null on insert.
+   */
+  async function seedItems(opts: {
+    count: number;
+    titlePrefix: string;
+    deleted?: boolean;
+  }): Promise<string[]> {
+    const ids: string[] = [];
+    const rows = Array.from({ length: opts.count }, (_, i) => ({
+      userId,
+      type: "task",
+      status: "active",
+      title: `${opts.titlePrefix}${i}`,
+    }));
+    const created = await prisma.item.createManyAndReturn({ data: rows });
+    for (const row of created) ids.push(row.id);
+    if (opts.deleted) {
+      // Use updateMany so we set deletedAt without going through the
+      // soft-delete-converter for delete (which would also fire here).
+      await prisma.item.updateMany({
+        where: { id: { in: ids } },
+        data: { deletedAt: new Date() },
+      });
+    }
+    return ids;
+  }
+
+  // ── Per-table default page sizing ──
+
+  it("uses a small default page size for `items` (50) when client omits limit", async () => {
+    // Seed 60 items — above the items default (50), below the small-table
+    // default (200). If the route is using the wrong default, the page
+    // size will visibly come back wrong.
+    await seedItems({ count: 60, titlePrefix: "bulk-" });
+    clearAllRateLimits();
+
+    const res = await authRequest("/sync/pull", token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.changes.items.upserted.length).toBe(50);
+    expect(body.changes.items.hasMore).toBe(true);
+  });
+
+  it("uses a larger default page size for metadata tables (lists) when client omits limit", async () => {
+    clearAllRateLimits();
+    // The route default for `lists` is 200. Even creating 60 lists should
+    // come back in a single page with hasMore=false.
+    for (let i = 0; i < 60; i++) {
+      await authRequest("/lists", token, {
+        method: "POST",
+        body: JSON.stringify({ name: `bulk-list-${i}`, colorClass: "bg-blue-500" }),
+      });
+    }
+    clearAllRateLimits();
+
+    const res = await authRequest("/sync/pull", token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    // 60 created above + the suite's seeded list = 61 rows on this user.
+    expect(body.changes.lists.upserted.length).toBeGreaterThanOrEqual(60);
+    expect(body.changes.lists.hasMore).toBe(false);
+
+    // Cleanup the bulk-created lists so subsequent tests aren't polluted.
+    await prisma.$executeRaw`DELETE FROM "List" WHERE "userId" = ${userId} AND "name" LIKE 'bulk-list-%'`;
+  });
+
+  it("client-supplied `limit` overrides every table's default", async () => {
+    // Verify the legacy single-knob behavior still works for clients on
+    // older protocols. Seed 5 items; ask for limit=2 → page caps at 2.
+    await seedItems({ count: 5, titlePrefix: "limit-test-" });
+    clearAllRateLimits();
+
+    const res = await authRequest("/sync/pull", token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {}, limit: 2 }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.changes.items.upserted.length).toBe(2);
+    expect(body.changes.items.hasMore).toBe(true);
+  });
+
+  // ── Multi-round walk via cursors ──
+
+  /**
+   * Walk /sync/pull until every requested table reports hasMore=false.
+   * Returns the union of every page's upserted ids for `items`. Used as a
+   * regression guard — total returned must equal total seeded.
+   */
+  async function walkSyncPull(
+    sessionToken: string,
+    initialCursors: Record<string, string> = {},
+  ): Promise<{ itemIds: string[]; rounds: number }> {
+    let cursors: Record<string, string> = { ...initialCursors };
+    const itemIds: string[] = [];
+    const SAFETY_CAP = 200;
+    for (let round = 0; round < SAFETY_CAP; round++) {
+      clearAllRateLimits();
+      const res = await authRequest("/sync/pull", sessionToken, {
+        method: "POST",
+        body: JSON.stringify({ protocolVersion: 1, cursors }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      for (const row of body.changes.items.upserted) {
+        itemIds.push(row.id);
+      }
+      const anyMore = Object.values(body.changes).some((c: any) => c.hasMore);
+      cursors = body.cursors;
+      if (!anyMore) return { itemIds, rounds: round + 1 };
+    }
+    throw new Error("walkSyncPull exceeded SAFETY_CAP");
+  }
+
+  it("walks 200 items across multiple pages without dropping any", async () => {
+    const seeded = new Set(await seedItems({ count: 200, titlePrefix: "walk-" }));
+
+    const { itemIds, rounds } = await walkSyncPull(token);
+    expect(new Set(itemIds)).toEqual(seeded);
+    expect(rounds).toBeGreaterThanOrEqual(4); // 200 / 50 per round = 4 rounds minimum
+  });
+
+  it("two consecutive full walks return identical id sets — the determinism guard", async () => {
+    await seedItems({ count: 120, titlePrefix: "det-" });
+
+    const walk1 = await walkSyncPull(token);
+    const walk2 = await walkSyncPull(token);
+    expect(new Set(walk1.itemIds)).toEqual(new Set(walk2.itemIds));
+  });
+
+  // ── Tombstone race regression guard ──
+
+  it("interleaved tombstones with later updatedAt than upsert tail are not skipped", async () => {
+    // Seed live rows first.
+    const liveIds = new Set(await seedItems({ count: 60, titlePrefix: "live-" }));
+
+    // Then create + delete 5 items so their tombstones sit at later
+    // `updatedAt` than every live row's last update. Pre-fix this exact
+    // shape was where the upsert-vs-tombstone winner race silently
+    // dropped rows. Direct prisma writes ensure the tombstones'
+    // updatedAt is strictly later than the live tail's.
+    const deadIds = new Set(await seedItems({ count: 5, titlePrefix: "dead-", deleted: true }));
+
+    const cursors: Record<string, string> = {};
+    let allUpserted: string[] = [];
+    let allDeleted: string[] = [];
+    let safety = 0;
+    while (true) {
+      clearAllRateLimits();
+      const res = await authRequest("/sync/pull", token, {
+        method: "POST",
+        body: JSON.stringify({ protocolVersion: 1, cursors }),
+      });
+      const body = (await res.json()) as any;
+      allUpserted = allUpserted.concat(body.changes.items.upserted.map((r: any) => r.id));
+      allDeleted = allDeleted.concat(body.changes.items.deleted);
+      Object.assign(cursors, body.cursors);
+      const anyMore = Object.values(body.changes).some((c: any) => c.hasMore);
+      if (!anyMore) break;
+      if (++safety > 50) throw new Error("walk did not converge");
+    }
+
+    // Every live row must surface in `upserted` and every deleted row in
+    // `deleted`. No row may be silently lost across the boundary.
+    expect(new Set(allUpserted)).toEqual(liveIds);
+    expect(new Set(allDeleted)).toEqual(deadIds);
+  });
+});

--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -684,6 +684,62 @@ describe("Sync Push", () => {
     expect(body.results[0].error).toContain("userId");
   });
 
+  /**
+   * Prisma's raw error messages include schema details ("Unique
+   * constraint failed on the fields: (`id`)", "Record to update not
+   * found", etc.) that confirm the existence of soft-deleted rows on
+   * a guessed id and leak internal column names. Pin the sanitisation
+   * here so a future refactor that drops `sanitisePushError` can't
+   * silently re-expose them.
+   */
+  it("CREATE collision returns sanitised public error, not Prisma's raw message", async () => {
+    clearAllRateLimits();
+
+    // Pick an id, create it once, then attempt a second CREATE with the
+    // same id from the same user. Prisma throws P2002; the route must
+    // map that to a stable "duplicate" — never echo the column hint.
+    const collidingId = generateId();
+    const idempotencyKeyA = `dup-create-A-${nonce}-${collidingId}`;
+    const idempotencyKeyB = `dup-create-B-${nonce}-${collidingId}`;
+
+    const firstRes = await authRequest("/sync/push", token, {
+      method: "POST",
+      body: JSON.stringify({
+        protocolVersion: 1,
+        mutations: [{
+          idempotencyKey: idempotencyKeyA,
+          entityType: "item",
+          entityId: collidingId,
+          action: "CREATE",
+          payload: { type: "task", title: "First", status: "active" },
+        }],
+      }),
+    });
+    expect(firstRes.status).toBe(200);
+    expect(((await firstRes.json()) as SyncPushResponse).results[0].status).toBe("applied");
+
+    const secondRes = await authRequest("/sync/push", token, {
+      method: "POST",
+      body: JSON.stringify({
+        protocolVersion: 1,
+        mutations: [{
+          idempotencyKey: idempotencyKeyB,
+          entityType: "item",
+          entityId: collidingId,
+          action: "CREATE",
+          payload: { type: "task", title: "Second", status: "active" },
+        }],
+      }),
+    });
+    expect(secondRes.status).toBe(200);
+    const body = (await secondRes.json()) as SyncPushResponse;
+    expect(body.results[0].status).toBe("error");
+    // Public message must NOT contain Prisma's column hints.
+    expect(body.results[0].error).toBe("duplicate");
+    expect(body.results[0].error).not.toMatch(/Unique constraint/i);
+    expect(body.results[0].error).not.toMatch(/fields:/i);
+  });
+
   it("max mutations exceeded returns 400", async () => {
     clearAllRateLimits();
 

--- a/apps/api/src/__tests__/things.test.ts
+++ b/apps/api/src/__tests__/things.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { createTestUser, authRequest } from "./helpers.js";
 import { app } from "../app.js";
 import { DEFAULT_LIST_NAME } from "@brett/business";
+import { prisma } from "../lib/prisma.js";
 
 describe("Things routes", () => {
   let token: string;
@@ -519,5 +520,171 @@ describe("GET /things?dueAfter", () => {
     expect(body.length).toBe(2);
     const titles = body.map((t: any) => t.title).sort();
     expect(titles).toEqual(["Past", "Today"]);
+  });
+});
+
+/**
+ * The shared `paginatedPull` core means /things and /sync/pull no longer
+ * have parallel pagination implementations, AND /things now walks until
+ * exhausted server-side instead of silently truncating at 500 rows. These
+ * tests pin both invariants — without them, a future regression could
+ * reintroduce either failure mode without obvious symptoms in dev.
+ */
+describe("GET /things — pagination correctness via shared sync core", () => {
+  let token: string;
+  let userId: string;
+  let seededIds: string[];
+
+  beforeAll(async () => {
+    const user = await createTestUser("Things Pagination");
+    token = user.token;
+    userId = user.userId;
+
+    // Bulk-seed 600 items — well past the old `take: 500` desktop cap —
+    // via direct Prisma to avoid serializing 600 HTTP POSTs (slow + would
+    // trip route rate limits inside the full test suite). Before the
+    // shared-core refactor, /things silently dropped the oldest 100 of
+    // these. The tests below pin that the full set now comes back.
+    const created = await prisma.item.createManyAndReturn({
+      data: Array.from({ length: 600 }, (_, i) => ({
+        userId,
+        type: "task",
+        status: "active",
+        title: `bulk-${i}`,
+      })),
+    });
+    seededIds = created.map((r) => r.id);
+  });
+
+  it("returns the full matching set for users above the legacy 500-row truncation", async () => {
+    const res = await authRequest("/things", token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    // The full set should come back — no silent truncation. The 2000-row
+    // default cap on /things is well above 600 so we expect every row.
+    expect(body.length).toBe(seededIds.length);
+    expect(new Set(body.map((t: any) => t.id))).toEqual(new Set(seededIds));
+  });
+
+  it("returns identical id sets across two consecutive calls — determinism", async () => {
+    // Mirrors the "two iOS sign-ins disagree" guard from paginated-pull
+    // tests, but at the route level. If the cursor stream is deterministic
+    // for an unchanging dataset, both calls must produce identical sets.
+    const res1 = await authRequest("/things", token);
+    const res2 = await authRequest("/things", token);
+    const body1 = (await res1.json()) as any[];
+    const body2 = (await res2.json()) as any[];
+    expect(new Set(body1.map((t: any) => t.id))).toEqual(new Set(body2.map((t: any) => t.id)));
+  });
+
+  it("filters paginate correctly across the internal page size — `status=active` returns all matching rows", async () => {
+    // Mark 50 of the seeded rows complete so we have a mixed dataset
+    // that crosses the internal page boundary (200). If filtering were
+    // applied AFTER pagination instead of THROUGH it, the active count
+    // could come back wrong.
+    const toComplete = seededIds.slice(0, 50);
+    await prisma.item.updateMany({
+      where: { id: { in: toComplete } },
+      data: { status: "done", completedAt: new Date() },
+    });
+
+    const res = await authRequest("/things?status=active", token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    expect(body.every((t: any) => t.status === "active")).toBe(true);
+    expect(body.length).toBe(seededIds.length - toComplete.length);
+
+    // Reset the dataset so subsequent tests in this describe see all 600
+    // again. Don't go through the route's PATCH (rate limit risk).
+    await prisma.item.updateMany({
+      where: { id: { in: toComplete } },
+      data: { status: "active", completedAt: null },
+    });
+  });
+
+  it("respects an explicit `?limit=` request below the default cap", async () => {
+    const res = await authRequest("/things?limit=37", token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    expect(body.length).toBeLessThanOrEqual(37);
+  });
+
+  it("clamps an absurd `?limit=` to the hard maximum", async () => {
+    // 999_999 must not OOM the server — the route caps at 5000 internally.
+    const res = await authRequest("/things?limit=999999", token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+    expect(body.length).toBeLessThanOrEqual(5000);
+  });
+
+  it("never returns rows belonging to a different user — IDOR defense on the hydrate query", async () => {
+    // Defense-in-depth check: paginatedPull already scopes by user, but
+    // the route's hydrate findMany is the second line of defense. If a
+    // future bug let a foreign id leak into the accumulated set, the
+    // hydrate would still drop it because of the userId clause.
+    const otherUser = await createTestUser("Things Pagination Other");
+    await prisma.item.createMany({
+      data: Array.from({ length: 20 }, (_, i) => ({
+        userId: otherUser.userId,
+        type: "task",
+        status: "active",
+        title: `other-${i}`,
+      })),
+    });
+
+    const res = await authRequest("/things", token);
+    const body = (await res.json()) as any[];
+    const titles = new Set(body.map((t: any) => t.title));
+    for (let i = 0; i < 20; i++) {
+      expect(titles.has(`other-${i}`)).toBe(false);
+    }
+  });
+});
+
+/**
+ * Cross-route parity: /things and /sync/pull must surface the same id set
+ * for the items table when called with no filters and a fresh cursor.
+ * They diverged for years before the shared-core refactor, which was the
+ * architectural asymmetry behind the iOS-vs-Electron count divergence.
+ * Pin the parity here so a future drift can't sneak back in.
+ */
+describe("/things ↔ /sync/pull cross-route parity", () => {
+  let token: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const user = await createTestUser("Sync Things Parity");
+    token = user.token;
+    userId = user.userId;
+    await prisma.item.createMany({
+      data: Array.from({ length: 75 }, (_, i) => ({
+        userId,
+        type: "task",
+        status: "active",
+        title: `parity-${i}`,
+      })),
+    });
+  });
+
+  it("both endpoints return the same id set when no filter is applied", async () => {
+    const thingsRes = await authRequest("/things", token);
+    const thingsBody = (await thingsRes.json()) as any[];
+
+    // Walk /sync/pull until exhausted, collecting items.
+    const seen = new Set<string>();
+    let cursors: Record<string, string> = {};
+    for (let safety = 0; safety < 50; safety++) {
+      const res = await authRequest("/sync/pull", token, {
+        method: "POST",
+        body: JSON.stringify({ protocolVersion: 1, cursors }),
+      });
+      const body = (await res.json()) as any;
+      for (const row of body.changes.items.upserted) seen.add(row.id);
+      const anyMore = Object.values(body.changes).some((c: any) => c.hasMore);
+      cursors = body.cursors;
+      if (!anyMore) break;
+    }
+
+    expect(new Set(thingsBody.map((t: any) => t.id))).toEqual(seen);
   });
 });

--- a/apps/api/src/lib/sync/paginated-pull.ts
+++ b/apps/api/src/lib/sync/paginated-pull.ts
@@ -65,6 +65,19 @@ export type PaginatedPullArgs = {
   /** Prisma model accessor (e.g. `prisma.item`). Must support `findMany`. */
   prismaModel: { findMany: (args: any) => Promise<any[]> };
 
+  /**
+   * Prisma client used to wrap the live + tombstone queries in a
+   * single transaction (`$transaction([...])`). Without the transaction,
+   * a row's state can change between the two queries — most innocuously
+   * appearing in BOTH `upserted` and `deleted` of the same page (the
+   * client merges then deletes, net correct), but in pathological
+   * timestamp-bump cases it could appear in NEITHER. The transaction
+   * gives both queries a consistent snapshot. Optional for
+   * back-compatibility; when omitted we fall back to two independent
+   * queries, which is correct under low-churn datasets.
+   */
+  prismaClient?: { $transaction: (queries: any[]) => Promise<any[]> };
+
   /** Always scoped to a single user. */
   userId: string;
 
@@ -174,7 +187,7 @@ function compareKeyset(a: { updatedAt: Date; id: string }, b: { updatedAt: Date;
 export async function paginatedPull<
   T extends { id: string; updatedAt: Date; deletedAt: Date | null },
 >(args: PaginatedPullArgs): Promise<PaginatedPullResult<T>> {
-  const { prismaModel, userId, cursor, limit, extraWhere = {}, includeTombstones = true } = args;
+  const { prismaModel, prismaClient, userId, cursor, limit, extraWhere = {}, includeTombstones = true } = args;
 
   if (!Number.isInteger(limit) || limit < 1) {
     throw new Error(`paginatedPull: limit must be a positive integer (got ${limit})`);
@@ -212,28 +225,45 @@ export async function paginatedPull<
     return clauses.length === 1 ? clauses[0] : { AND: clauses };
   }
 
+  // Build the two findMany argument objects up-front so we can either
+  // run them as a $transaction (consistent snapshot) or fall back to
+  // two sequential queries when the caller didn't pass a client.
+  //
   // Live query — soft-delete extension auto-filters to `deletedAt: null`
   // because the resulting `where` has no top-level `deletedAt` key.
-  const live = (await prismaModel.findMany({
+  const liveArgs = {
     where: buildWhere(),
     orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
     take: limit + 1,
-  })) as T[];
+  };
 
-  let dead: T[] = [];
-  if (includeTombstones) {
-    // Tombstone query — `deletedAt: { not: null }` lifted to the OUTER
-    // where (not inside the AND) so the soft-delete extension's bypass
-    // check (`"deletedAt" in where`) sees it. If we put it inside the
-    // AND, the extension would auto-add `deletedAt: null`, contradicting
-    // the tombstone filter and silently returning zero rows.
-    const deadWhere: Record<string, unknown> = { ...buildWhere(), deletedAt: { not: null } };
+  // Tombstone query — `deletedAt: { not: null }` lifted to the OUTER
+  // where (not inside the AND) so the soft-delete extension's bypass
+  // check (`"deletedAt" in where`) sees it. If we put it inside the
+  // AND, the extension would auto-add `deletedAt: null`, contradicting
+  // the tombstone filter and silently returning zero rows.
+  const deadArgs = includeTombstones
+    ? {
+        where: { ...buildWhere(), deletedAt: { not: null } },
+        orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+        take: limit + 1,
+      }
+    : null;
 
-    dead = (await prismaModel.findMany({
-      where: deadWhere,
-      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
-      take: limit + 1,
-    })) as T[];
+  let live: T[];
+  let dead: T[];
+  if (prismaClient && deadArgs) {
+    // Single snapshot for both queries. Eliminates the window where a
+    // row's state can shift between live and tombstone reads.
+    const [liveRows, deadRows] = await prismaClient.$transaction([
+      prismaModel.findMany(liveArgs),
+      prismaModel.findMany(deadArgs),
+    ]);
+    live = liveRows as T[];
+    dead = deadRows as T[];
+  } else {
+    live = (await prismaModel.findMany(liveArgs)) as T[];
+    dead = deadArgs ? ((await prismaModel.findMany(deadArgs)) as T[]) : [];
   }
 
   // Two-way merge by `(updatedAt, id)` ASC. Both inputs are already in

--- a/apps/api/src/lib/sync/paginated-pull.ts
+++ b/apps/api/src/lib/sync/paginated-pull.ts
@@ -1,0 +1,273 @@
+/**
+ * Single-table keyset-paginated read of a user's rows, returning a strict
+ * ordered slice of rows newer than `cursor`, plus `hasMore` and the cursor
+ * for the next page.
+ *
+ * ## Why this exists
+ *
+ * The original /sync/pull paginated upserts and tombstones in two
+ * independent queries with a shared starting cursor, then advanced ONE
+ * cursor by max(lastUpsert.updatedAt, lastTombstone.updatedAt). When the
+ * two streams' tails fell at different timestamps, every row in the gap
+ * was permanently dropped on the next round — the user's app silently
+ * showed fewer items than the server held.
+ *
+ * This function fetches both streams (live + tombstones) for the same
+ * user/where/cursor, merges them in `(updatedAt, id)` keyset order, and
+ * emits ONE cursor that is the merged-stream tail. There is no third
+ * state — every row with `(updatedAt, id) <= cursor` is in this page,
+ * every row strictly after is in a future page, no row is in both, no
+ * row is in neither. `hasMore` is detected from the merged length, not
+ * the per-side length, so it's never wrong.
+ *
+ * ## Memory bound
+ *
+ * Each call fetches at most `2 * (limit + 1)` rows from Postgres
+ * (`limit + 1` from each of live and tombstone queries). The `+ 1` is
+ * needed regardless of which side wins the tail — without it, a tail
+ * dominated by one side would lose `hasMore` resolution.
+ *
+ * ## Caller contract
+ *
+ * - `prismaModel` must be a soft-delete-aware Prisma model accessor
+ *   (Item, List, etc.). Tables without a `deletedAt` column are not
+ *   supported — pass `includeTombstones: false` or use a different
+ *   read path.
+ * - `cursor` from a previous page is opaque to the caller; pass it back
+ *   verbatim. `null` means "from the beginning."
+ * - `extraWhere` is layered as additional AND clauses. Don't put
+ *   `deletedAt` or `userId` in it — internal handling owns those keys.
+ * - `includeTombstones: false` is the right setting for view-shaped
+ *   reads (like /things) where deleted rows have nothing to display.
+ *   /sync/pull replication uses the default `true` so the client can
+ *   apply the deletion locally.
+ *
+ * ## What this function CANNOT detect or surface
+ *
+ * - **Hard deletes.** A `DELETE FROM <table>` (raw SQL or any path
+ *   that bypasses the soft-delete extension) leaves no tombstone, so
+ *   no client ever learns the row is gone. Their local mirror keeps
+ *   it forever. Production code must always go through the extension
+ *   (which converts deletes to soft-deletes) for sync to remain
+ *   coherent.
+ * - **Rows that age out of an `extraWhere` filter.** E.g.,
+ *   /sync/pull's calendar-events 90-day window: an event whose
+ *   `startTime` falls outside the window is excluded from BOTH the
+ *   live and tombstone queries. A previously-synced event that ages
+ *   out becomes a permanent local ghost on the client. This is the
+ *   caller's design choice — paginatedPull just respects what
+ *   `extraWhere` says.
+ */
+
+export type CursorParts = { ts: Date; id: string | null };
+
+export type PaginatedPullArgs = {
+  /** Prisma model accessor (e.g. `prisma.item`). Must support `findMany`. */
+  prismaModel: { findMany: (args: any) => Promise<any[]> };
+
+  /** Always scoped to a single user. */
+  userId: string;
+
+  /**
+   * Cursor of the form `"<ISO-8601 timestamp>|<row id>"` or, for clients
+   * on the legacy format, just `"<ISO-8601 timestamp>"`. `null` =
+   * pull from the beginning.
+   */
+  cursor: string | null;
+
+  /** Page size. Each call returns at most this many rows in `upserted + deleted`. */
+  limit: number;
+
+  /**
+   * Additional Prisma `where` clauses, AND-layered onto `userId` and the
+   * cursor filter. Use to narrow by status, listId, etc. Do NOT include
+   * `deletedAt` here — internal logic owns that key.
+   */
+  extraWhere?: Record<string, unknown>;
+
+  /**
+   * If true (default), tombstones are merged into the keyset stream and
+   * returned in `deleted`. If false, only live rows are queried; `deleted`
+   * is always empty. View-shaped reads (`/things`) want false; replication
+   * (`/sync/pull`) wants true.
+   */
+  includeTombstones?: boolean;
+};
+
+export type PaginatedPullResult<T = any> = {
+  /** Live rows in `(updatedAt, id)` ascending order. */
+  upserted: T[];
+  /** Tombstone IDs in `(updatedAt, id)` ascending order. Empty when `includeTombstones: false`. */
+  deleted: string[];
+  /** True if at least one row exists with key strictly greater than this page's tail. */
+  hasMore: boolean;
+  /**
+   * Cursor for the next call. Pass back verbatim. `null` means no rows
+   * were returned in this page — caller should preserve any prior cursor.
+   */
+  nextCursor: string | null;
+};
+
+const CURSOR_PIPE = "|";
+
+/**
+ * Parse a cursor string into `(ts, id)`. Accepts both the new pipe-separated
+ * keyset form and the legacy timestamp-only form (`id: null`). Returns
+ * `null` for malformed input — callers should treat that as "no cursor"
+ * rather than 400-ing, matching the existing /sync/pull tolerance.
+ */
+export function parseCursor(raw: string | null | undefined): CursorParts | null {
+  if (!raw) return null;
+  const pipeAt = raw.indexOf(CURSOR_PIPE);
+  if (pipeAt === -1) {
+    const ts = new Date(raw);
+    return Number.isNaN(ts.getTime()) ? null : { ts, id: null };
+  }
+  const ts = new Date(raw.slice(0, pipeAt));
+  if (Number.isNaN(ts.getTime())) return null;
+  const id = raw.slice(pipeAt + 1);
+  if (id.length === 0) return null;
+  return { ts, id };
+}
+
+/**
+ * Format `(updatedAt, id)` into the canonical wire form. Always emits the
+ * pipe form, even though `parseCursor` accepts the legacy form on input.
+ */
+export function formatCursor(updatedAt: Date | string, id: string): string {
+  const iso = updatedAt instanceof Date ? updatedAt.toISOString() : updatedAt;
+  return `${iso}${CURSOR_PIPE}${id}`;
+}
+
+/**
+ * Build the Prisma `where` clause that selects rows strictly after the
+ * cursor in `(updatedAt, id)` keyset order. For the legacy timestamp-only
+ * form, falls back to a simple `updatedAt > ts` (rows sharing that exact
+ * millisecond may be re-fetched, which is harmless — clients upsert
+ * idempotently).
+ */
+function buildCursorClause(c: CursorParts): Record<string, unknown> {
+  if (c.id === null) {
+    return { updatedAt: { gt: c.ts } };
+  }
+  return {
+    OR: [
+      { updatedAt: { gt: c.ts } },
+      { AND: [{ updatedAt: c.ts }, { id: { gt: c.id } }] },
+    ],
+  };
+}
+
+/**
+ * Compare two rows by `(updatedAt, id)` ascending. Used for the in-memory
+ * merge of live + tombstone result sets. Both inputs must already be
+ * sorted by this same order; this is the standard 2-way merge step.
+ */
+function compareKeyset(a: { updatedAt: Date; id: string }, b: { updatedAt: Date; id: string }): number {
+  const ta = a.updatedAt instanceof Date ? a.updatedAt.getTime() : new Date(a.updatedAt).getTime();
+  const tb = b.updatedAt instanceof Date ? b.updatedAt.getTime() : new Date(b.updatedAt).getTime();
+  if (ta !== tb) return ta - tb;
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? -1 : 1;
+}
+
+export async function paginatedPull<
+  T extends { id: string; updatedAt: Date; deletedAt: Date | null },
+>(args: PaginatedPullArgs): Promise<PaginatedPullResult<T>> {
+  const { prismaModel, userId, cursor, limit, extraWhere = {}, includeTombstones = true } = args;
+
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(`paginatedPull: limit must be a positive integer (got ${limit})`);
+  }
+  if (!userId) {
+    throw new Error("paginatedPull: userId is required");
+  }
+  if ("deletedAt" in extraWhere) {
+    // Reserve `deletedAt` ownership — it's how we bypass the soft-delete
+    // extension for the tombstone query. A caller passing it would
+    // either be clobbered (silent) or break the bypass (insidious).
+    throw new Error("paginatedPull: extraWhere must not include `deletedAt`");
+  }
+  if ("userId" in extraWhere) {
+    // Reserve `userId` ownership. If a caller passes a different userId,
+    // the wrap below would still apply — and we'd happily query someone
+    // else's rows. Fail loud rather than expose a defense-in-depth hole
+    // for a future refactor.
+    throw new Error("paginatedPull: extraWhere must not include `userId`");
+  }
+
+  const cursorParts = parseCursor(cursor);
+  const cursorClause = cursorParts ? buildCursorClause(cursorParts) : null;
+
+  // Wrap every condition in a single top-level AND so caller-provided
+  // `AND` / `OR` clauses (e.g. `things.ts` search) compose cleanly with
+  // our own cursor clause without clobbering. The straightforward
+  // spread `{ userId, ...extraWhere, AND: [cursor] }` would overwrite a
+  // caller's top-level `AND` because object spread can't merge
+  // same-key arrays. The wrap below sidesteps that entirely.
+  function buildWhere(): Record<string, unknown> {
+    const clauses: Array<Record<string, unknown>> = [{ userId }];
+    if (Object.keys(extraWhere).length > 0) clauses.push(extraWhere);
+    if (cursorClause) clauses.push(cursorClause);
+    return clauses.length === 1 ? clauses[0] : { AND: clauses };
+  }
+
+  // Live query — soft-delete extension auto-filters to `deletedAt: null`
+  // because the resulting `where` has no top-level `deletedAt` key.
+  const live = (await prismaModel.findMany({
+    where: buildWhere(),
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+    take: limit + 1,
+  })) as T[];
+
+  let dead: T[] = [];
+  if (includeTombstones) {
+    // Tombstone query — `deletedAt: { not: null }` lifted to the OUTER
+    // where (not inside the AND) so the soft-delete extension's bypass
+    // check (`"deletedAt" in where`) sees it. If we put it inside the
+    // AND, the extension would auto-add `deletedAt: null`, contradicting
+    // the tombstone filter and silently returning zero rows.
+    const deadWhere: Record<string, unknown> = { ...buildWhere(), deletedAt: { not: null } };
+
+    dead = (await prismaModel.findMany({
+      where: deadWhere,
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: limit + 1,
+    })) as T[];
+  }
+
+  // Two-way merge by `(updatedAt, id)` ASC. Both inputs are already in
+  // that order from Prisma's orderBy, so this is a linear merge.
+  const merged: T[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < live.length && j < dead.length) {
+    if (compareKeyset(live[i], dead[j]) <= 0) {
+      merged.push(live[i++]);
+    } else {
+      merged.push(dead[j++]);
+    }
+  }
+  while (i < live.length) merged.push(live[i++]);
+  while (j < dead.length) merged.push(dead[j++]);
+
+  const hasMore = merged.length > limit;
+  const slice: T[] = hasMore ? merged.slice(0, limit) : merged;
+
+  // Classify after slicing — a tombstone in the +1 detection slot must
+  // not leak into `deleted`, only the in-page rows count.
+  const upserted: T[] = [];
+  const deletedIds: string[] = [];
+  for (const row of slice) {
+    if (row.deletedAt == null) {
+      upserted.push(row);
+    } else {
+      deletedIds.push(row.id);
+    }
+  }
+
+  const last = slice[slice.length - 1];
+  const nextCursor = last ? formatCursor(last.updatedAt, last.id) : null;
+
+  return { upserted, deleted: deletedIds, hasMore, nextCursor };
+}

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -120,6 +120,45 @@ const FALLBACK_DEFAULT_LIMIT = 50;
 // the algorithm behind why we don't paginate upserts and tombstones
 // independently anymore.
 
+/**
+ * Map a thrown error from a /sync/push mutation handler into a public
+ * response message safe to send back to the client. Raw Prisma errors
+ * include schema details (column names, constraint names, table
+ * structure) that should never leave the server — they confirm the
+ * existence of soft-deleted records on a guessed id, or hint at
+ * internal modelling that an attacker could pivot from.
+ *
+ * Returns:
+ * - `publicMessage` — what the client sees in `result.error`.
+ * - `logFull` — true when the caller should log the original error
+ *   message server-side. False for benign cases the route handler
+ *   already classified (so we don't spam ops with expected outcomes).
+ */
+function sanitisePushError(err: unknown): { publicMessage: string; logFull: boolean } {
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    switch (err.code) {
+      case "P2002":
+        // Unique constraint violation. Could be a CREATE colliding on
+        // an id (whether live or soft-deleted) — either way "duplicate"
+        // is the only safe public framing.
+        return { publicMessage: "duplicate", logFull: true };
+      case "P2025":
+        // Record to update/delete not found. Caller-facing equivalent
+        // of `not_found` — surface that without leaking the where
+        // clause Prisma echoes.
+        return { publicMessage: "not_found", logFull: false };
+      default:
+        // Any other known Prisma error — never echo it.
+        return { publicMessage: "database_error", logFull: true };
+    }
+  }
+  if (err instanceof Prisma.PrismaClientValidationError) {
+    return { publicMessage: "invalid_payload", logFull: true };
+  }
+  // Genuinely unknown — keep public message generic.
+  return { publicMessage: "internal_error", logFull: true };
+}
+
 export const sync = new Hono<AuthEnv>()
   .use("/*", authMiddleware)
 
@@ -201,8 +240,13 @@ export const sync = new Hono<AuthEnv>()
       // Keyset-merged pull: live + tombstones in one ordered stream, single
       // monotonic cursor. See `paginated-pull.ts` for the algorithm and
       // why the previous independent-pagination approach lost rows.
+      // Pass `prismaClient` so the live + tombstone queries share a
+      // single snapshot — without it, a mutation between the two
+      // queries can leave a row in an inconsistent classification
+      // for that page.
       const result = await paginatedPull({
         prismaModel: model,
+        prismaClient: prisma,
         userId: user.id,
         cursor,
         limit: tableLimit,
@@ -310,10 +354,26 @@ export const sync = new Hono<AuthEnv>()
             };
         }
       } catch (err) {
+        // Don't leak Prisma's raw error messages to clients — they
+        // include schema/column hints (e.g. "Unique constraint failed
+        // on the fields: (`id`)") that confirm the existence of
+        // soft-deleted rows or expose internal column names. Map known
+        // Prisma error codes to stable, sanitised public messages;
+        // server logs keep the full detail for ops.
+        const sanitised = sanitisePushError(err);
+        if (err instanceof Error && sanitised.logFull) {
+          console.warn(
+            "[sync/push] mutation failed:",
+            mutation.action,
+            mutation.entityType,
+            mutation.entityId,
+            err.message,
+          );
+        }
         result = {
           idempotencyKey: mutation.idempotencyKey,
           status: "error",
-          error: err instanceof Error ? err.message : "Unknown error",
+          error: sanitised.publicMessage,
         };
       }
 

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -7,6 +7,7 @@ import { fieldLevelMerge, findMissingBaselines } from "../lib/sync-merge.js";
 import { publishSSE } from "../lib/sse.js";
 import { detectContentType } from "@brett/utils";
 import { runExtraction } from "../lib/content-extractor.js";
+import { paginatedPull, parseCursor } from "../lib/sync/paginated-pull.js";
 import type {
   SyncPullRequest, SyncPullResponse, SyncTableChanges,
   SyncPushRequest, SyncPushResponse, SyncMutation, SyncMutationResult,
@@ -73,51 +74,51 @@ function filterCreatePayload(
 }
 
 const CURRENT_PROTOCOL_VERSION = 1;
-const DEFAULT_LIMIT = 500;
 const MAX_LIMIT = 1000;
 const STALE_CURSOR_DAYS = 30;
 const MAX_MUTATIONS = 50;
 const MAX_BODY_SIZE = 1_048_576; // 1MB
 
 /**
- * Cursor is `"<ISO-8601 timestamp>|<row id>"` or, for clients on the old
- * format, just `"<ISO-8601 timestamp>"`. We always emit the pipe form; we
- * still accept the old form so an existing client's stored cursor keeps
- * working across the deploy.
+ * Per-table default page sizes. The values are chosen so that the worst
+ * realistic per-row payload × per-table limit stays comfortably under
+ * 1 MB even for content-heavy users:
  *
- * Keyset pagination over `(updatedAt, id)` fixes a boundary bug where many
- * rows sharing the exact same `updatedAt` could get sliced across pages
- * and the skipped ones permanently missed on the next pull.
+ *   - `items` rows can include up to ~5–8 KB of extracted `contentBody`,
+ *     so 50 rows ≈ 250–400 KB worst case. Going higher (e.g. 200) risks
+ *     a single page exceeding 1 MB on power users.
+ *   - `brett_messages` rows include AI assistant responses + citations,
+ *     similar size class to items. 50 keeps memory and parse cost sane.
+ *   - All other tables hold lightweight metadata (≤1 KB / row), so 200
+ *     is comfortable and cuts the round-trip count for power users.
+ *
+ * If the client sends `body.limit`, it overrides ALL tables — that's
+ * the legacy single-limit knob and we keep honoring it for clients on
+ * older protocols. Modern clients should omit `limit` so the per-table
+ * defaults apply.
  */
-function parseCursor(raw: string | null | undefined): { ts: Date; id: string | null } | null {
-  if (!raw) return null;
-  const pipe = raw.indexOf("|");
-  if (pipe === -1) {
-    const ts = new Date(raw);
-    return Number.isNaN(ts.getTime()) ? null : { ts, id: null };
-  }
-  const ts = new Date(raw.slice(0, pipe));
-  if (Number.isNaN(ts.getTime())) return null;
-  return { ts, id: raw.slice(pipe + 1) };
-}
+const DEFAULT_LIMIT_BY_TABLE: Record<SyncTable, number> = {
+  items: 50,
+  brett_messages: 50,
+  lists: 200,
+  calendar_events: 200,
+  calendar_event_notes: 200,
+  scouts: 200,
+  scout_findings: 200,
+  attachments: 200,
+};
 
-function formatCursor(updatedAt: Date | string, id: string): string {
-  const iso = updatedAt instanceof Date ? updatedAt.toISOString() : updatedAt;
-  return `${iso}|${id}`;
-}
+/**
+ * Fallback if a new table is added to `SYNC_TABLES` without being added
+ * to `DEFAULT_LIMIT_BY_TABLE`. Conservative — the small-table value, so
+ * a forgotten content-heavy addition wouldn't accidentally pump 200 rows.
+ */
+const FALLBACK_DEFAULT_LIMIT = 50;
 
-function applyCursorFilter(where: Record<string, unknown>, cursor: string | null | undefined): void {
-  const parsed = parseCursor(cursor);
-  if (!parsed) return;
-  if (parsed.id === null) {
-    where.updatedAt = { gt: parsed.ts };
-    return;
-  }
-  where.OR = [
-    { updatedAt: { gt: parsed.ts } },
-    { updatedAt: parsed.ts, id: { gt: parsed.id } },
-  ];
-}
+// Cursor parsing/formatting + keyset-merge pagination live in
+// `lib/sync/paginated-pull.ts`. See that file for the wire format and
+// the algorithm behind why we don't paginate upserts and tombstones
+// independently anymore.
 
 export const sync = new Hono<AuthEnv>()
   .use("/*", authMiddleware)
@@ -134,13 +135,17 @@ export const sync = new Hono<AuthEnv>()
       );
     }
 
-    // Validate limit
-    const limit = body.limit ?? DEFAULT_LIMIT;
-    if (limit < 1 || limit > MAX_LIMIT) {
-      return c.json(
-        { error: `limit must be between 1 and ${MAX_LIMIT}` },
-        400,
-      );
+    // Validate limit. `body.limit`, when present, is a single value that
+    // overrides every table's default. Modern clients should omit it and
+    // let the per-table defaults apply (see `DEFAULT_LIMIT_BY_TABLE`).
+    const overrideLimit = body.limit;
+    if (overrideLimit !== undefined && overrideLimit !== null) {
+      if (!Number.isInteger(overrideLimit) || overrideLimit < 1 || overrideLimit > MAX_LIMIT) {
+        return c.json(
+          { error: `limit must be between 1 and ${MAX_LIMIT}` },
+          400,
+        );
+      }
     }
 
     const cursors = body.cursors ?? {};
@@ -176,81 +181,47 @@ export const sync = new Hono<AuthEnv>()
       const modelAccessor = SYNC_TABLE_TO_MODEL[table];
       const model = (prisma as any)[modelAccessor];
 
-      // Runtime check — skip if model accessor is invalid
+      // Runtime check — skip if model accessor is invalid (defense against a
+      // future SYNC_TABLES entry that doesn't map to a real Prisma model).
       if (!model || typeof model.findMany !== "function") {
         changes[table] = { upserted: [], deleted: [], hasMore: false };
         continue;
       }
 
       const cursor = cursors[table] ?? null;
+      const tableLimit = overrideLimit ?? DEFAULT_LIMIT_BY_TABLE[table] ?? FALLBACK_DEFAULT_LIMIT;
 
-      // Every syncable model has a direct userId column, so sync pull
-      // hits the composite `(userId, updatedAt)` index without a join.
-      const where: any = { userId: user.id };
-      applyCursorFilter(where, cursor);
-
-      // Special handling for calendar_events: scope to last 90 days + future
+      // Per-table extra filters. Calendar events scope to last 90 days +
+      // future to keep mobile from pulling years of historical events.
+      const extraWhere: Record<string, unknown> = {};
       if (table === "calendar_events") {
-        where.startTime = { gte: ninetyDaysAgo };
+        extraWhere.startTime = { gte: ninetyDaysAgo };
       }
 
-      // Keyset pagination: order by (updatedAt, id) so rows sharing a
-      // millisecond don't get split across pages and silently lost.
-      const upserted = await model.findMany({
-        where,
-        orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
-        take: limit + 1, // +1 to detect hasMore
-      });
-
-      // Query tombstone IDs only (bypasses soft-delete extension via key existence)
-      const tombstoneWhere: any = {
+      // Keyset-merged pull: live + tombstones in one ordered stream, single
+      // monotonic cursor. See `paginated-pull.ts` for the algorithm and
+      // why the previous independent-pagination approach lost rows.
+      const result = await paginatedPull({
+        prismaModel: model,
         userId: user.id,
-        deletedAt: { not: null }, // key exists -> bypasses extension
-      };
-      applyCursorFilter(tombstoneWhere, cursor);
-      // Special handling for calendar_events tombstones
-      if (table === "calendar_events") {
-        tombstoneWhere.startTime = { gte: ninetyDaysAgo };
-      }
-
-      // Include updatedAt on tombstones so we can advance the cursor past them.
-      // Otherwise a high-volume upsert window would "hide" tombstones that fall
-      // later in the timestamp sequence: the cursor would jump to the last
-      // upsert's updatedAt, skipping tombstones whose updatedAt was further in
-      // the future. Soft-deletes would then never propagate to mobile.
-      const tombstones = await model.findMany({
-        where: tombstoneWhere,
-        select: { id: true, updatedAt: true },
-        take: limit,
-        orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+        cursor,
+        limit: tableLimit,
+        extraWhere,
       });
-      const deleted = tombstones.map((r: any) => r.id);
 
-      // Check pagination
-      const hasMore = upserted.length > limit;
-      const records = hasMore ? upserted.slice(0, limit) : upserted;
-
-      // Compute new cursor from the latest row across upserts and tombstones.
-      // Cursor is `"<updatedAt>|<id>"` so clients can resume on the exact row
-      // boundary without skipping siblings that share a timestamp.
-      const lastUpserted = records.length > 0 ? records[records.length - 1] : null;
-      const lastTombstone = tombstones.length > 0 ? tombstones[tombstones.length - 1] : null;
-      let winner: { updatedAt: Date | string; id: string } | null = null;
-      if (lastUpserted && lastTombstone) {
-        const a = new Date(lastUpserted.updatedAt).getTime();
-        const b = new Date(lastTombstone.updatedAt).getTime();
-        winner = a >= b ? lastUpserted : lastTombstone;
-      } else {
-        winner = lastUpserted ?? lastTombstone;
-      }
-      if (winner) {
-        newCursors[table] = formatCursor(winner.updatedAt, winner.id);
+      changes[table] = {
+        upserted: result.upserted,
+        deleted: result.deleted,
+        hasMore: result.hasMore,
+      };
+      if (result.nextCursor) {
+        newCursors[table] = result.nextCursor;
       } else if (cursor) {
-        // Preserve existing cursor if no new records
+        // Preserve existing cursor when no rows were returned — without
+        // this, a temporarily empty page would reset the client to
+        // cursor=null and force a fresh full re-walk on the next pull.
         newCursors[table] = cursor;
       }
-
-      changes[table] = { upserted: records, deleted, hasMore };
     }
 
     const response: SyncPullResponse = {

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -9,6 +9,7 @@ import { enqueueEmbed, deleteEmbeddings, assembleItemText, assembleContentText, 
 import type { ItemAssemblerInput, ContentAssemblerInput } from "@brett/ai";
 import type { ThingDetail, Attachment as AttachmentType, ItemLink as ItemLinkType, BrettMessage as BrettMessageType } from "@brett/types";
 import { getEmbeddingProvider } from "../lib/embedding-provider.js";
+import { paginatedPull, type PaginatedPullResult } from "../lib/sync/paginated-pull.js";
 
 const things = new Hono<AuthEnv>();
 
@@ -145,52 +146,128 @@ async function verifyListOwnership(listId: string, userId: string) {
 things.use("*", authMiddleware);
 
 // GET /things — list things with optional filters
+//
 // Supports date range filters:
 //   dueBefore=ISO   — items with dueDate <= value (inclusive)
 //   dueAfter=ISO    — items with dueDate > value (exclusive)
 //   completedAfter=ISO — items with completedAt >= value
-// Hard cap so a heavy-user load doesn't serialize the entire Item table on
-// every desktop open. `500` comfortably covers Today/Upcoming/Inbox working
-// sets; the clients paginate via the dueBefore/dueAfter/completedAfter filters
-// for historical data.
-const THINGS_LIST_DEFAULT_LIMIT = 500;
-const THINGS_LIST_MAX_LIMIT = 2000;
+//
+// Goes through the same `paginatedPull` core that /sync/pull uses so both
+// clients see the same correct, deterministic, no-row-skip data — the
+// previous direct `findMany({ take: 500 })` quietly truncated power
+// users and used a different code path than mobile, which was the
+// architectural asymmetry behind the Electron-vs-iOS divergence.
+//
+// `paginatedPull` returns rows in `(updatedAt, id)` ascending keyset
+// order; we accumulate across pages and re-sort by `createdAt` desc at
+// the end to preserve the existing UI ordering contract. Sorting in
+// memory is fine: the `limit` cap below bounds N.
+const THINGS_INTERNAL_PAGE_SIZE = 200;          // per-page server walk; metadata-light tables can use a bigger page
+const THINGS_LIST_DEFAULT_MAX_ROWS = 2000;      // upper bound on the accumulated walk per request
+const THINGS_LIST_HARD_MAX_ROWS = 5000;         // never let `?limit=` push past this — prevents server OOM on bad input
 
 things.get("/", async (c) => {
   const user = c.get("user");
   const { listId, type, status, source, dueBefore, dueAfter, completedAfter, search, limit } = c.req.query();
 
-  const where: Record<string, unknown> = { userId: user.id };
+  // `extraWhere` is layered AND with `userId` and the cursor inside
+  // `paginatedPull`. Keep `userId` and `deletedAt` out of here — those
+  // are owned by the pull function.
+  const extraWhere: Record<string, unknown> = {};
   if (search) {
-    where.OR = [
+    extraWhere.OR = [
       { title: { contains: search, mode: "insensitive" } },
       { notes: { contains: search, mode: "insensitive" } },
     ];
   }
-  if (listId) where.listId = listId;
-  if (type) where.type = type;
-  if (status) where.status = status;
-  if (source) where.source = source;
+  if (listId) extraWhere.listId = listId;
+  if (type) extraWhere.type = type;
+  if (status) extraWhere.status = status;
+  if (source) extraWhere.source = source;
   if (dueBefore && dueAfter) {
-    where.dueDate = { gt: new Date(dueAfter), lte: new Date(dueBefore) };
+    extraWhere.dueDate = { gt: new Date(dueAfter), lte: new Date(dueBefore) };
   } else if (dueBefore) {
-    where.dueDate = { lte: new Date(dueBefore) };
+    extraWhere.dueDate = { lte: new Date(dueBefore) };
   } else if (dueAfter) {
-    where.dueDate = { gt: new Date(dueAfter) };
+    extraWhere.dueDate = { gt: new Date(dueAfter) };
   }
-  if (completedAfter) where.completedAt = { gte: new Date(completedAfter) };
+  if (completedAfter) extraWhere.completedAt = { gte: new Date(completedAfter) };
 
-  const parsedLimit = limit ? parseInt(limit, 10) : THINGS_LIST_DEFAULT_LIMIT;
-  const take = Number.isFinite(parsedLimit) && parsedLimit > 0
-    ? Math.min(parsedLimit, THINGS_LIST_MAX_LIMIT)
-    : THINGS_LIST_DEFAULT_LIMIT;
+  // Resolve the "stop walking once we've collected N rows" cap. Honors
+  // `?limit=` if sane, else falls back to the default.
+  const parsedLimit = limit ? parseInt(limit, 10) : THINGS_LIST_DEFAULT_MAX_ROWS;
+  const maxRows = Number.isFinite(parsedLimit) && parsedLimit > 0
+    ? Math.min(parsedLimit, THINGS_LIST_HARD_MAX_ROWS)
+    : THINGS_LIST_DEFAULT_MAX_ROWS;
 
-  const items = await prisma.item.findMany({
-    where,
-    include: { list: { select: { name: true } }, meetingNote: { select: { title: true, calendarEventId: true } } },
-    orderBy: [{ createdAt: "desc" }],
-    take,
-  });
+  // Walk paginatedPull until we've either collected `maxRows` ids or
+  // exhausted the user's matching set. `includeTombstones: false` —
+  // /things is a view-shaped read; deleted rows have nothing to show.
+  // We only collect ids here — the relation-aware re-fetch below
+  // produces the actual response payload.
+  const ids: string[] = [];
+  let cursor: string | null = null;
+  // Defensive watchdog: round-count cap that's far above any legitimate
+  // walk. With page size 200 and maxRows 5000, a healthy walk is at
+  // most 25 rounds. 100 rounds means something is wrong (e.g. a future
+  // bug where the cursor stops advancing) and we should bail rather
+  // than spin.
+  const ROUND_CAP = 100;
+  for (let round = 0; round < ROUND_CAP; round++) {
+    const remaining = maxRows - ids.length;
+    if (remaining <= 0) break;
+    const pageLimit = Math.min(THINGS_INTERNAL_PAGE_SIZE, remaining);
+    type Row = { id: string; updatedAt: Date; deletedAt: Date | null };
+    const result: PaginatedPullResult<Row> = await paginatedPull({
+      prismaModel: prisma.item,
+      userId: user.id,
+      cursor,
+      limit: pageLimit,
+      extraWhere,
+      includeTombstones: false,
+    });
+    for (const row of result.upserted) {
+      ids.push(row.id);
+    }
+    if (!result.hasMore) break;
+    if (!result.nextCursor || cursor === result.nextCursor) {
+      // Belt-and-braces: paginatedPull guarantees monotonic advancement
+      // when hasMore is true, but if some future bug breaks that, fail
+      // closed instead of looping forever.
+      break;
+    }
+    cursor = result.nextCursor;
+  }
+
+  // Re-fetch with relations + ordering for the accumulated id set. Two
+  // round trips (paginatedPull then this hydrate) is the price for
+  // routing /things through the shared sync core; the alternative —
+  // accepting a `select`/`include` parameter on `paginatedPull` —
+  // would couple the sync engine to view-specific shaping. The id set
+  // is bounded by `maxRows`, so the second query stays cheap.
+  //
+  // Defense in depth: re-scope by `userId` even though `paginatedPull`
+  // already enforced it on the id collection step. If a future bug
+  // anywhere upstream (bad spread, refactor, prisma extension issue)
+  // let a foreign id leak into `ids`, the hydrate would happily return
+  // it. Belt-and-braces.
+  //
+  // Note on the live-vs-hydrate window: a row can be soft-deleted
+  // BETWEEN the paginatedPull walk and this query, in which case the
+  // soft-delete extension's auto-`deletedAt: null` filter drops it.
+  // The response then under-counts by one row vs the walk's id list.
+  // That's acceptable for a view-shaped read — the next sync round
+  // surfaces the tombstone — but worth knowing.
+  const items = ids.length === 0
+    ? []
+    : await prisma.item.findMany({
+        where: { id: { in: ids }, userId: user.id },
+        include: {
+          list: { select: { name: true } },
+          meetingNote: { select: { title: true, calendarEventId: true } },
+        },
+        orderBy: [{ createdAt: "desc" }],
+      });
 
   const enriched = await enrichWithScoutNames(items);
   const thingsList = enriched.map((item) => itemToThing(item as any));

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -220,6 +220,7 @@ things.get("/", async (c) => {
     type Row = { id: string; updatedAt: Date; deletedAt: Date | null };
     const result: PaginatedPullResult<Row> = await paginatedPull({
       prismaModel: prisma.item,
+      prismaClient: prisma,
       userId: user.id,
       cursor,
       limit: pageLimit,

--- a/apps/ios/Brett/Networking/Endpoints/SyncEndpoints.swift
+++ b/apps/ios/Brett/Networking/Endpoints/SyncEndpoints.swift
@@ -21,9 +21,14 @@ enum SyncProtocol {
     /// with `CURRENT_PROTOCOL_VERSION` in `apps/api/src/routes/sync.ts`.
     static let version: Int = 1
 
-    /// Default page size for pulls. The server caps individual responses
-    /// regardless; we use a large value to reduce round-trips.
-    static let defaultPullLimit: Int = 500
+    /// Optional client-side override for the per-table page size. Nil
+    /// means "let the server pick per-table defaults" — that's the right
+    /// answer post the server's keyset-merge fix, where defaults are
+    /// items=50 (large rows) and others=200 (metadata). Setting this
+    /// non-nil applies one value to ALL tables (legacy single-knob
+    /// behavior; needed only for tests that want a deterministic page
+    /// boundary).
+    static let defaultPullLimit: Int? = nil
 
     /// The canonical list of tables the pull engine tracks. Order matches
     /// the server's `SYNC_TABLES` constant.
@@ -190,7 +195,10 @@ struct SyncPushRequestBody {
 /// POST body for `/sync/pull`. `null` cursors (first sync) are encoded as JSON null.
 struct SyncPullRequestBody {
     let cursors: [String: String?]
-    let limit: Int
+    /// Optional override applied uniformly to all tables. Nil omits the
+    /// `limit` field from the request entirely so the server's per-table
+    /// defaults kick in (items=50 vs lists=200, etc.).
+    let limit: Int?
 
     func encode() throws -> Data {
         // JSONSerialization requires NSNull for null values — wrap optionals.
@@ -201,11 +209,13 @@ struct SyncPullRequestBody {
                 acc[pair.key] = NSNull()
             }
         }
-        let dict: [String: Any] = [
+        var dict: [String: Any] = [
             "protocolVersion": SyncProtocol.version,
             "cursors": encodedCursors,
-            "limit": limit,
         ]
+        if let limit {
+            dict["limit"] = limit
+        }
         return try JSONSerialization.data(withJSONObject: dict, options: [])
     }
 }
@@ -227,10 +237,12 @@ extension APIClient {
     }
 
     /// POST to `/sync/pull` with per-table cursors. Pass `nil` for tables
-    /// that have never been synced.
+    /// that have never been synced. `limit` defaults to nil → server
+    /// applies per-table page sizes; set non-nil to force a uniform
+    /// page size across every table (rarely useful outside tests).
     func syncPull(
         cursors: [String: String?],
-        limit: Int = SyncProtocol.defaultPullLimit
+        limit: Int? = SyncProtocol.defaultPullLimit
     ) async throws -> SyncPullResponse {
         let body = try SyncPullRequestBody(cursors: cursors, limit: limit).encode()
         let (data, _) = try await rawRequest(

--- a/apps/ios/Brett/Sync/MutationQueue.swift
+++ b/apps/ios/Brett/Sync/MutationQueue.swift
@@ -294,10 +294,22 @@ final class MutationQueue: MutationQueueProtocol {
 
     /// HTTP status codes that are never worth retrying: the server will
     /// reject the payload deterministically no matter how many times we
-    /// resend it. Spec §2.4 + §RESILIENCE lists 400/422 as permanent; we
-    /// treat the other 4xx "client error" codes the same way.
+    /// resend it. Spec §2.4 + §RESILIENCE lists 400/422 as permanent.
+    /// Other 4xx codes are EITHER transient or permanent — we treat the
+    /// transient ones (`408`, `429`) and `5xx` the same as a network
+    /// error (retry on the next push cycle), and only the truly
+    /// permanent client errors (everything else in the 4xx band) as
+    /// dead-on-arrival.
+    ///
+    /// 429 in particular: a transient rate-limit blip used to be marked
+    /// dead, which silently dropped the user's mutation forever. The
+    /// next push cycle will retry instead.
     private static func isPermanent4xx(_ code: Int?) -> Bool {
         guard let code else { return false }
-        return (400...499).contains(code)
+        // Out of the 4xx band → not 4xx-permanent.
+        if !(400...499).contains(code) { return false }
+        // Transient throttling / timeout — retry, don't kill.
+        if code == 408 || code == 429 { return false }
+        return true
     }
 }

--- a/apps/ios/Brett/Sync/PullEngine.swift
+++ b/apps/ios/Brett/Sync/PullEngine.swift
@@ -47,11 +47,22 @@ final class PullEngine {
 
     enum PullError: LocalizedError {
         case savePersistFailed(underlying: Error)
+        /// Detected when the server's pagination cursor for a table that
+        /// reported `hasMore=true` does not advance between rounds —
+        /// only possible if the server side regressed. Bail rather than
+        /// infinite-loop; the next sync cycle will retry from the
+        /// (unchanged) cursor against whatever the server's state is by
+        /// then. The `table` field tells you WHICH table is broken — a
+        /// single stuck table shouldn't drag the whole pull into a loop
+        /// just because OTHER tables still have legitimate work to do.
+        case cursorStuck(round: Int, table: String)
 
         var errorDescription: String? {
             switch self {
             case .savePersistFailed(let underlying):
                 return "Pull save failed: \(underlying.localizedDescription)"
+            case .cursorStuck(let round, let table):
+                return "Pull cursor for table '\(table)' stopped advancing on round \(round) — server pagination is broken."
             }
         }
     }
@@ -79,9 +90,25 @@ final class PullEngine {
 
     // MARK: - Pull
 
-    /// Run a single pull cycle. Loops internally (up to `maxRounds`) when
-    /// the server reports `hasMore` — one round per `limit` slice.
-    func pull(maxRounds: Int = 10) async throws -> PullOutcome {
+    /// Soft cap on round count for a single `pull()` invocation. With the
+    /// server-side keyset-merge fix, every round either consumes new
+    /// rows OR converges to `hasMore=false` — so this cap should never
+    /// fire under normal operation. It exists as a watchdog: if a future
+    /// regression breaks cursor monotonicity, the loop bails instead of
+    /// spinning forever. 1000 rounds × the smallest server page (50)
+    /// covers 50k rows per pull, far above any realistic dataset.
+    static let safetyRoundCap = 1000
+
+    /// Run a single pull cycle. Loops internally until every requested
+    /// table reports `hasMore=false`, OR a cursor-stuck safety check
+    /// fires, OR the safety round cap is exhausted.
+    ///
+    /// Cursor-stuck detection: if a round reports `anyHasMore=true` but
+    /// no table's cursor advanced, the server-side pagination is broken
+    /// and continuing would infinite-loop. Bail with an error so the
+    /// next foreground poll has a chance to retry against (presumably)
+    /// fixed server state.
+    func pull() async throws -> PullOutcome {
         var tablesUpserted: [String: Int] = [:]
         var tablesDeleted: [String: Int] = [:]
 
@@ -93,8 +120,12 @@ final class PullEngine {
         // upsertCursor) yielding O(tables × rounds) fetches per pull.
         var cursorCache = loadCursorCache()
 
-        for _ in 0..<maxRounds {
+        for round in 0..<Self.safetyRoundCap {
             let cursors = cursorMap(from: cursorCache)
+            // Snapshot pre-round cursors for the cursor-stuck safety
+            // check below. `Dictionary` has value semantics so this is
+            // a real snapshot, not a reference.
+            let cursorsBeforeRound = cursors
             let response: SyncPullResponse
 
             do {
@@ -125,6 +156,12 @@ final class PullEngine {
             var anyHasMore = false
             var pendingUpsertsThisRound: [String: Int] = [:]
             var pendingDeletesThisRound: [String: Int] = [:]
+            // Track per-table `hasMore` so the cursor-stuck check below
+            // can fire when ANY single table loops without advancing —
+            // a global "all cursors unchanged" check would miss the
+            // case where one table is stuck while another is still
+            // making real progress.
+            var hasMoreByTable: [String: Bool] = [:]
 
             // Yield every `yieldBatch` rows so a big pull doesn't lock up
             // the main actor. SyncEntityMapper.upsert is @MainActor, and on
@@ -172,6 +209,7 @@ final class PullEngine {
 
                 pendingUpsertsThisRound[table] = inserted
                 pendingDeletesThisRound[table] = deleted
+                hasMoreByTable[table] = slice.hasMore
                 if slice.hasMore { anyHasMore = true }
             }
 
@@ -208,6 +246,27 @@ final class PullEngine {
             }
 
             if !anyHasMore { break }
+
+            // Per-table cursor-stuck safety. With the server's keyset-
+            // merge pagination, every table that reports `hasMore=true`
+            // must advance its cursor on the next round. If ANY such
+            // table failed to advance, the server is broken on that
+            // table specifically — continuing would loop at the rate
+            // of (other-table progress) for as long as the bug persists.
+            // Fail loud rather than spin: the next foreground poll
+            // retries against whatever the server's state is by then.
+            // Counts as a real failure so the poll backoff kicks in.
+            let cursorsAfterRound = cursorMap(from: cursorCache)
+            for (table, hasMore) in hasMoreByTable where hasMore {
+                if cursorsBeforeRound[table] == cursorsAfterRound[table] {
+                    let stuckError = PullError.cursorStuck(round: round, table: table)
+                    BrettLog.pull.error(
+                        "pull cursor stuck for \(table, privacy: .public) on round \(round, privacy: .public)"
+                    )
+                    recordPullFailure(error: stuckError)
+                    throw stuckError
+                }
+            }
         }
 
         recordPullSuccess()

--- a/apps/ios/Brett/Sync/SSEClient.swift
+++ b/apps/ios/Brett/Sync/SSEClient.swift
@@ -67,6 +67,21 @@ final class SSEClient {
     /// cadence quickly. Exposed via init for tests.
     private let sustainedHealthyThreshold: TimeInterval
 
+    /// Maximum gap allowed between consecutive bytes from the SSE
+    /// server. The server sends a `: heartbeat` comment every ~30s, so
+    /// any silence past ≈2.5× that is a sign the connection has gone
+    /// dead at the network layer (broken intermediary, NAT timeout
+    /// without TCP RST). The default 75s strikes that balance:
+    /// resilient to a single missed heartbeat, fast enough that the
+    /// user isn't stranded on a phantom-connected stream for 10 min
+    /// (which is what the prior 600s timeout allowed).
+    ///
+    /// Wired into `URLRequest.timeoutInterval` — that value is the max
+    /// gap between received bytes for streaming requests, RESET on
+    /// every byte. So healthy heartbeats keep the connection alive
+    /// indefinitely; only true silence triggers a reconnect.
+    private let silentStreamWatchdog: TimeInterval
+
     // MARK: - Event stream
 
     /// Raw stream of parsed events. `SSEEventHandler.start()` is the primary
@@ -104,8 +119,10 @@ final class SSEClient {
         session: URLSession = .shared,
         maxBackoffSeconds: TimeInterval = 30,
         backoffMultiplier: TimeInterval = 1,
-        sustainedHealthyThreshold: TimeInterval = 300
+        sustainedHealthyThreshold: TimeInterval = 300,
+        silentStreamWatchdog: TimeInterval = 75
     ) {
+        self.silentStreamWatchdog = silentStreamWatchdog
         self.apiClient = apiClient
         self.session = session
         self.maxBackoffSeconds = maxBackoffSeconds
@@ -234,12 +251,19 @@ final class SSEClient {
         request.httpMethod = "GET"
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
-        // Long timeout — SSE streams are expected to stay open indefinitely.
-        // The server sends a heartbeat every ~30s, but URLSession's default
-        // timeout (60s) would still fire during lulls. Give ourselves plenty
-        // of headroom; if the connection truly dies, bytes iteration will
-        // throw and the outer loop handles the reconnect.
-        request.timeoutInterval = 600
+        // `timeoutInterval` on a streaming request is the max gap allowed
+        // between received bytes — it RESETS each time data arrives.
+        // The server sends `: heartbeat` every 30s, so any byte gap past
+        // `silentStreamWatchdog` (default 75s, ≈2.5× heartbeat) means
+        // the connection has gone dead at the network layer (broken NAT,
+        // intermediary that swallowed the FIN, etc.). When that timeout
+        // fires, `bytes(for:)` throws and the outer loop reconnects.
+        //
+        // The previous 600s value was a "give the stream lots of headroom"
+        // misread — heartbeats already reset the timer, so a healthy
+        // stream never trips a tighter timeout, and a dead stream
+        // shouldn't have to wait 10 minutes to be detected.
+        request.timeoutInterval = silentStreamWatchdog
 
         let (bytes, response) = try await session.bytes(for: request)
         try Self.validateStreamResponse(response)

--- a/apps/ios/Brett/Sync/SyncEntityMapper.swift
+++ b/apps/ios/Brett/Sync/SyncEntityMapper.swift
@@ -32,6 +32,23 @@ enum SyncEntityMapper {
     ) {
         guard let id = record["id"] as? String, !id.isEmpty else { return }
 
+        // Defense in depth: drop rows whose `userId` doesn't match the
+        // active session. /sync/pull is server-side user-scoped, so under
+        // correct operation every row carries the current user's id.
+        // But if a stale response from a prior account were ever to land
+        // (sign-out → sign-in race, mock URL replay, malicious proxy),
+        // applying its rows would write a foreign userId onto local
+        // models — silent cross-user data leakage. Reject defensively.
+        if let activeUserId = ActiveSession.userId,
+           let recordUserId = record["userId"] as? String,
+           !recordUserId.isEmpty,
+           recordUserId != activeUserId {
+            BrettLog.pull.error(
+                "dropping incoming \(tableName, privacy: .public) row whose userId does not match active session — possible stale-response or cross-user leak"
+            )
+            return
+        }
+
         switch tableName {
         case "lists":
             upsertList(id: id, dict: record, context: context, respectLocalPending: respectLocalPending)

--- a/apps/ios/BrettTests/Sync/PullEngineTests.swift
+++ b/apps/ios/BrettTests/Sync/PullEngineTests.swift
@@ -232,16 +232,19 @@ struct PullEngineTests {
 
     // MARK: - Multi-round (hasMore)
 
-    @Test func hasMoreTriggersAdditionalRounds() async throws {
+    /// Cursor-stuck detection — if a single table reports `hasMore=true`
+    /// but its cursor doesn't advance between rounds, the engine must
+    /// bail rather than infinite-loop. With the post-fix server, this
+    /// scenario is impossible under correct operation; the test still
+    /// pins the safety net so a future server regression doesn't lock
+    /// up the client.
+    ///
+    /// Mechanism: stub once with `hasMore=true` and a fixed cursor.
+    /// Round 1 advances the local cursor from nil → that fixed value;
+    /// round 2 sees `cursorsBefore[items] == cursorsAfter[items]` and
+    /// throws `PullError.cursorStuck(table: "items")`.
+    @Test func cursorStuckDetectionPreventsInfiniteLoop() async throws {
         let context = try InMemoryPersistenceController.makeContext()
-
-        // We can't change the stubbed response mid-test with MockURLProtocol
-        // (same URL → same stub). Instead, stub once with `hasMore = false`
-        // and assert the engine uses the stub once; for multi-round we rely
-        // on the engine's deterministic loop-until-false logic, which is
-        // covered by the functional test below using `hasMore = true` on
-        // the first (and only) stub — the loop should bail after
-        // `maxRounds` without spinning forever.
 
         var body = emptyPullBody()
         var changes = body["changes"] as! [String: Any]
@@ -257,26 +260,144 @@ struct PullEngineTests {
                 "updatedAt": "2026-04-14T11:30:00.000Z",
             ]],
             "deleted": [],
-            "hasMore": true, // server says "more to fetch"
+            "hasMore": true, // server claims more, but cursor below never moves
         ]
         body["changes"] = changes
-        body["cursors"] = ["items": "2026-04-14T11:30:00.000Z"]
+        body["cursors"] = ["items": "2026-04-14T11:30:00.000Z|stuck"]
         try stubPull(body)
 
         let engine = PullEngine(apiClient: makeStubbedClient(), context: context)
-        // With maxRounds=3 the loop should fire the stub 3 times and stop
-        // without infinite recursion, even though every response says hasMore.
-        let outcome = try await engine.pull(maxRounds: 3)
 
-        // Exactly one local upsert (same record id), after 3 requests.
-        let items: [Item] = (try? context.fetch(FetchDescriptor<Item>())) ?? []
-        #expect(items.count == 1)
-        #expect(items.first?.title == "Batch 1")
-        #expect(outcome.tablesUpserted["items"] == 3)
-        // Recorded 3 HTTP POSTs to /sync/pull — proof the loop honoured hasMore.
-        let requests = MockURLProtocol.recordedRequests()
-            .filter { $0.url?.path == "/sync/pull" }
-        #expect(requests.count == 3)
+        do {
+            _ = try await engine.pull()
+            Issue.record("expected cursorStuck error")
+        } catch let err as PullEngine.PullError {
+            if case .cursorStuck(_, let table) = err {
+                #expect(table == "items", "cursorStuck should identify the broken table")
+                // Confirm the engine made exactly two HTTP calls
+                // (round 1 advanced the cursor, round 2 detected stuck).
+                let requests = MockURLProtocol.recordedRequests()
+                    .filter { $0.url?.path == "/sync/pull" }
+                #expect(requests.count == 2)
+            } else {
+                Issue.record("expected cursorStuck error, got \(err)")
+            }
+        } catch {
+            Issue.record("expected PullEngine.PullError, got \(error)")
+        }
+    }
+
+    /// Cursor-stuck must fire even when only ONE table is broken and
+    /// others are still making progress. Without this check, a single
+    /// stuck table would let the engine spin against
+    /// `safetyRoundCap` (1000 rounds) before giving up — many minutes
+    /// of wasted round-trips behind the rate limiter.
+    ///
+    /// Mechanism: items has `hasMore=true` with a frozen cursor; lists
+    /// has `hasMore=false`. Pre-fix (whole-dict equality), only the
+    /// items cursor freezing wouldn't matter because lists' cursor
+    /// also wouldn't advance — the global compare would not catch the
+    /// items-only failure. Post-fix the per-table check fires on items
+    /// regardless of lists' state.
+    @Test func cursorStuckFiresWhenOneTableStuckOthersProgressing() async throws {
+        let context = try InMemoryPersistenceController.makeContext()
+
+        var body = emptyPullBody()
+        var changes = body["changes"] as! [String: Any]
+        // items: hasMore=true, frozen cursor.
+        changes["items"] = [
+            "upserted": [[
+                "id": "item-stuck",
+                "userId": "user-1",
+                "type": "task",
+                "status": "active",
+                "title": "Stuck",
+                "source": "Brett",
+                "createdAt": "2026-04-14T00:00:00.000Z",
+                "updatedAt": "2026-04-14T11:30:00.000Z",
+            ]],
+            "deleted": [],
+            "hasMore": true,
+        ]
+        // lists: hasMore=false (this table converged), but a row was
+        // returned so its cursor moved — proves the per-table check
+        // doesn't false-fire on healthy tables.
+        changes["lists"] = [
+            "upserted": [[
+                "id": "list-1",
+                "userId": "user-1",
+                "name": "Work",
+                "colorClass": "bg-blue-500",
+                "sortOrder": 0,
+                "createdAt": "2026-04-14T00:00:00.000Z",
+                "updatedAt": "2026-04-14T11:00:00.000Z",
+            ]],
+            "deleted": [],
+            "hasMore": false,
+        ]
+        body["changes"] = changes
+        body["cursors"] = [
+            "items": "2026-04-14T11:30:00.000Z|stuck",
+            "lists": "2026-04-14T11:00:00.000Z|list-1",
+        ]
+        try stubPull(body)
+
+        let engine = PullEngine(apiClient: makeStubbedClient(), context: context)
+
+        do {
+            _ = try await engine.pull()
+            Issue.record("expected cursorStuck for items")
+        } catch let err as PullEngine.PullError {
+            if case .cursorStuck(_, let table) = err {
+                #expect(table == "items", "items is the stuck table; lists progressed normally")
+            } else {
+                Issue.record("expected cursorStuck error, got \(err)")
+            }
+        } catch {
+            Issue.record("expected PullEngine.PullError, got \(error)")
+        }
+    }
+
+    /// `cursorStuck` is a real failure — `consecutiveFailures` must
+    /// increment so the foreground poll backs off rather than retrying
+    /// in a tight loop against a server that's currently broken.
+    @Test func cursorStuckIncrementsConsecutiveFailures() async throws {
+        let context = try InMemoryPersistenceController.makeContext()
+
+        var body = emptyPullBody()
+        var changes = body["changes"] as! [String: Any]
+        changes["items"] = [
+            "upserted": [[
+                "id": "item-stuck",
+                "userId": "user-1",
+                "type": "task",
+                "status": "active",
+                "title": "Stuck",
+                "source": "Brett",
+                "createdAt": "2026-04-14T00:00:00.000Z",
+                "updatedAt": "2026-04-14T11:30:00.000Z",
+            ]],
+            "deleted": [],
+            "hasMore": true,
+        ]
+        body["changes"] = changes
+        body["cursors"] = ["items": "2026-04-14T11:30:00.000Z|stuck"]
+        try stubPull(body)
+
+        let engine = PullEngine(apiClient: makeStubbedClient(), context: context)
+
+        do {
+            _ = try await engine.pull()
+            Issue.record("expected throw")
+        } catch {
+            // Expected
+        }
+
+        let health: [SyncHealth] = (try? context.fetch(FetchDescriptor<SyncHealth>())) ?? []
+        #expect(health.count == 1)
+        #expect((health.first?.consecutiveFailures ?? 0) >= 1,
+                "cursorStuck must bump consecutiveFailures so poll backoff kicks in")
+        #expect(health.first?.lastError != nil)
     }
 
     // MARK: - SyncHealth touched on success


### PR DESCRIPTION
## What this fixes

Two consecutive iOS sign-ins were returning different task counts, both lower than Electron's. Three bugs stacked:

1. **`/sync/pull` paginated upserts and tombstones independently**, then advanced one cursor by `max()` — when their tails diverged, rows in the gap were permanently dropped. Two cycles disagreed because server-side `updatedAt` writeback (content extraction, scout findings) shifted the boundary between cycles.
2. **`/things` ran a separate, capped-at-500 path** with no keyset semantics — Electron showed a third number, silently truncated for power users.
3. **iOS `PullEngine` capped at `maxRounds: 10`**, so a user with >5,000 rows of changes couldn't catch up in one cycle.

After this PR, both clients land on the same correct, deterministic, no-row-skip data.

## Architecture

New shared core at [apps/api/src/lib/sync/paginated-pull.ts](apps/api/src/lib/sync/paginated-pull.ts) — keyset-merge pagination over `(updatedAt, id)`. `/sync/pull` and `/things` both route through it. Provably no row is skipped: every row with key ≤ cursor is in the current page, every row > cursor is in a future page, no third state.

Per-table page sizes:
- `items` = 50, `brett_messages` = 50 (large rows; content body up to ~5–8 KB)
- everything else = 200 (lightweight metadata)
- Client `body.limit` still overrides for legacy iOS clients

iOS `PullEngine` now loops until every table reports `hasMore=false`. A per-table cursor-stuck detector fires `PullError.cursorStuck(round, table)` if any single table loops without advancing — single stuck table doesn't drag the whole pull into a hot loop.

iOS `SyncEndpoints` now omits `limit` by default so server's per-table defaults actually activate in production.

## Tests

- **API**: 720 pass / 14 skipped (was 682). New: 25 unit tests for `paginatedPull` (`paginated-pull.test.ts`), 6 route tests for `/sync/pull` (`sync-pull-correctness.test.ts`), 7 new tests in `things.test.ts` for the route's pagination, parity, and IDOR defense.
- **iOS**: 555 pass (was 553). New: cursor-stuck detection (single + multi-table), `consecutiveFailures` bump on cursor-stuck.

Pinned correctness invariants:
- 200-row walk: every seeded id surfaces, no duplicates
- Two consecutive walks return identical id sets — the determinism guard
- Upsert + tombstone interleaving: both surface in both tail orderings
- Sibling timestamps: 60 same-ms rows do not split across pages
- Mid-walk server writeback: no row dropped (may be re-delivered, which is correct)
- `extraWhere` rejects reserved `userId` / `deletedAt` keys
- `/things` and `/sync/pull` return identical id sets unfiltered
- `/things` hydrate scoped by userId (IDOR defense in depth)
- iOS cursor-stuck: fires per-table, bumps `consecutiveFailures` so poll backoff kicks in

## Self-review

Independent senior-peer review pass before commit. Findings addressed:
- Defense-in-depth: `extraWhere.userId` override defended
- `/things` hydrate scoped by `userId` (was relying solely on paginatedPull)
- iOS `defaultPullLimit = nil` so per-table sizing actually activates (was dormant otherwise)
- Per-table cursor-stuck (was whole-dict equality, missed single-table-stuck case)
- Reserved-key guard on `extraWhere`
- Documented hard-delete bypass + calendar-90-day ghost-row constraints

## Migration notes

- No DB changes
- Cursor format unchanged (still `<ts>|<id>` with legacy `<ts>` tolerated)
- Response shape unchanged
- Mid-deploy: old API + new API can coexist. Both parsers accept both cursor forms.
- iOS clients on the prior `defaultPullLimit = 500` build keep working; they just won't get per-table sizing until they update.

## Test plan
- [x] `pnpm test` (API) — 720 / 720 pass
- [x] `pnpm typecheck` (api, api-core, types, business, utils) — clean
- [x] `xcodebuild test` — 555 / 555 pass
- [ ] On Railway preview: Walk `/sync/pull` from cursor=null with 600+ items, confirm full set returned across pages
- [ ] On Electron: GET /things with >500 active items, confirm full set returned
- [ ] On TestFlight after merge: sign-out/sign-in twice, confirm identical task counts; compare to Electron count

🤖 Generated with [Claude Code](https://claude.com/claude-code)