### PR TITLE
release: perf — on-demand sync + background ModelActor

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -309,10 +309,187 @@ describe("POST /sync/pull", () => {
     const body = (await res.json()) as any;
 
     const eventIds = body.changes.calendar_events.upserted.map((e: any) => e.id);
-    // The old event must be excluded by the 90-day scope filter
+    // The old event must be excluded by the ±14d scope filter (was 90d
+    // back, narrowed when on-demand fetch landed for outside-window
+    // ranges via /events/fetch-range).
     expect(eventIds).not.toContain(oldEventId);
     // The recent event must be included
     expect(eventIds).toContain(recentEventId);
+  });
+
+  // ── On-demand sync filters (perf-driven hot/cold split) ──
+
+  it("items filter: archived items are excluded from sync", async () => {
+    clearAllRateLimits();
+
+    const archUser = await createTestUser("Archived Filter User");
+    // Active item (in)
+    const activeRes = await authRequest("/things", archUser.token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Active task", status: "active" }),
+    });
+    const activeId = ((await activeRes.json()) as any).id;
+    // Archived item (out) — change status via mutation push
+    const archivedRes = await authRequest("/things", archUser.token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Archived task", status: "active" }),
+    });
+    const archivedRow = (await archivedRes.json()) as any;
+    // Promote to archived directly (status mutation is allow-listed via push,
+    // but /things doesn't expose it; flip via Prisma to keep the test focused).
+    await prisma.item.update({
+      where: { id: archivedRow.id },
+      data: { status: "archived" },
+    });
+
+    clearAllRateLimits();
+    const res = await authRequest("/sync/pull", archUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    const body = (await res.json()) as any;
+    const ids = body.changes.items.upserted.map((r: any) => r.id);
+    expect(ids).toContain(activeId);
+    expect(ids).not.toContain(archivedRow.id);
+  });
+
+  it("items filter: completed-old items excluded, recent ones included", async () => {
+    clearAllRateLimits();
+
+    const completedUser = await createTestUser("Completed Filter User");
+    const recentRes = await authRequest("/things", completedUser.token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Recent done", status: "active" }),
+    });
+    const recentId = ((await recentRes.json()) as any).id;
+    const oldRes = await authRequest("/things", completedUser.token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Old done", status: "active" }),
+    });
+    const oldId = ((await oldRes.json()) as any).id;
+    // Mark both done via Prisma. Recent: completed 1h ago (in window).
+    // Old: completed 5d ago (outside the 48h window).
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    await prisma.item.update({
+      where: { id: recentId },
+      data: { status: "done", completedAt: oneHourAgo },
+    });
+    await prisma.item.update({
+      where: { id: oldId },
+      data: { status: "done", completedAt: fiveDaysAgo },
+    });
+
+    clearAllRateLimits();
+    const res = await authRequest("/sync/pull", completedUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    const body = (await res.json()) as any;
+    const ids = body.changes.items.upserted.map((r: any) => r.id);
+    expect(ids).toContain(recentId);
+    expect(ids).not.toContain(oldId);
+  });
+
+  it("lists filter: archived lists are excluded from sync", async () => {
+    clearAllRateLimits();
+
+    const listUser = await createTestUser("List Filter User");
+    const activeRes = await authRequest("/lists", listUser.token, {
+      method: "POST",
+      body: JSON.stringify({ name: "Active list", colorClass: "bg-blue-500" }),
+    });
+    const activeListId = ((await activeRes.json()) as any).id;
+    const archivedRes = await authRequest("/lists", listUser.token, {
+      method: "POST",
+      body: JSON.stringify({ name: "Archived list", colorClass: "bg-red-500" }),
+    });
+    const archivedListId = ((await archivedRes.json()) as any).id;
+    await prisma.list.update({
+      where: { id: archivedListId },
+      data: { archivedAt: new Date() },
+    });
+
+    clearAllRateLimits();
+    const res = await authRequest("/sync/pull", listUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    const body = (await res.json()) as any;
+    const ids = body.changes.lists.upserted.map((r: any) => r.id);
+    expect(ids).toContain(activeListId);
+    expect(ids).not.toContain(archivedListId);
+  });
+
+  it("cursor-key gating: tables omitted from cursors are skipped", async () => {
+    clearAllRateLimits();
+
+    const optInUser = await createTestUser("OptIn User");
+    // Seed both an item and a list so we'd see them under a full sync.
+    const itemRes = await authRequest("/things", optInUser.token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Opt-in item", status: "active" }),
+    });
+    const itemId = ((await itemRes.json()) as any).id;
+    const listRes = await authRequest("/lists", optInUser.token, {
+      method: "POST",
+      body: JSON.stringify({ name: "Opt-in list", colorClass: "bg-blue-500" }),
+    });
+    const listId = ((await listRes.json()) as any).id;
+
+    clearAllRateLimits();
+    // Modern client: only request items. Server should skip lists entirely.
+    const res = await authRequest("/sync/pull", optInUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: { items: null } }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    expect(body.changes.items).toBeDefined();
+    const itemIds = body.changes.items.upserted.map((r: any) => r.id);
+    expect(itemIds).toContain(itemId);
+
+    // Lists were not requested → must be absent from changes.
+    expect(body.changes.lists).toBeUndefined();
+    // Stale-but-untouched cursor for items still echoes; lists has none.
+    expect(body.cursors.lists).toBeUndefined();
+
+    // Sanity: the row exists, it just wasn't asked for. Confirm by asking
+    // for it explicitly in a follow-up call.
+    clearAllRateLimits();
+    const fullRes = await authRequest("/sync/pull", optInUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: { lists: null } }),
+    });
+    const fullBody = (await fullRes.json()) as any;
+    const listIds = fullBody.changes.lists.upserted.map((r: any) => r.id);
+    expect(listIds).toContain(listId);
+  });
+
+  it("cursor-key gating: empty cursors map preserves legacy full-sync behavior", async () => {
+    clearAllRateLimits();
+
+    const legacyUser = await createTestUser("Legacy Client User");
+    const itemRes = await authRequest("/things", legacyUser.token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Legacy item", status: "active" }),
+    });
+    const itemId = ((await itemRes.json()) as any).id;
+
+    clearAllRateLimits();
+    // Legacy client: empty cursors. Server should fall back to processing
+    // every SYNC_TABLE so old iOS builds keep working post-rollout.
+    const res = await authRequest("/sync/pull", legacyUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    const body = (await res.json()) as any;
+    for (const table of SYNC_TABLES) {
+      expect(body.changes[table]).toBeDefined();
+    }
+    const itemIds = body.changes.items.upserted.map((r: any) => r.id);
+    expect(itemIds).toContain(itemId);
   });
 });
 

--- a/apps/api/src/routes/calendar.ts
+++ b/apps/api/src/routes/calendar.ts
@@ -246,7 +246,14 @@ calendar.get("/events/:id/notes", async (c) => {
     },
   });
 
+  // Include the note `id` so on-demand iOS clients (which no longer
+  // replicate calendar_event_notes via /sync/pull) can upsert into local
+  // SwiftData using the server's primary key. Without it, an offline
+  // edit followed by a push would CREATE a new row with a fresh local
+  // id and collide with the existing (calendarEventId, userId) unique
+  // constraint server-side.
   return c.json({
+    id: note?.id ?? null,
     content: note?.content ?? null,
     updatedAt: note?.updatedAt.toISOString() ?? null,
   });

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -212,11 +212,44 @@ export const sync = new Hono<AuthEnv>()
     const changes: Record<string, SyncTableChanges> = {};
     const newCursors: Record<string, string> = {};
 
-    // Calendar events: scope to last 90 days + future
-    const ninetyDaysAgo = new Date();
-    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+    // Per-table windows so mobile only mirrors what the user might see
+    // imminently. Anything outside these windows is fetched on-demand
+    // via the per-resource GET endpoints (chat, findings, notes, etc.).
+    //
+    // Items: active/snoozed (open work, no cap) OR recently completed
+    // (last 48h to span any timezone's startOfToday with margin). Local
+    // filter (TodaySections) narrows further to the user's local "today."
+    // 48h was chosen over 24h because UTC-based cutoffs vs user-local
+    // "today" can drift up to ~14h either way; 48h gives a clean
+    // overlap on every timezone, including UTC-12 with a yesterday-late
+    // completion.
+    // Calendar events: ±14 days. Calendar page fetches outside-window
+    // ranges via /events/fetch-range when the user navigates.
+    const completedCutoff = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const fourteenDaysAgo = new Date();
+    fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14);
+    const fourteenDaysAhead = new Date();
+    fourteenDaysAhead.setDate(fourteenDaysAhead.getDate() + 14);
 
-    for (const table of SYNC_TABLES) {
+    // Modern clients opt in to per-table sync by listing the table key
+    // in `cursors` (value `null` for first sync, cursor string for
+    // incremental). Cold tables (chat history, scout findings, event
+    // notes, attachment metadata) are fetched lazily via dedicated GET
+    // endpoints, so the iOS client trims those keys out of the request.
+    //
+    // Backward compat: when `cursors` is empty (`{}`), we process every
+    // SYNC_TABLE so legacy clients and tests that send `{cursors: {}}`
+    // still get a full first sync. Once a client sends ANY explicit
+    // cursor key, we treat that as the explicit list — clients that
+    // want a subset must enumerate it.
+    const cursorKeys = Object.keys(cursors);
+    const requestedTables = cursorKeys.length === 0
+      ? SYNC_TABLES
+      : SYNC_TABLES.filter((t) =>
+          Object.prototype.hasOwnProperty.call(cursors, t),
+        );
+
+    for (const table of requestedTables) {
       const modelAccessor = SYNC_TABLE_TO_MODEL[table];
       const model = (prisma as any)[modelAccessor];
 
@@ -230,11 +263,21 @@ export const sync = new Hono<AuthEnv>()
       const cursor = cursors[table] ?? null;
       const tableLimit = overrideLimit ?? DEFAULT_LIMIT_BY_TABLE[table] ?? FALLBACK_DEFAULT_LIMIT;
 
-      // Per-table extra filters. Calendar events scope to last 90 days +
-      // future to keep mobile from pulling years of historical events.
       const extraWhere: Record<string, unknown> = {};
       if (table === "calendar_events") {
-        extraWhere.startTime = { gte: ninetyDaysAgo };
+        extraWhere.startTime = { gte: fourteenDaysAgo, lte: fourteenDaysAhead };
+      } else if (table === "items") {
+        // Active work + just-completed. Excludes archived entirely;
+        // older done items are fetched on-demand via /things and via
+        // list-detail pagination on the server.
+        extraWhere.OR = [
+          { status: { in: ["active", "snoozed"] } },
+          { AND: [{ status: "done" }, { completedAt: { gte: completedCutoff } }] },
+        ];
+      } else if (table === "lists") {
+        extraWhere.archivedAt = null;
+      } else if (table === "scouts") {
+        extraWhere.status = { not: "archived" };
       }
 
       // Keyset-merged pull: live + tombstones in one ordered stream, single

--- a/apps/ios/Brett/Auth/ActiveSession.swift
+++ b/apps/ios/Brett/Auth/ActiveSession.swift
@@ -49,8 +49,16 @@ final class Session {
         self.sseClient = sseClient
 
         let context = persistence.mainContext
-        let pushEngine = PushEngine(mutationQueue: MutationQueue(context: context))
-        let pullEngine = PullEngine()
+        // Single background ModelActor shared by both engines so they
+        // both write through the same on-actor context. SyncManager
+        // serialises pull/push via a mutex, so there's no concurrent
+        // write race; sharing also avoids the second allocation cost.
+        let syncData = SyncDataActor(modelContainer: persistence.container)
+        let pushEngine = PushEngine(
+            mutationQueue: MutationQueue(context: context),
+            syncData: syncData
+        )
+        let pullEngine = PullEngine(syncData: syncData)
 
         self.syncManager = SyncManager(
             pushEngine: SessionPushEngineAdapter(pushEngine),
@@ -88,6 +96,11 @@ final class Session {
         sseHandler?.stop()
         sseHandler = nil
         syncManager.stop()
+        // Drop any on-demand cache entries from this session — chat
+        // history, event notes, etc. — so the next user can never
+        // observe the previous user's cached server data. Detached
+        // because `RemoteCache` is an actor; tearDown is synchronous.
+        Task.detached { await RemoteCache.shared.clear() }
     }
 }
 

--- a/apps/ios/Brett/Networking/APIError.swift
+++ b/apps/ios/Brett/Networking/APIError.swift
@@ -98,4 +98,62 @@ enum APIError: Error, CustomStringConvertible {
             return "APIError.unknown"
         }
     }
+
+    /// Diagnostic message intended for the in-app sync-error alert
+    /// (`SyncStatusIndicator`'s tap-to-reveal). Distinct from
+    /// `description` (log-safe, scrubbed) and `userFacingMessage`
+    /// (sign-in-screen-quality, polite). This includes the URLError
+    /// code for `.unknown` so support / the user can tell "timed out"
+    /// from "host unreachable" from "DNS failed" — none of which are
+    /// PII. Without this, the previous formatter rendered every
+    /// transport failure as bare "APIError.unknown" with no signal.
+    var diagnosticMessage: String {
+        switch self {
+        case .offline:
+            return "You're offline."
+        case .unauthorized:
+            return "Session expired."
+        case .invalidCredentials:
+            return "Invalid credentials."
+        case .rateLimited(let retry):
+            if let retry { return "Rate limited (retry in \(retry)s)." }
+            return "Rate limited."
+        case .serverError(let status):
+            return "Server error \(status)."
+        case .validation:
+            return "Invalid request."
+        case .decodingFailed:
+            return "Couldn't parse server response."
+        case .unknown(let underlying):
+            if let urlError = underlying as? URLError {
+                return Self.urlErrorMessage(urlError)
+            }
+            // Type name only — never the message string, since unknown
+            // wraps arbitrary Errors which may stringify to PII.
+            return "Network error (\(type(of: underlying)))."
+        }
+    }
+
+    /// Map a `URLError.Code` to a short human label. Codes are stable
+    /// across iOS versions and contain no PII. Unknown codes fall
+    /// through to the bare integer code so support can look it up.
+    private static func urlErrorMessage(_ error: URLError) -> String {
+        switch error.code {
+        case .timedOut: return "Timed out."
+        case .cannotConnectToHost: return "Couldn't reach the server."
+        case .cannotFindHost: return "Server hostname not found."
+        case .networkConnectionLost: return "Connection lost mid-request."
+        case .notConnectedToInternet: return "Not connected to internet."
+        case .dnsLookupFailed: return "DNS lookup failed."
+        case .secureConnectionFailed: return "Secure connection failed."
+        case .serverCertificateUntrusted: return "Server certificate untrusted."
+        case .badServerResponse: return "Bad server response."
+        case .resourceUnavailable: return "Resource unavailable."
+        case .dataNotAllowed: return "Cellular data disallowed for this app."
+        case .internationalRoamingOff: return "International roaming off."
+        case .callIsActive: return "Call active — network unavailable."
+        case .cancelled: return "Request cancelled."
+        default: return "Network error (URLError \(error.code.rawValue))."
+        }
+    }
 }

--- a/apps/ios/Brett/Networking/Endpoints/CalendarEndpoints.swift
+++ b/apps/ios/Brett/Networking/Endpoints/CalendarEndpoints.swift
@@ -106,6 +106,12 @@ extension APIClient {
     }
 
     struct CalendarNoteResponse: Decodable, Sendable {
+        /// Server primary key — present when a note exists, nil otherwise.
+        /// Required for iOS clients that fetch notes on-demand: the local
+        /// SwiftData mirror has to be keyed by the server's id so a
+        /// subsequent user edit pushes as an UPDATE rather than colliding
+        /// with the (calendarEventId, userId) unique constraint as a CREATE.
+        let id: String?
         let content: String?
         let updatedAt: Date?
     }

--- a/apps/ios/Brett/Networking/Endpoints/ChatHistoryEndpoints.swift
+++ b/apps/ios/Brett/Networking/Endpoints/ChatHistoryEndpoints.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Typed `APIClient` extensions for the paginated chat history endpoints.
+///
+/// Mirrors the server handler in `apps/api/src/routes/brett-chat.ts`. The
+/// streaming POST endpoints stay in `ChatStore` (raw URLSession bytes path);
+/// these history methods are plain JSON and decode through the standard
+/// `request` helper.
+///
+/// Why a separate concern from the streaming path: history is read-only and
+/// cacheable (`RemoteCache.chatHistoryForItem`) — pagination + caching make
+/// no sense on the streaming side, where every send is a one-shot SSE.
+@MainActor
+extension APIClient {
+    // MARK: - Response DTOs
+
+    /// One message in a paginated history page. Roles are a free-form string
+    /// from the server (`"user" | "assistant" | "tool" | …`) rather than the
+    /// iOS `MessageRole` enum so an unknown future role doesn't drop the
+    /// whole page.
+    struct ChatHistoryMessage: Codable, Equatable, Sendable {
+        let id: String
+        let role: String
+        let content: String
+        let createdAt: Date
+    }
+
+    struct ChatHistoryPage: Codable, Equatable, Sendable {
+        let messages: [ChatHistoryMessage]
+        let hasMore: Bool
+        let cursor: String?
+        let totalCount: Int?
+    }
+
+    // MARK: - Endpoints
+
+    /// GET /brett/chat/:itemId — paginated history for a task chat thread.
+    /// Default page size is the server's default (20). Pass `cursor` to
+    /// load the page strictly older than that ISO timestamp.
+    func fetchChatHistoryForItem(
+        itemId: String,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ChatHistoryPage {
+        let path = chatHistoryPath("/brett/chat/\(itemId)", limit: limit, cursor: cursor)
+        return try await requestRelative(ChatHistoryPage.self, relativePath: path, method: "GET")
+    }
+
+    /// GET /brett/chat/event/:eventId — paginated history for a calendar
+    /// event chat thread.
+    func fetchChatHistoryForEvent(
+        eventId: String,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ChatHistoryPage {
+        let path = chatHistoryPath("/brett/chat/event/\(eventId)", limit: limit, cursor: cursor)
+        return try await requestRelative(ChatHistoryPage.self, relativePath: path, method: "GET")
+    }
+
+    /// Build the `/brett/chat/...?limit&cursor` query string.
+    /// Percent-encodes the cursor (it's an ISO timestamp containing `:`) so
+    /// the query string survives URLComponents intact.
+    nonisolated private func chatHistoryPath(
+        _ base: String,
+        limit: Int,
+        cursor: String?
+    ) -> String {
+        var path = "\(base)?limit=\(limit)"
+        if let cursor, !cursor.isEmpty {
+            let encoded = cursor.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? cursor
+            path += "&cursor=\(encoded)"
+        }
+        return path
+    }
+}

--- a/apps/ios/Brett/Networking/Endpoints/SyncEndpoints.swift
+++ b/apps/ios/Brett/Networking/Endpoints/SyncEndpoints.swift
@@ -30,17 +30,22 @@ enum SyncProtocol {
     /// boundary).
     static let defaultPullLimit: Int? = nil
 
-    /// The canonical list of tables the pull engine tracks. Order matches
-    /// the server's `SYNC_TABLES` constant.
+    /// The canonical list of tables the pull engine replicates locally.
+    ///
+    /// Hot path only — these are the tables every UI surface needs to render
+    /// immediately on cold launch, even offline. Server-side filters narrow
+    /// each one further (active/recent items, ±14d events, non-archived
+    /// lists/scouts) so the local mirror stays small.
+    ///
+    /// Cold tables fetched on-demand via the per-resource GET endpoints
+    /// (`brett-chat`, `scout findings`, `event notes`, item attachments)
+    /// are not in this list. The server's `/sync/pull` honors the omission
+    /// and skips those tables entirely for clients that don't request them.
     static let tables: [String] = [
         "lists",
         "items",
         "calendar_events",
-        "calendar_event_notes",
         "scouts",
-        "scout_findings",
-        "brett_messages",
-        "attachments",
     ]
 }
 

--- a/apps/ios/Brett/Networking/RemoteCache.swift
+++ b/apps/ios/Brett/Networking/RemoteCache.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// In-memory cache for on-demand server data — chat history, scout findings,
+/// event notes. Anything mobile fetches lazily instead of replicating into
+/// SwiftData lives here for the lifetime of the process.
+///
+/// Why an actor: cache reads and writes can fire from any task (multiple
+/// detail views opening at once, push-success invalidations from a
+/// background sync). The actor serialises access without forcing every
+/// caller onto the main actor — and reads return value types so the
+/// rest of the call site can run wherever it likes.
+///
+/// Persistence: in-memory only. Process restart drops everything; the next
+/// detail-view open re-fetches. Disk persistence can come later if cold-
+/// launch chat-thread perception ever suffers — for now the simplification
+/// is worth more than the cache hit on a fresh launch.
+///
+/// TTL: each entry stamps a fetch time. `value(forKey:)` returns nil once
+/// `now - fetchedAt > ttl`. Defaults to 5 min, but per-resource methods
+/// can override (notes use a tighter TTL because edits flow through the
+/// mutation queue and we want to see them quickly).
+///
+/// Sign-out: `clear()` is called from `ActiveSession.tearDown()` so a new
+/// user can never observe the previous user's cached on-demand data.
+actor RemoteCache {
+    static let shared = RemoteCache()
+
+    private struct Entry {
+        let value: Any
+        let fetchedAt: Date
+        let ttl: TimeInterval
+    }
+
+    private var store: [String: Entry] = [:]
+
+    /// Default TTL when a caller doesn't specify. 5 minutes balances
+    /// freshness against re-fetch cost; per-call sites override when
+    /// the resource changes more or less often.
+    static let defaultTTL: TimeInterval = 5 * 60
+
+    // MARK: - Generic primitives
+
+    /// Read a value if present and within TTL. Returns nil for missing or expired.
+    func value<T>(forKey key: String, as: T.Type = T.self) -> T? {
+        guard let entry = store[key] else { return nil }
+        if Date().timeIntervalSince(entry.fetchedAt) > entry.ttl {
+            store.removeValue(forKey: key)
+            return nil
+        }
+        return entry.value as? T
+    }
+
+    /// Write a value with the given TTL.
+    func set<T>(_ value: T, forKey key: String, ttl: TimeInterval = RemoteCache.defaultTTL) {
+        store[key] = Entry(value: value, fetchedAt: Date(), ttl: ttl)
+    }
+
+    /// Drop a single key. Called after a write that we know invalidates
+    /// the cached server view (e.g. user sent a chat message → next read
+    /// must re-fetch to see the assistant reply).
+    func invalidate(key: String) {
+        store.removeValue(forKey: key)
+    }
+
+    /// Drop every key with the given prefix. Used for bulk resets like
+    /// "all chat history" without enumerating every itemId.
+    func invalidate(prefix: String) {
+        for k in store.keys where k.hasPrefix(prefix) {
+            store.removeValue(forKey: k)
+        }
+    }
+
+    /// Clear the entire cache. Called on sign-out so the next user can't
+    /// see the previous user's cached on-demand data.
+    func clear() {
+        store.removeAll()
+    }
+}
+
+// MARK: - Per-resource fetchers
+
+extension RemoteCache {
+    // Key formats — kept tight so `invalidate(prefix:)` can target by
+    // resource family.
+    private static func chatItemKey(_ itemId: String) -> String { "chat.item.\(itemId)" }
+    private static func chatEventKey(_ eventId: String) -> String { "chat.event.\(eventId)" }
+    private static func eventNoteKey(_ eventId: String) -> String { "event.note.\(eventId)" }
+
+    /// Fetch the most-recent chat history page for an item. Returns the
+    /// cached value if fresh, otherwise hits the server and caches the
+    /// result. Errors propagate so the view can show a soft banner.
+    func chatHistoryForItem(_ itemId: String) async throws -> APIClient.ChatHistoryPage {
+        let key = Self.chatItemKey(itemId)
+        if let cached: APIClient.ChatHistoryPage = value(forKey: key) {
+            return cached
+        }
+        let page = try await APIClient.shared.fetchChatHistoryForItem(itemId: itemId)
+        set(page, forKey: key)
+        return page
+    }
+
+    /// Same as `chatHistoryForItem` but for calendar event chat threads.
+    func chatHistoryForEvent(_ eventId: String) async throws -> APIClient.ChatHistoryPage {
+        let key = Self.chatEventKey(eventId)
+        if let cached: APIClient.ChatHistoryPage = value(forKey: key) {
+            return cached
+        }
+        let page = try await APIClient.shared.fetchChatHistoryForEvent(eventId: eventId)
+        set(page, forKey: key)
+        return page
+    }
+
+    /// Drop the cached chat history so the next read fetches fresh.
+    /// Called after a streaming send completes — the server has new
+    /// messages we need to surface on the next detail-view open.
+    func invalidateChatHistory(itemId: String? = nil, eventId: String? = nil) {
+        if let itemId { invalidate(key: Self.chatItemKey(itemId)) }
+        if let eventId { invalidate(key: Self.chatEventKey(eventId)) }
+    }
+
+    /// Fetch the private event note. Notes have a shorter TTL (30s)
+    /// because user edits propagate through the mutation queue and we
+    /// want a fresh-after-push view if the user re-opens the event.
+    func eventNote(eventId: String) async throws -> APIClient.CalendarNoteResponse {
+        let key = Self.eventNoteKey(eventId)
+        if let cached: APIClient.CalendarNoteResponse = value(forKey: key) {
+            return cached
+        }
+        let note = try await APIClient.shared.fetchEventNote(eventId: eventId)
+        set(note, forKey: key, ttl: 30)
+        return note
+    }
+
+    /// Drop the cached event note so the next read fetches fresh.
+    func invalidateEventNote(eventId: String) {
+        invalidate(key: Self.eventNoteKey(eventId))
+    }
+}

--- a/apps/ios/Brett/Stores/CalendarStore.swift
+++ b/apps/ios/Brett/Stores/CalendarStore.swift
@@ -62,6 +62,50 @@ final class CalendarStore {
 
     // MARK: - Notes (read/write)
 
+    /// Hydrate the local `CalendarEventNote` mirror from a server fetch.
+    /// Notes are no longer replicated via /sync/pull — they're fetched
+    /// on-demand when the user opens an event detail. We still keep a
+    /// local SwiftData copy so:
+    ///   1. The notes section renders instantly on the next open while
+    ///      the network refresh is in flight.
+    ///   2. User edits go through the existing offline-first mutation
+    ///      queue without races against the unique-constraint on
+    ///      `(calendarEventId, userId)`.
+    ///
+    /// Crucially, the local row is keyed by the SERVER's primary id.
+    /// A pending local edit (`_syncStatus != synced`) is preserved
+    /// untouched — applying server state on top of unpushed user input
+    /// would silently throw away that input.
+    func applyServerNote(
+        id: String,
+        eventId: String,
+        userId: String,
+        content: String,
+        updatedAt: Date
+    ) {
+        if let existing = fetchNote(for: eventId, userId: userId) {
+            // Pending writes belong to the user — never clobber.
+            if existing._syncStatus != SyncStatus.synced.rawValue { return }
+            existing.content = content
+            existing.updatedAt = updatedAt
+            existing._baseUpdatedAt = BrettDate.isoString(updatedAt)
+            save()
+            return
+        }
+        let note = CalendarEventNote(
+            id: id,
+            calendarEventId: eventId,
+            userId: userId,
+            content: content,
+            createdAt: updatedAt,
+            updatedAt: updatedAt
+        )
+        note._syncStatus = SyncStatus.synced.rawValue
+        note._baseUpdatedAt = BrettDate.isoString(updatedAt)
+        context.insert(note)
+        save()
+    }
+
     /// Fetch the note for a given event. `userId` scopes the lookup so a
     /// note belonging to a prior account (stale after an unfinished wipe)
     /// can never be matched on sign-in of a new user.

--- a/apps/ios/Brett/Stores/ChatStore.swift
+++ b/apps/ios/Brett/Stores/ChatStore.swift
@@ -96,6 +96,32 @@ final class ChatStore {
         }
     }
 
+    /// Seed from server-fetched chat history. The server returns messages in
+    /// `createdAt DESC` order (newest first); we sort ascending here so the
+    /// rendered panel reads top-down chronologically. We replace any
+    /// previously-hydrated bucket entirely — this is called after the local
+    /// hydrate runs, so the server view authoritatively wins. Streaming
+    /// bubbles in flight are blown away if they overlap, but in practice
+    /// the user can't open a thread mid-stream without first finishing it.
+    func hydrate(itemId: String, from messages: [APIClient.ChatHistoryMessage]) {
+        let sorted = messages.sorted(by: { $0.createdAt < $1.createdAt })
+        self.messages[itemId] = sorted.map { message in
+            ChatMessage(
+                id: message.id,
+                role: ChatMessage.Role(rawValue: message.role) ?? .brett,
+                content: message.content,
+                isStreaming: false,
+                createdAt: message.createdAt
+            )
+        }
+    }
+
+    /// Same as `hydrate(itemId:from:)` but for an event chat thread.
+    /// Separate keying so the same server method can drive both paths.
+    func hydrateEvent(eventId: String, from messages: [APIClient.ChatHistoryMessage]) {
+        hydrate(itemId: eventId, from: messages)
+    }
+
     /// POST `/brett/chat/:itemId` with `message`; append deltas into a
     /// trailing assistant bubble. Throws only on pre-flight failures (bad
     /// URL, missing auth); network errors are swallowed into `lastError`
@@ -279,6 +305,19 @@ final class ChatStore {
                         itemId: itemId,
                         calendarEventId: calendarEventId,
                         userId: userId
+                    )
+                    // Invalidate cached history so the next detail-view
+                    // open re-fetches from the server (which now holds
+                    // the messages we just streamed). Awaited inline —
+                    // a detached Task here would yield, allowing a new
+                    // detail-view open to read the still-cached stale
+                    // entry between persistAssistant and the eviction.
+                    // The actor hop is cheap (one suspension) and we're
+                    // already inside a Task on the streaming path, so
+                    // there's nothing meaningful to "block."
+                    await RemoteCache.shared.invalidateChatHistory(
+                        itemId: itemId,
+                        eventId: calendarEventId
                     )
                 }
             }

--- a/apps/ios/Brett/Sync/MutationQueue.swift
+++ b/apps/ios/Brett/Sync/MutationQueue.swift
@@ -149,6 +149,19 @@ final class MutationQueue: MutationQueueProtocol {
         return (try? context.fetch(descriptor)) ?? []
     }
 
+    /// Count of rows in `.pending` status — uses `fetchCount` so the
+    /// caller never has to materialise the full queue for a count.
+    /// Matters because SyncHealth telemetry on every push pass used
+    /// to call `pendingEntries(limit: 10_000)` and allocate up to
+    /// 10k SwiftData objects on main just to read `.count`.
+    func pendingCount() -> Int {
+        let pendingRaw = MutationStatus.pending.rawValue
+        let descriptor = FetchDescriptor<MutationQueueEntry>(
+            predicate: #Predicate { $0.status == pendingRaw }
+        )
+        return (try? context.fetchCount(descriptor)) ?? 0
+    }
+
     /// Look up an entry by its idempotency key — used by HTTP retry paths
     /// to detect duplicates before resubmitting.
     func getByIdempotencyKey(_ key: String) -> MutationQueueEntry? {

--- a/apps/ios/Brett/Sync/MutationQueueProtocol.swift
+++ b/apps/ios/Brett/Sync/MutationQueueProtocol.swift
@@ -30,6 +30,12 @@ protocol MutationQueueProtocol: AnyObject {
     /// Look up an entry by its idempotency key. Used to cross-reference
     /// push results (which echo the key) back to the originating mutation.
     func getByIdempotencyKey(_ key: String) -> MutationQueueEntry?
+
+    /// Count of pending entries — uses `fetchCount` on the underlying
+    /// store so SyncHealth telemetry never has to materialise the whole
+    /// queue just to know its depth. Important under retry storms when
+    /// the queue can pile up to thousands of entries.
+    func pendingCount() -> Int
 }
 
 extension MutationQueueProtocol {

--- a/apps/ios/Brett/Sync/PullEngine.swift
+++ b/apps/ios/Brett/Sync/PullEngine.swift
@@ -29,6 +29,11 @@ final class PullEngine {
 
     private let apiClient: APIClient
     private let context: ModelContext
+    /// Background actor that owns the per-row upsert/delete + save. Keeps
+    /// the dominant cost of a pull off the main run loop. Optional only
+    /// for the in-memory test path, which still drives applies through
+    /// the test context directly.
+    private let syncData: SyncDataActor?
 
     // MARK: - Summary
 
@@ -70,22 +75,29 @@ final class PullEngine {
     // MARK: - Init
 
     /// Production initialiser — borrows the shared persistence container.
+    /// `syncData` runs the per-row apply on a background `@ModelActor`
+    /// so the heavy work doesn't block the main run loop.
     init(
         apiClient: APIClient = .shared,
-        persistence: PersistenceController = .shared
+        persistence: PersistenceController = .shared,
+        syncData: SyncDataActor? = nil
     ) {
         self.apiClient = apiClient
         self.context = persistence.mainContext
+        self.syncData = syncData ?? SyncDataActor(modelContainer: persistence.container)
     }
 
     /// Test-oriented init — accepts any `ModelContext` for in-memory
-    /// containers in test suites.
+    /// containers in test suites. The test path applies rows directly
+    /// through the test context (no background actor) so existing
+    /// tests don't need to care about cross-actor scheduling.
     init(
         apiClient: APIClient,
         context: ModelContext
     ) {
         self.apiClient = apiClient
         self.context = context
+        self.syncData = nil
     }
 
     // MARK: - Pull
@@ -163,60 +175,76 @@ final class PullEngine {
             // making real progress.
             var hasMoreByTable: [String: Bool] = [:]
 
-            // Yield every `yieldBatch` rows so a big pull doesn't lock up
-            // the main actor. SyncEntityMapper.upsert is @MainActor, and on
-            // a 500-item page each row takes ~200-500µs — which sums to
-            // ~100-250ms of contiguous main-thread work without yields.
-            // `Task.yield()` lets UI gestures, @Query refreshes, and other
-            // main-actor tasks interleave. `isSyncing` in SyncManager
-            // prevents another pull from racing in.
-            let yieldBatch = 100
-            var sinceYield = 0
-
+            // Build the per-table slices for the round. The actual
+            // upsert + delete + save runs on `SyncDataActor` (a
+            // `@ModelActor` with its own background context) so the
+            // heaviest cost — fetch-by-id, apply fields, save —
+            // doesn't block the main run loop. Without that hop we'd
+            // sprinkle `Task.yield()` to let the UI breathe; the
+            // background actor obviates that, and the yields disappear.
+            var slices: [SyncDataActor.PullSlice] = []
+            slices.reserveCapacity(SyncProtocol.tables.count)
             for table in SyncProtocol.tables {
                 guard let slice = response.changes[table] else { continue }
-
-                var inserted = 0
-                for record in slice.upserted {
-                    SyncEntityMapper.upsert(
-                        tableName: table,
-                        record: record,
-                        context: context,
-                        respectLocalPending: true
-                    )
-                    inserted += 1
-                    sinceYield += 1
-                    if sinceYield >= yieldBatch {
-                        sinceYield = 0
-                        await Task.yield()
-                    }
-                }
-
-                var deleted = 0
-                for id in slice.deleted {
-                    SyncEntityMapper.hardDelete(
-                        tableName: table,
-                        id: id,
-                        context: context
-                    )
-                    deleted += 1
-                    sinceYield += 1
-                    if sinceYield >= yieldBatch {
-                        sinceYield = 0
-                        await Task.yield()
-                    }
-                }
-
-                pendingUpsertsThisRound[table] = inserted
-                pendingDeletesThisRound[table] = deleted
+                slices.append(SyncDataActor.PullSlice(
+                    table: table,
+                    upserts: slice.upserted,
+                    deletes: slice.deleted
+                ))
                 hasMoreByTable[table] = slice.hasMore
                 if slice.hasMore { anyHasMore = true }
             }
 
-            // Advance cursors in the same context transaction as the rows
-            // — save() below commits them atomically, so we can't end up
-            // with "cursor advanced, rows lost" or "rows inserted, cursor
-            // stale."
+            do {
+                if let syncData {
+                    let counts = try await syncData.applyPullRound(slices)
+                    for (table, c) in counts {
+                        pendingUpsertsThisRound[table] = c.upserted
+                        pendingDeletesThisRound[table] = c.deleted
+                    }
+                } else {
+                    // Test path — apply against the engine's own
+                    // (test-supplied) context so in-memory tests can
+                    // assert against a single shared store.
+                    for slice in slices {
+                        var inserted = 0
+                        for record in slice.upserts {
+                            SyncEntityMapper.upsert(
+                                tableName: slice.table,
+                                record: record,
+                                context: context,
+                                respectLocalPending: true
+                            )
+                            inserted += 1
+                        }
+                        var deleted = 0
+                        for id in slice.deletes {
+                            SyncEntityMapper.hardDelete(
+                                tableName: slice.table,
+                                id: id,
+                                context: context
+                            )
+                            deleted += 1
+                        }
+                        pendingUpsertsThisRound[slice.table] = inserted
+                        pendingDeletesThisRound[slice.table] = deleted
+                    }
+                    try context.save()
+                }
+            } catch {
+                BrettLog.pull.error("pull apply failed: \(String(describing: error), privacy: .public)")
+                recordPullFailure(error: error)
+                throw PullError.savePersistFailed(underlying: error)
+            }
+
+            // Advance cursors on the main context. Cursor rows are tiny
+            // and infrequently saved — keeping them on main avoids a
+            // second cross-actor hop on every round. The order
+            // (rows-first, cursors-second) is deliberate: if the cursor
+            // save fails after the row save succeeded, the next pull
+            // re-fetches the same rows and idempotent upsert handles
+            // the duplicate. The reverse failure mode (cursor advanced,
+            // rows lost) is impossible because rows save first.
             for (table, cursor) in response.cursors {
                 upsertCursor(
                     tableName: table,
@@ -228,9 +256,7 @@ final class PullEngine {
             do {
                 try context.save()
             } catch {
-                // Propagate: outer SyncManager will surface the error and
-                // the next sync starts from the same cursor (idempotent).
-                BrettLog.pull.error("pull save failed: \(String(describing: error), privacy: .public)")
+                BrettLog.pull.error("pull cursor save failed: \(String(describing: error), privacy: .public)")
                 recordPullFailure(error: error)
                 throw PullError.savePersistFailed(underlying: error)
             }

--- a/apps/ios/Brett/Sync/PushEngine.swift
+++ b/apps/ios/Brett/Sync/PushEngine.swift
@@ -24,6 +24,13 @@ final class PushEngine {
     private let mutationQueue: MutationQueueProtocol
     private let apiClient: APIClient
     private let context: ModelContext
+    /// Background ModelActor for the per-row apply of server-confirmed
+    /// records. The mutation queue (status transitions, idempotency,
+    /// compaction) stays on main because `MutationCompactor` reasons
+    /// about the entire pending queue transactionally; only the domain
+    /// row apply moves off main. Optional only for the in-memory test
+    /// path.
+    private let syncData: SyncDataActor?
 
     // MARK: - Summary
 
@@ -52,15 +59,19 @@ final class PushEngine {
     init(
         mutationQueue: MutationQueueProtocol,
         apiClient: APIClient = .shared,
-        persistence: PersistenceController = .shared
+        persistence: PersistenceController = .shared,
+        syncData: SyncDataActor? = nil
     ) {
         self.mutationQueue = mutationQueue
         self.apiClient = apiClient
         self.context = persistence.mainContext
+        self.syncData = syncData ?? SyncDataActor(modelContainer: persistence.container)
     }
 
     /// Test-oriented init — accepts any `ModelContext` so in-memory
-    /// containers created by tests can be wired in directly.
+    /// containers created by tests can be wired in directly. Tests apply
+    /// server records through the test context (no background actor) so
+    /// existing test fixtures don't need to care about cross-actor scheduling.
     init(
         mutationQueue: MutationQueueProtocol,
         apiClient: APIClient,
@@ -69,6 +80,7 @@ final class PushEngine {
         self.mutationQueue = mutationQueue
         self.apiClient = apiClient
         self.context = context
+        self.syncData = nil
     }
 
     // MARK: - Push (single pass)
@@ -115,61 +127,164 @@ final class PushEngine {
 
         var applied = 0, merged = 0, conflicts = 0, errors = 0
 
+        // First pass — classify every result. Collect:
+        //   * records to apply on the background actor
+        //   * queue transitions to commit on main AFTER the apply lands
+        //   * conflict logs to write
+        // No queue mutations happen here yet; we want the domain row
+        // update to become observable BEFORE the queue says "applied,"
+        // otherwise a UI re-fetch in between could see stale data while
+        // the queue claims the mutation succeeded. Doing the classify
+        // pass first also lets us skip any queue work if the bg apply
+        // throws — the next push retries via the server's idempotency
+        // key and we never claim success against a row we couldn't
+        // commit.
+        var serverRecordsToApply: [SyncDataActor.ServerRecord] = []
+        // Snapshot the matched mutation so we don't have to re-query
+        // by idempotency key after the await (the queue may have
+        // shifted in the meantime if a debounced push landed).
+        struct PendingDecision {
+            enum Action { case complete, conflict(message: String), error(message: String) }
+            let mutationId: String
+            let action: Action
+            let conflictResult: SyncPushResult?
+            let mutation: MutationQueueEntry
+        }
+        var decisions: [PendingDecision] = []
+
         for result in response.results {
             guard let mutation = mutationQueue.getByIdempotencyKey(result.idempotencyKey) else {
-                // Server returned a result for a mutation we don't recognise;
-                // skip. This can happen in tests, or if the queue was wiped.
                 continue
             }
-
             switch result.status {
             case .applied:
-                applyServerRecord(result.record, to: mutation)
-                mutationQueue.complete(id: mutation.id)
+                if let record = result.record {
+                    serverRecordsToApply.append(SyncDataActor.ServerRecord(
+                        table: tableName(for: mutation.entityType),
+                        record: record
+                    ))
+                }
+                decisions.append(PendingDecision(
+                    mutationId: mutation.id,
+                    action: .complete,
+                    conflictResult: nil,
+                    mutation: mutation
+                ))
                 applied += 1
 
             case .merged:
-                applyServerRecord(result.record, to: mutation)
-                logMergeConflict(result: result, mutation: mutation)
-                mutationQueue.complete(id: mutation.id)
+                if let record = result.record {
+                    serverRecordsToApply.append(SyncDataActor.ServerRecord(
+                        table: tableName(for: mutation.entityType),
+                        record: record
+                    ))
+                }
+                decisions.append(PendingDecision(
+                    mutationId: mutation.id,
+                    action: .complete,
+                    conflictResult: result,
+                    mutation: mutation
+                ))
                 merged += 1
 
             case .conflict:
-                markLocalConflict(mutation: mutation)
-                logMergeConflict(result: result, mutation: mutation)
                 let message = result.error ?? "Server rejected mutation (conflict)."
-                mutationQueue.fail(id: mutation.id, error: message, errorCode: 409)
+                decisions.append(PendingDecision(
+                    mutationId: mutation.id,
+                    action: .conflict(message: message),
+                    conflictResult: result,
+                    mutation: mutation
+                ))
                 conflicts += 1
 
             case .notFound:
-                // The record already matches the client's desired state
-                // (a DELETE of a non-existent row, or a record the server
-                // reaped). Drop the mutation.
-                mutationQueue.complete(id: mutation.id)
+                decisions.append(PendingDecision(
+                    mutationId: mutation.id,
+                    action: .complete,
+                    conflictResult: nil,
+                    mutation: mutation
+                ))
                 applied += 1
 
             case .error:
                 let message = result.error ?? "Unknown server error."
-                mutationQueue.fail(id: mutation.id, error: message, errorCode: nil)
+                decisions.append(PendingDecision(
+                    mutationId: mutation.id,
+                    action: .error(message: message),
+                    conflictResult: nil,
+                    mutation: mutation
+                ))
                 errors += 1
             }
         }
 
-        // Persist all the changes we made to @Model records + the conflict log.
-        //
-        // If this save fails, the mutation queue status transitions AND the
-        // server-record upserts we applied are both rolled back by SwiftData
-        // (they're pending context changes). On next launch, `resetInFlight`
-        // flips in-flight rows back to pending, the push retries, and the
-        // server's idempotency key handles the duplicate. Logged at error
-        // level so sysdiagnose records the stuck-save condition.
+        // Apply the server-confirmed records FIRST on the background
+        // actor so the domain row update is committed (and observable to
+        // every @Query subscriber via SwiftData history) before we mark
+        // any mutation "applied." If this throws, we skip the
+        // corresponding queue transitions — the next push retries via
+        // the server's idempotency key, which is exactly what
+        // server-side dedupe is for. Better to redo the network round
+        // trip than to claim local-side success against a row that
+        // didn't materialise.
+        var bgApplyFailed = false
+        if !serverRecordsToApply.isEmpty {
+            do {
+                if let syncData {
+                    try await syncData.applyServerRecords(serverRecordsToApply)
+                } else {
+                    for r in serverRecordsToApply {
+                        SyncEntityMapper.upsert(
+                            tableName: r.table,
+                            record: r.record,
+                            context: context,
+                            respectLocalPending: false
+                        )
+                    }
+                }
+            } catch {
+                BrettLog.push.error("push server-record apply failed: \(String(describing: error), privacy: .public)")
+                bgApplyFailed = true
+            }
+        }
+
+        // Second pass — commit queue transitions + conflict logs on
+        // main. If the bg apply failed we skip the .complete actions
+        // for results that needed a row write so the queue stays
+        // pending and the next push retries. Conflicts and errors are
+        // safe to commit either way (they don't depend on a row write).
+        for decision in decisions {
+            switch decision.action {
+            case .complete:
+                if bgApplyFailed && decision.conflictResult?.record != nil {
+                    // This .applied/.merged depended on a row apply
+                    // that didn't land — leave the mutation pending.
+                    continue
+                }
+                if let result = decision.conflictResult {
+                    logMergeConflict(result: result, mutation: decision.mutation)
+                }
+                mutationQueue.complete(id: decision.mutationId)
+            case .conflict(let message):
+                markLocalConflict(mutation: decision.mutation)
+                if let result = decision.conflictResult {
+                    logMergeConflict(result: result, mutation: decision.mutation)
+                }
+                mutationQueue.fail(id: decision.mutationId, error: message, errorCode: 409)
+            case .error(let message):
+                mutationQueue.fail(id: decision.mutationId, error: message, errorCode: nil)
+            }
+        }
+
+        // Save main context: mutation queue transitions + conflict logs
+        // (and, in the test path, the in-line server records too).
         do {
             try context.save()
         } catch {
             BrettLog.push.error("push save failed: \(String(describing: error), privacy: .public)")
         }
 
-        let remaining = mutationQueue.pendingEntries(limit: 1).count
+        let remaining = mutationQueue.pendingCount()
         let outcome = PushOutcome(
             applied: applied,
             merged: merged,
@@ -248,20 +363,6 @@ final class PushEngine {
     }
 
     // MARK: - Record application / conflict bookkeeping
-
-    /// Write the server's authoritative record back into SwiftData, bypassing
-    /// the pending-write guard (we know the push succeeded, so local state
-    /// should catch up to the server).
-    private func applyServerRecord(_ record: [String: Any]?, to mutation: MutationQueueEntry) {
-        guard let record else { return }
-        let table = tableName(for: mutation.entityType)
-        SyncEntityMapper.upsert(
-            tableName: table,
-            record: record,
-            context: context,
-            respectLocalPending: false
-        )
-    }
 
     /// Set `_syncStatus = "conflict"` on the local record corresponding to
     /// a rejected mutation. If we can't find the record the mutation refers
@@ -364,7 +465,7 @@ final class PushEngine {
         health.isPushing = isPushing
         // We compute absolute counts rather than deltas — accurate across
         // app restarts and safe even if the delta drifts.
-        health.pendingMutationCount = mutationQueue.pendingEntries(limit: 10_000).count
+        health.pendingMutationCount = mutationQueue.pendingCount()
         health.deadMutationCount = deadCount()
         if success {
             health.lastSuccessfulPushAt = Date()

--- a/apps/ios/Brett/Sync/SyncDataActor.swift
+++ b/apps/ios/Brett/Sync/SyncDataActor.swift
@@ -1,0 +1,129 @@
+import Foundation
+import SwiftData
+
+/// Background ModelActor for the dominant cost of /sync/pull and the apply
+/// step of /sync/push: per-row upsert/delete + the matching `save()`.
+///
+/// Owns its own `ModelContext` bound to the same `ModelContainer` the UI's
+/// main context uses, so saves here propagate to every `@Query` observer
+/// via SwiftData's history tracking — no manual main-actor hop required
+/// for the UI to refresh.
+///
+/// Why this exists: PullEngine used to be `@MainActor` and applied each
+/// upsert/delete on the main thread. Even with `Task.yield()` between
+/// rows the cumulative cost (fetch-by-id + apply fields + insert/update
+/// + save) blocked the main run loop for tens of milliseconds per round.
+/// Power users with thousands of items felt the lag as a frozen UI for
+/// the duration of a sync climb. Moving the per-row work to a background
+/// actor leaves the UI thread free for scroll, taps, and rendering.
+///
+/// Scope: per-row apply + the matching save() are the only things this
+/// actor owns. Cursors, SyncHealth, MutationQueue state, and full-resync
+/// wipes stay on the main context — they're tiny, infrequent, and
+/// straightforward enough that splitting them adds complexity without
+/// measurable gain. (And MutationQueue must stay on main because
+/// `MutationCompactor` reasons about the entire pending queue
+/// transactionally.)
+///
+/// Concurrency:
+///   - The actor's serial executor guarantees in-order processing across
+///     concurrent callers.
+///   - `modelContext` is non-Sendable but lives on the actor's executor
+///     — safe as long as no other actor reaches in.
+///   - Payload types use `@unchecked Sendable` because they wrap
+///     `[String: Any]` dicts produced by `JSONSerialization`. Those
+///     dicts contain only value-type / immutable Foundation reference
+///     types (NSString, NSNumber, NSDictionary), so passing them across
+///     actor boundaries is safe in practice; the Sendable check
+///     can't reason about that automatically.
+@ModelActor
+actor SyncDataActor {
+
+    // MARK: - Payload wrappers
+
+    /// One table's slice from a /sync/pull round. Wrapped in a struct so
+    /// the actor takes a single argument (one cross-actor hop per round)
+    /// rather than per-table.
+    struct PullSlice: @unchecked Sendable {
+        let table: String
+        let upserts: [[String: Any]]
+        let deletes: [String]
+    }
+
+    /// One row returned from /sync/push (`applied` or `merged` results).
+    /// Bypasses the local-pending guard because the push succeeded — local
+    /// state must catch up to server.
+    struct ServerRecord: @unchecked Sendable {
+        let table: String
+        let record: [String: Any]
+    }
+
+    // MARK: - Pull side
+
+    /// Apply a full round's table slices in a single transaction, then
+    /// save once. Returns per-table row counts actually persisted (matching
+    /// the existing `PullOutcome` telemetry shape).
+    ///
+    /// Local pending writes are skipped — `respectLocalPending: true`
+    /// inside `SyncEntityMapper.upsert` checks `_syncStatus` before
+    /// clobbering. Counts here include skipped-pending rows because
+    /// the existing PullOutcome semantics counted them.
+    ///
+    /// One save covers every table in the round so a mid-round crash
+    /// can't leave inconsistent partial state — same atomicity the
+    /// `@MainActor`-era PullEngine offered.
+    func applyPullRound(
+        _ slices: [PullSlice]
+    ) throws -> [String: (upserted: Int, deleted: Int)] {
+        var counts: [String: (upserted: Int, deleted: Int)] = [:]
+
+        for slice in slices {
+            var inserted = 0
+            for record in slice.upserts {
+                SyncEntityMapper.upsert(
+                    tableName: slice.table,
+                    record: record,
+                    context: modelContext,
+                    respectLocalPending: true
+                )
+                inserted += 1
+            }
+
+            var deletedCount = 0
+            for id in slice.deletes {
+                SyncEntityMapper.hardDelete(
+                    tableName: slice.table,
+                    id: id,
+                    context: modelContext
+                )
+                deletedCount += 1
+            }
+
+            counts[slice.table] = (inserted, deletedCount)
+        }
+
+        try modelContext.save()
+        return counts
+    }
+
+    // MARK: - Push side
+
+    /// Apply a batch of server-confirmed mutation records (the response
+    /// payload of /sync/push). Bypasses the local-pending guard because
+    /// the push succeeded by definition — local state must catch up to
+    /// what the server now holds.
+    ///
+    /// Single save() at the end so a multi-record batch lands as one
+    /// transaction (mirroring the prior PushEngine behaviour).
+    func applyServerRecords(_ records: [ServerRecord]) throws {
+        for r in records {
+            SyncEntityMapper.upsert(
+                tableName: r.table,
+                record: r.record,
+                context: modelContext,
+                respectLocalPending: false
+            )
+        }
+        try modelContext.save()
+    }
+}

--- a/apps/ios/Brett/Sync/SyncEntityMapper.swift
+++ b/apps/ios/Brett/Sync/SyncEntityMapper.swift
@@ -23,7 +23,13 @@ enum SyncEntityMapper {
 
     /// Apply a server record to an existing local model or insert a new one.
     /// Mirrors the pull-engine behaviour: never clobbers local pending writes.
-    @MainActor
+    ///
+    /// Caller-actor agnostic: the function only mutates the passed
+    /// `ModelContext`, so it runs correctly on whatever actor owns that
+    /// context. Sync moved off `@MainActor` so this had to lose its
+    /// own annotation; the cross-user defense reads via `SharedConfig`,
+    /// which is nonisolated UserDefaults storage rather than the
+    /// main-actor `ActiveSession` registry.
     static func upsert(
         tableName: String,
         record: [String: Any],
@@ -39,7 +45,7 @@ enum SyncEntityMapper {
         // (sign-out → sign-in race, mock URL replay, malicious proxy),
         // applying its rows would write a foreign userId onto local
         // models — silent cross-user data leakage. Reject defensively.
-        if let activeUserId = ActiveSession.userId,
+        if let activeUserId = SharedConfig.resolveCurrentUserId(),
            let recordUserId = record["userId"] as? String,
            !recordUserId.isEmpty,
            recordUserId != activeUserId {
@@ -75,7 +81,12 @@ enum SyncEntityMapper {
 
     /// Hard-delete a record by (table, id). Pulls are authoritative for
     /// deletions, so we ignore local pending state here.
-    @MainActor
+    ///
+    /// Caller owns the save: this function only stages the delete on the
+    /// passed context. SyncDataActor batches dozens of deletes per round
+    /// and saves once at the end; saving inside this helper would amplify
+    /// to one save per row, defeating the batching. Standalone callers
+    /// (SSE event handler, ad-hoc cleanups) save their context explicitly.
     static func hardDelete(
         tableName: String,
         id: String,
@@ -101,8 +112,6 @@ enum SyncEntityMapper {
         default:
             return
         }
-        // Flush the delete so subsequent fetches don't return the ghost.
-        try? context.save()
     }
 
     // MARK: - Item
@@ -631,7 +640,6 @@ enum SyncEntityMapper {
 
     // MARK: - Per-table upsert wrappers
 
-    @MainActor
     private static func upsertItem(
         id: String,
         dict: [String: Any],
@@ -651,7 +659,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertList(
         id: String,
         dict: [String: Any],
@@ -671,7 +678,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertCalendarEvent(
         id: String,
         dict: [String: Any],
@@ -691,7 +697,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertCalendarEventNote(
         id: String,
         dict: [String: Any],
@@ -711,7 +716,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertScout(
         id: String,
         dict: [String: Any],
@@ -731,7 +735,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertScoutFinding(
         id: String,
         dict: [String: Any],
@@ -751,7 +754,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertBrettMessage(
         id: String,
         dict: [String: Any],
@@ -771,7 +773,6 @@ enum SyncEntityMapper {
         }
     }
 
-    @MainActor
     private static func upsertAttachment(
         id: String,
         dict: [String: Any],

--- a/apps/ios/Brett/Sync/SyncManager.swift
+++ b/apps/ios/Brett/Sync/SyncManager.swift
@@ -384,7 +384,14 @@ final class SyncManager {
     // MARK: - Helpers
 
     private func describe(_ error: Error) -> String {
-        (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+        // APIError gets its diagnostic-quality message: includes the
+        // URLError code for `.unknown` so the red-dot alert reveals the
+        // actual transport failure ("Timed out", "Connection lost", etc.)
+        // instead of bare "APIError.unknown" with no signal.
+        if let apiError = error as? APIError {
+            return apiError.diagnosticMessage
+        }
+        return (error as? LocalizedError)?.errorDescription ?? String(describing: error)
     }
 }
 

--- a/apps/ios/Brett/Views/Detail/EventDetailView.swift
+++ b/apps/ios/Brett/Views/Detail/EventDetailView.swift
@@ -32,6 +32,13 @@ struct EventDetailView: View {
     @State private var relatedItems: [APIClient.RelatedItem] = []
     @State private var meetingHistory: APIClient.MeetingHistoryResponse?
     @State private var isLoadingAsides = false
+    /// Guard so back-and-forward navigation through the detail stack
+    /// doesn't re-hit `/events/:id/related-items` and
+    /// `/events/:id/meeting-history` on every re-appear. SwiftUI's
+    /// `.task` re-fires whenever the view is re-inserted; without this
+    /// flag a 3-deep navigation pop-push double-hits both endpoints.
+    /// Notes are cached separately by `RemoteCache`.
+    @State private var asidesLoaded = false
 
     private var api: APIClient { APIClient.shared }
 
@@ -392,16 +399,70 @@ struct EventDetailView: View {
     }
 
     private func loadAsides() async {
+        // Notes go through RemoteCache (TTL handles freshness). Related
+        // items + meeting history are fetched once per view-mount
+        // because they're stable for the duration of a session — no
+        // mutation path changes them — and re-fetching on every nav
+        // re-appear was a double-hit per stack pop-push.
+        guard !asidesLoaded else {
+            // Refresh notes only — those CAN change while the view is
+            // backgrounded (the user might have edited from desktop).
+            if let noteResp = try? await RemoteCache.shared.eventNote(eventId: eventId),
+               let id = noteResp.id,
+               let content = noteResp.content,
+               let updatedAt = noteResp.updatedAt {
+                let userId = authManager.currentUser?.id ?? event?.userId ?? ""
+                if !userId.isEmpty {
+                    calendarStore.applyServerNote(
+                        id: id,
+                        eventId: eventId,
+                        userId: userId,
+                        content: content,
+                        updatedAt: updatedAt
+                    )
+                    if !isNotesFocused && notesDraft.isEmpty {
+                        notesDraft = content
+                    }
+                }
+            }
+            return
+        }
         isLoadingAsides = true
         defer { isLoadingAsides = false }
         async let related = api.fetchEventRelatedItems(eventId: eventId)
         async let history = api.fetchEventMeetingHistory(eventId: eventId)
+        async let note = RemoteCache.shared.eventNote(eventId: eventId)
 
         if let relatedResp = try? await related {
             relatedItems = relatedResp.relatedItems
         }
         if let historyResp = try? await history {
             meetingHistory = historyResp
+        }
+        asidesLoaded = true
+        // Notes are no longer replicated via /sync/pull. Fetch on-open and
+        // mirror into local SwiftData using the server's primary id so a
+        // subsequent user edit pushes as an UPDATE (not a CREATE that
+        // would collide with the unique constraint).
+        if let noteResp = try? await note,
+           let id = noteResp.id,
+           let content = noteResp.content,
+           let updatedAt = noteResp.updatedAt {
+            let userId = authManager.currentUser?.id ?? event?.userId ?? ""
+            if !userId.isEmpty {
+                calendarStore.applyServerNote(
+                    id: id,
+                    eventId: eventId,
+                    userId: userId,
+                    content: content,
+                    updatedAt: updatedAt
+                )
+                // Sync the editor draft only if the user hasn't started
+                // typing — overwriting their input would feel hostile.
+                if !isNotesFocused && notesDraft.isEmpty {
+                    notesDraft = content
+                }
+            }
         }
     }
 

--- a/apps/ios/Brett/Views/Detail/TaskDetailView.swift
+++ b/apps/ios/Brett/Views/Detail/TaskDetailView.swift
@@ -256,9 +256,36 @@ private struct TaskDetailBody: View {
         Task { await refreshFromServer() }
     }
 
+    /// Hydrate the chat panel from the server. Chat history is no longer
+    /// replicated via /sync/pull — the local `BrettMessage` table only
+    /// holds whatever assistant responses streamed during this install,
+    /// so it's an incomplete view (no user messages, no cross-device
+    /// history). Source of truth is `GET /brett/chat/:itemId`, cached
+    /// in `RemoteCache` for the lifetime of the process.
+    ///
+    /// Run order on a cold open:
+    ///   1. Show local SwiftData immediately (`MessageStore.fetchForItem`)
+    ///      so the panel renders without a network round-trip on
+    ///      reasonable connections — kept as a soft fallback for true
+    ///      offline.
+    ///   2. Fetch latest from server in a Task; replace the panel with
+    ///      the server's authoritative ordering when it lands.
     private func hydrateChat() {
         let persisted = messageStore.fetchForItem(itemId, userId: authManager.currentUser?.id)
         chatStore.hydrate(itemId: itemId, from: persisted)
+
+        Task {
+            do {
+                let page = try await RemoteCache.shared.chatHistoryForItem(itemId)
+                await MainActor.run {
+                    chatStore.hydrate(itemId: itemId, from: page.messages)
+                }
+            } catch {
+                // Network error — keep the local hydrate. The chat panel
+                // already renders SOMETHING; surfacing a banner here is
+                // worse than a quiet fallback.
+            }
+        }
     }
 
     private func refreshFromServer() async {

--- a/apps/ios/Brett/Views/Inbox/InboxPage.swift
+++ b/apps/ios/Brett/Views/Inbox/InboxPage.swift
@@ -39,17 +39,16 @@ struct InboxPage: View {
     /// the page fetched imperatively via `itemStore.fetchInbox()` and
     /// needed a manual poke to re-render.
     ///
-    /// The @Query filter is intentionally narrow (`deletedAt == nil`) for
-    /// two reasons: (1) the broader 4-condition predicate that mirrors
-    /// `ItemStore.fetchInbox` times out Swift's type checker under newer
-    /// toolchains when combined with mixed `Date?` / `String?` nil checks,
-    /// and (2) we want the final filter to include the authenticated
-    /// `userId`, which can't be captured in a `@Query` initializer. The
-    /// remaining filters (inbox-shape + userId scoping) run in
-    /// `allInboxItems`. Row volume is bounded per user, so Swift-side
-    /// filtering is cheap.
+    /// The @Query filter is intentionally narrow (`deletedAt == nil` plus
+    /// the unbounded-side `dueDate == nil` shape). The full inbox
+    /// predicate (listId / status / snoozedUntil) trips the Swift 6
+    /// type checker once mixed `Date?` and `String?` nil checks land in
+    /// the same `#Predicate` body, so the remaining narrowing happens in
+    /// Swift via `allInboxItems`. The pre-filter at least cuts out every
+    /// item with a due date — typically the dominant share of a power
+    /// user's set, since most tasks get scheduled.
     @Query(
-        filter: #Predicate<Item> { $0.deletedAt == nil },
+        filter: #Predicate<Item> { $0.deletedAt == nil && $0.dueDate == nil },
         sort: \Item.createdAt,
         order: .reverse
     ) private var nonDeletedItemsAnyUser: [Item]
@@ -73,7 +72,6 @@ struct InboxPage: View {
         return nonDeletedItemsAnyUser.filter { item in
             item.userId == uid
                 && item.listId == nil
-                && item.dueDate == nil
                 && item.status == activeStatus
                 && (item.snoozedUntil == nil || item.snoozedUntil! <= now)
         }

--- a/apps/ios/Brett/Views/MainContainer.swift
+++ b/apps/ios/Brett/Views/MainContainer.swift
@@ -67,10 +67,26 @@ struct MainContainer: View {
         syncHealthRows.first?.lastSuccessfulPullAt != nil
     }
 
-    /// Full item set used for badge computation. Mirrors the query in
-    /// `TodayPage` — one notification drives the whole badge pipeline.
+    /// Items that could affect the iOS badge — active with a due date.
+    ///
+    /// Narrower than the prior "all non-deleted items" query because the
+    /// badge count only ever counts items in `(overdue, due today, this
+    /// week)`, which by definition excludes done/archived/snoozed and
+    /// items with no due date. SwiftData fires @Query updates whenever
+    /// any matched row changes, including transitions OUT of the result
+    /// set (e.g. an active item gets completed → row leaves → @Query
+    /// fires → badgeSignature recomputes → badge refresh fires). Items
+    /// without a due date never contribute to the badge regardless of
+    /// status, so filtering them out is purely a hash-cost optimisation.
+    ///
+    /// Why this matters: badgeSignature hashes every row in the result
+    /// set on every `body` pass. On a power user with hundreds of done
+    /// or no-due-date items the prior unbounded query made every TabView
+    /// swap cost O(n_total). The narrower predicate caps the iteration
+    /// at the active-with-due subset, which is bounded by the user's
+    /// open-work load (typically dozens, never hundreds).
     @Query(
-        filter: #Predicate<Item> { $0.deletedAt == nil },
+        filter: #Predicate<Item> { $0.deletedAt == nil && $0.status == "active" },
         sort: \Item.createdAt,
         order: .reverse
     ) private var allItems: [Item]

--- a/apps/ios/Brett/Views/Omnibar/ListDrawer.swift
+++ b/apps/ios/Brett/Views/Omnibar/ListDrawer.swift
@@ -300,13 +300,25 @@ struct ListDrawer: View {
     }
 
     private func pillModels(from lists: [ItemList]) -> [PillModel] {
-        lists.map { list in
-            let count = userItems.filter { $0.listId == list.id && $0.itemStatus != .done }.count
-            return PillModel(
+        // Bucket items by listId in one pass so the per-list count is
+        // O(1) lookup instead of O(items) re-filter. Prior shape was
+        // `lists.map { list in userItems.filter { ... }.count }` —
+        // O(lists × items) on every drawer render. With ~10 lists and
+        // a few hundred active items that's a few thousand string
+        // comparisons per render, enough to feel as drawer-open lag
+        // for power users.
+        var countsByListId: [String: Int] = [:]
+        countsByListId.reserveCapacity(lists.count)
+        for item in userItems where item.itemStatus != .done {
+            guard let listId = item.listId else { continue }
+            countsByListId[listId, default: 0] += 1
+        }
+        return lists.map { list in
+            PillModel(
                 id: list.id,
                 name: list.name,
                 color: ListColor(colorClass: list.colorClass) ?? .slate,
-                itemCount: count,
+                itemCount: countsByListId[list.id] ?? 0,
                 sortOrder: list.sortOrder
             )
         }

--- a/apps/ios/Brett/Views/Shared/MarkdownRenderer.swift
+++ b/apps/ios/Brett/Views/Shared/MarkdownRenderer.swift
@@ -123,20 +123,82 @@ struct MarkdownRenderer: View {
     }
 
     private func inline(_ text: String) -> AttributedString {
-        let options = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace
-        )
-        if let parsed = try? AttributedString(markdown: text, options: options) {
-            return parsed
-        }
-        return AttributedString(text)
+        MarkdownRenderer.attributedCache.inline(text)
     }
 
     // MARK: - Block parsing
 
     /// Public for testing so we can pin the parser's block segmentation.
     var blocks: [MarkdownBlock] {
-        MarkdownBlock.parse(source)
+        MarkdownRenderer.blockCache.blocks(for: source)
+    }
+
+    // MARK: - Caches
+
+    /// Process-wide LRU cache for `AttributedString(markdown:)` results.
+    /// Markdown parsing is one of the heaviest things SwiftUI does on a
+    /// MarkdownRenderer body — a chat thread with 30 messages parses 30+
+    /// inline strings on every render pass; a daily briefing with 10
+    /// blocks parses 10. Caching by source string short-circuits the
+    /// CommonMark parse on every render after the first. Bounded by
+    /// `countLimit` so a streaming briefing can't drift the cache
+    /// unbounded.
+    fileprivate static let attributedCache = AttributedStringCache(countLimit: 256)
+    fileprivate static let blockCache = BlockCache(countLimit: 64)
+}
+
+/// Thread-safe (`NSCache`) memo cache for inline-markdown parses.
+/// `NSCache` evicts on memory pressure and respects `countLimit`.
+fileprivate final class AttributedStringCache {
+    private let cache = NSCache<NSString, Box>()
+
+    init(countLimit: Int) {
+        cache.countLimit = countLimit
+    }
+
+    func inline(_ text: String) -> AttributedString {
+        let key = text as NSString
+        if let hit = cache.object(forKey: key) {
+            return hit.value
+        }
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        let parsed = (try? AttributedString(markdown: text, options: options))
+            ?? AttributedString(text)
+        cache.setObject(Box(parsed), forKey: key)
+        return parsed
+    }
+
+    private final class Box: NSObject {
+        let value: AttributedString
+        init(_ value: AttributedString) { self.value = value }
+    }
+}
+
+/// Memo cache for full-source markdown block segmentation. Different
+/// instance from the inline cache because the keys are different
+/// shapes (full document vs single inline run).
+fileprivate final class BlockCache {
+    private let cache = NSCache<NSString, Box>()
+
+    init(countLimit: Int) {
+        cache.countLimit = countLimit
+    }
+
+    func blocks(for source: String) -> [MarkdownBlock] {
+        let key = source as NSString
+        if let hit = cache.object(forKey: key) {
+            return hit.value
+        }
+        let parsed = MarkdownBlock.parse(source)
+        cache.setObject(Box(parsed), forKey: key)
+        return parsed
+    }
+
+    private final class Box: NSObject {
+        let value: [MarkdownBlock]
+        init(_ value: [MarkdownBlock]) { self.value = value }
     }
 }
 

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -94,6 +94,13 @@ struct TodayPage: View {
     /// and the user's next tap lands on the wrong row. Cleared 2s after
     /// the last completion (any new tap resets the clock).
     @State private var pendingDoneIDs: Set<String> = []
+    /// Memo cache for `TodaySections.bucket(...)`. Without it, the
+    /// bucket runs on every SwiftUI body re-eval (sync save, scenePhase,
+    /// TabView selection, completionPulse, etc.) — a 200-item set
+    /// becomes hundreds of date comparisons + 5 sorts per render. The
+    /// cache short-circuits when items + reflow + pendingDone are
+    /// unchanged, which is the common case for state-only re-renders.
+    @State private var sectionsCache = TodaySectionsCache()
 
     /// Ticker driving NextUpCard's relative-time copy.
     @State private var tickerNow: Date = Date()
@@ -188,7 +195,7 @@ struct TodayPage: View {
     // MARK: - Section computation
 
     private var sections: TodaySections {
-        TodaySections.bucket(
+        sectionsCache.sections(
             items: userItems,
             reflowKey: reflowSnapshotKey,
             pendingDoneIDs: pendingDoneIDs

--- a/apps/ios/Brett/Views/Today/TodaySections.swift
+++ b/apps/ios/Brett/Views/Today/TodaySections.swift
@@ -148,3 +148,80 @@ struct TodaySections {
         )
     }
 }
+
+/// Memo-cache around `TodaySections.bucket(...)`. Held in a `@State`
+/// reference type on `TodayPage` so it survives across body passes.
+///
+/// Why: `TodayPage.sections` was a computed property calling
+/// `TodaySections.bucket(items:reflowKey:pendingDoneIDs:)` on every
+/// SwiftUI body re-evaluation, which fires on EVERY @Query update,
+/// every @State change (completionPulse, scenePhase, etc.), and every
+/// TabView selection. Bucket is O(n) classify + 5 small sorts; for
+/// 200 active items + 50 done that's a few hundred operations per
+/// render, including comparing dates. Adds up under a sync climb.
+///
+/// The cache is keyed by a hash of (id, status, dueDate, completedAt)
+/// across the items plus the reflow + pending-done state. Hash is
+/// also O(n), but ~10x cheaper than bucket because there's no sort.
+/// On cache hits (items stable, state changes only) we skip bucket
+/// entirely.
+///
+/// `@MainActor` because `TodayPage` is main-actor; the cache itself
+/// has no other reason to leave it.
+@MainActor
+final class TodaySectionsCache {
+    private var lastSignature: Int?
+    private var lastResult: TodaySections?
+
+    func sections(
+        items: [Item],
+        reflowKey: Int,
+        pendingDoneIDs: Set<String>
+    ) -> TodaySections {
+        let signature = Self.signature(
+            items: items,
+            reflowKey: reflowKey,
+            pendingDoneIDs: pendingDoneIDs
+        )
+        if let lastSignature, lastSignature == signature, let lastResult {
+            return lastResult
+        }
+        let result = TodaySections.bucket(
+            items: items,
+            reflowKey: reflowKey,
+            pendingDoneIDs: pendingDoneIDs
+        )
+        lastSignature = signature
+        lastResult = result
+        return result
+    }
+
+    /// Hash the inputs that could change the bucket output. Mirrors
+    /// the fields `bucket()` reads. Including pendingDoneIDs and
+    /// reflowKey so the debounce mechanic still re-derives correctly.
+    /// `Hasher.finalize()` collisions are vanishingly rare in this
+    /// shape — even if one happens, the only consequence is one
+    /// stale render before the next mutation re-keys it.
+    private static func signature(
+        items: [Item],
+        reflowKey: Int,
+        pendingDoneIDs: Set<String>
+    ) -> Int {
+        var hasher = Hasher()
+        hasher.combine(reflowKey)
+        // Set is hashable but its `hashValue` is unstable across
+        // launches; combine sorted elements for a deterministic hash
+        // within the process lifetime (we only need stability across
+        // back-to-back render passes, not across launches).
+        for id in pendingDoneIDs.sorted() {
+            hasher.combine(id)
+        }
+        for item in items {
+            hasher.combine(item.id)
+            hasher.combine(item.status)
+            hasher.combine(item.dueDate)
+            hasher.combine(item.completedAt)
+        }
+        return hasher.finalize()
+    }
+}

--- a/apps/ios/BrettTests/Networking/RemoteCacheTests.swift
+++ b/apps/ios/BrettTests/Networking/RemoteCacheTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Foundation
+@testable import Brett
+
+/// Tests for `RemoteCache` — the in-memory TTL store backing on-demand
+/// reads (chat history, event notes). The endpoint-fetcher methods
+/// (`chatHistoryForItem`, etc.) hit `APIClient.shared` and aren't
+/// exercised here; this suite covers the generic primitives + the
+/// invalidation path used by the streaming send completion.
+@Suite("RemoteCache")
+struct RemoteCacheTests {
+
+    // Each test creates its own cache instance so the shared singleton
+    // doesn't leak state across tests.
+    private func makeCache() -> RemoteCache {
+        RemoteCache()
+    }
+
+    @Test func setAndGetReturnsCachedValue() async {
+        let cache = makeCache()
+        await cache.set("hello", forKey: "k.1")
+        let v: String? = await cache.value(forKey: "k.1")
+        #expect(v == "hello")
+    }
+
+    @Test func missingKeyReturnsNil() async {
+        let cache = makeCache()
+        let v: String? = await cache.value(forKey: "k.missing")
+        #expect(v == nil)
+    }
+
+    @Test func expiredEntryReturnsNilAndEvicts() async throws {
+        let cache = makeCache()
+        // 100ms TTL — short enough to expire reliably within the test.
+        await cache.set("ephemeral", forKey: "k.ttl", ttl: 0.1)
+        let immediate: String? = await cache.value(forKey: "k.ttl")
+        #expect(immediate == "ephemeral")
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        let afterExpiry: String? = await cache.value(forKey: "k.ttl")
+        #expect(afterExpiry == nil)
+    }
+
+    @Test func invalidateKeyRemovesEntry() async {
+        let cache = makeCache()
+        await cache.set(42, forKey: "k.invalidate")
+        await cache.invalidate(key: "k.invalidate")
+        let v: Int? = await cache.value(forKey: "k.invalidate")
+        #expect(v == nil)
+    }
+
+    @Test func invalidatePrefixDropsAllMatchingKeys() async {
+        let cache = makeCache()
+        await cache.set("a", forKey: "chat.item.A")
+        await cache.set("b", forKey: "chat.item.B")
+        await cache.set("c", forKey: "event.note.X")
+
+        await cache.invalidate(prefix: "chat.item.")
+
+        let a: String? = await cache.value(forKey: "chat.item.A")
+        let b: String? = await cache.value(forKey: "chat.item.B")
+        let c: String? = await cache.value(forKey: "event.note.X")
+        #expect(a == nil)
+        #expect(b == nil)
+        // Non-matching prefix survives.
+        #expect(c == "c")
+    }
+
+    @Test func clearRemovesEverything() async {
+        let cache = makeCache()
+        await cache.set("a", forKey: "k.1")
+        await cache.set("b", forKey: "k.2")
+        await cache.clear()
+        let a: String? = await cache.value(forKey: "k.1")
+        let b: String? = await cache.value(forKey: "k.2")
+        #expect(a == nil)
+        #expect(b == nil)
+    }
+
+    @Test func invalidateChatHistoryItemDropsItemKey() async {
+        let cache = makeCache()
+        // Seed manually using the same key shape `chatHistoryForItem`
+        // would produce. We don't exercise the network fetcher here —
+        // just the invalidation contract.
+        await cache.set("seeded", forKey: "chat.item.item-1")
+
+        await cache.invalidateChatHistory(itemId: "item-1", eventId: nil)
+
+        let v: String? = await cache.value(forKey: "chat.item.item-1")
+        #expect(v == nil)
+    }
+
+    @Test func invalidateChatHistoryEventDropsEventKey() async {
+        let cache = makeCache()
+        await cache.set("seeded", forKey: "chat.event.event-1")
+
+        await cache.invalidateChatHistory(itemId: nil, eventId: "event-1")
+
+        let v: String? = await cache.value(forKey: "chat.event.event-1")
+        #expect(v == nil)
+    }
+
+    @Test func setOverwritesExistingValue() async {
+        let cache = makeCache()
+        await cache.set("first", forKey: "k.dup")
+        await cache.set("second", forKey: "k.dup")
+        let v: String? = await cache.value(forKey: "k.dup")
+        #expect(v == "second")
+    }
+
+    @Test func valueReturnsCorrectTypeForGeneric() async {
+        // Mixed-type entries shouldn't bleed across keys.
+        let cache = makeCache()
+        await cache.set([1, 2, 3], forKey: "k.array")
+        await cache.set("text", forKey: "k.string")
+
+        let arr: [Int]? = await cache.value(forKey: "k.array")
+        let str: String? = await cache.value(forKey: "k.string")
+        #expect(arr == [1, 2, 3])
+        #expect(str == "text")
+
+        // Wrong type for an existing key returns nil (the cast fails).
+        let mismatched: [Int]? = await cache.value(forKey: "k.string")
+        #expect(mismatched == nil)
+    }
+}

--- a/apps/ios/BrettTests/Sync/PushEngineTests.swift
+++ b/apps/ios/BrettTests/Sync/PushEngineTests.swift
@@ -53,6 +53,10 @@ struct PushEngineTests {
         func getByIdempotencyKey(_ key: String) -> MutationQueueEntry? {
             pending.first(where: { $0.idempotencyKey == key })
         }
+
+        func pendingCount() -> Int {
+            pending.count
+        }
     }
 
     /// Build an APIClient backed by `MockURLProtocol`. Does NOT reset the

--- a/apps/ios/BrettTests/Sync/SyncEntityMapperTests.swift
+++ b/apps/ios/BrettTests/Sync/SyncEntityMapperTests.swift
@@ -381,6 +381,9 @@ struct SyncEntityMapperTests {
         try context.save()
 
         SyncEntityMapper.hardDelete(tableName: "items", id: "item-1", context: context)
+        // Caller owns the save now — `hardDelete` no longer flushes
+        // implicitly so the actor batch path can save once per round.
+        try context.save()
 
         let fetched: [Item] = (try? context.fetch(FetchDescriptor<Item>())) ?? []
         #expect(fetched.isEmpty)

--- a/apps/ios/BrettTests/Views/TodaySectionsTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsTests.swift
@@ -11,6 +11,16 @@ import SwiftData
 @MainActor
 struct TodaySectionsTests {
 
+    /// UTC calendar — must match the calendar `TodaySections.bucket()`
+    /// uses internally, otherwise local-vs-UTC date math drifts and
+    /// fixtures land in the wrong bucket non-deterministically by
+    /// time of day the test suite runs.
+    private let utcCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
     private func makeContext() throws -> ModelContext {
         let container = try InMemoryPersistenceController.makeContainer()
         return ModelContext(container)
@@ -25,7 +35,7 @@ struct TodaySectionsTests {
 
     @Test func itemDueYesterdayGoesToOverdue() throws {
         let ctx = try makeContext()
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let yesterday = utcCalendar.date(byAdding: .day, value: -1, to: Date())!
         let item = itemDue(yesterday)
         ctx.insert(item)
 
@@ -38,7 +48,7 @@ struct TodaySectionsTests {
 
     @Test func itemDueTodayGoesToToday() throws {
         let ctx = try makeContext()
-        let today = Calendar.current.startOfDay(for: Date()).addingTimeInterval(3600)
+        let today = utcCalendar.startOfDay(for: Date()).addingTimeInterval(3600)
         let item = itemDue(today)
         ctx.insert(item)
 
@@ -62,7 +72,7 @@ struct TodaySectionsTests {
 
     @Test func itemCompletedYesterdayIsOmittedEntirely() throws {
         let ctx = try makeContext()
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let yesterday = utcCalendar.date(byAdding: .day, value: -1, to: Date())!
         let item = itemDue(yesterday, completedAt: yesterday, status: .done)
         ctx.insert(item)
 
@@ -90,7 +100,7 @@ struct TodaySectionsTests {
         // prior section (not the "Done today" bucket) until the debounce
         // expires — lets the user tap nearby rows without the list jumping.
         let ctx = try makeContext()
-        let today = Calendar.current.startOfDay(for: Date()).addingTimeInterval(3600)
+        let today = utcCalendar.startOfDay(for: Date()).addingTimeInterval(3600)
         let item = itemDue(today, completedAt: Date(), status: .done)
         ctx.insert(item)
 


### PR DESCRIPTION
## Summary

Promotes [#96](https://github.com/brentbarkman/brett/pull/96) to release.

- iOS sync overhaul: hot tables only (items/lists/scouts/calendar_events ±14d), cold tables on-demand, per-row apply on a background `@ModelActor`.
- Server-side filters narrow what /sync/pull returns. Cursor-key gating lets new clients opt out of cold tables; legacy empty-cursors path preserved so any older iOS install keeps syncing.
- Hot @Query narrows + view memoization (TodaySections, MarkdownRenderer caches).

## Test plan

- [x] iOS unit tests: 573/573
- [x] iOS Debug build: green
- [x] API typecheck: green
- [ ] Railway deploy lands cleanly (release CI)
- [ ] Smoke test prod after deploy: cold-launch sync + chat thread / event notes hydrate on open

🤖 Generated with [Claude Code](https://claude.com/claude-code)