### PR TITLE
fix(ios): align this-week/next-week boundary with electron exactly

### DIFF
--- a/apps/ios/Brett/Utilities/DateHelpers.swift
+++ b/apps/ios/Brett/Utilities/DateHelpers.swift
@@ -1,12 +1,22 @@
 import Foundation
 
 enum DateHelpers {
-    static func computeUrgency(dueDate: Date?, isCompleted: Bool) -> Urgency {
+    /// UTC calendar — matches `TodaySections.bucket()` and desktop's
+    /// `computeUrgency` (`packages/business/src/index.ts`). Switching off
+    /// `Calendar.current` makes this helper agree with the section
+    /// bucketer rather than disagreeing once UTC and local fall on
+    /// different days.
+    private static let utcCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    static func computeUrgency(dueDate: Date?, isCompleted: Bool, now: Date = Date()) -> Urgency {
         if isCompleted { return .done }
         guard let dueDate else { return .later }
 
-        let calendar = Calendar.current
-        let now = Date()
+        let calendar = Self.utcCalendar
         let startOfToday = calendar.startOfDay(for: now)
         let startOfDueDay = calendar.startOfDay(for: dueDate)
 
@@ -14,17 +24,23 @@ enum DateHelpers {
             return .overdue
         }
 
-        if calendar.isDate(dueDate, inSameDayAs: now) {
+        if startOfDueDay == startOfToday {
             return .today
         }
 
-        // End of this week (Sunday)
-        let endOfWeek = calendar.date(byAdding: .day, value: 7 - calendar.component(.weekday, from: now), to: startOfToday)!
+        // Boundary mirrors desktop's `computeUrgency` exactly: "this week"
+        // is inclusive of the upcoming Sunday; on Sunday itself it
+        // extends a full 7 days. Same end-of-Sunday-UTC moment as
+        // `TodaySections.bucket()`, just compared with `<=` against
+        // `startOfDueDay` (also UTC-stripped) instead of `<` against
+        // start-of-Monday — equivalent semantics.
+        let weekday = calendar.component(.weekday, from: now)
+        let daysUntilEndOfWeek = weekday == 1 ? 7 : (8 - weekday) // Sunday = 1
+        let endOfWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday)!
         if startOfDueDay <= endOfWeek {
             return .thisWeek
         }
 
-        // End of next week
         let endOfNextWeek = calendar.date(byAdding: .day, value: 7, to: endOfWeek)!
         if startOfDueDay <= endOfNextWeek {
             return .nextWeek

--- a/apps/ios/Brett/Views/Today/TodaySections.swift
+++ b/apps/ios/Brett/Views/Today/TodaySections.swift
@@ -26,15 +26,12 @@ struct TodaySections {
 
     /// Count shown on the iOS home-screen badge and the macOS dock badge.
     /// Overdue + due today + due this week, excluding Next Week, completed,
-    /// archived, and items without a due date. Semantically equivalent to
-    /// desktop's `activeThingsForCount.length` in `apps/desktop/src/App.tsx`,
-    /// but the two can diverge at week boundaries for non-UTC timezones —
-    /// desktop uses UTC end-of-week (`getEndOfWeekUTC`) while iOS uses
-    /// `Calendar.current` (local time). Matches the existing iOS vs desktop
-    /// split in the Today view itself, so the badge stays consistent with
-    /// what each client shows on-screen.
-    static func badgeCount(items: [Item]) -> Int {
-        let s = bucket(items: items, reflowKey: 0)
+    /// archived, and items without a due date. Semantically identical to
+    /// desktop's `activeThingsForCount.length` in `apps/desktop/src/App.tsx`
+    /// — both bucket on the same UTC day/week boundaries, so a row that
+    /// counts on one client counts on the other.
+    static func badgeCount(items: [Item], now: Date = Date()) -> Int {
+        let s = bucket(items: items, reflowKey: 0, now: now)
         return s.overdue.count + s.today.count + s.thisWeek.count
     }
 
@@ -68,19 +65,28 @@ struct TodaySections {
     static func bucket(
         items: [Item],
         reflowKey: Int,
-        pendingDoneIDs: Set<String> = []
+        pendingDoneIDs: Set<String> = [],
+        now: Date = Date()
     ) -> TodaySections {
         _ = reflowKey // force re-derivation on change; see toggle() in the parent
         let calendar = Self.utcCalendar
-        let now = Date()
         let startOfToday = calendar.startOfDay(for: now)
         let endOfToday = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday.addingTimeInterval(86_400)
 
-        // End of this week = next Sunday midnight UTC. Mirrors
-        // `getEndOfWeekUTC` in packages/business: "if today is Sunday,
-        // next Sunday; otherwise the upcoming Sunday."
+        // Boundary mirrors desktop's `computeUrgency`
+        // (`packages/business/src/index.ts`) exactly: "this week" is
+        // inclusive of the upcoming Sunday; on Sunday itself it extends
+        // a full 7 days. Desktop achieves this with `dueMs <=
+        // endOfThisWeek` against start-of-Sunday UTC. We use `<` against
+        // start-of-Monday UTC (one day past Sunday) so the comparison
+        // stays symmetric with `endOfToday` and so a row stored anywhere
+        // on Sunday — including 00:00:00 UTC — buckets identically on
+        // both clients. The previous off-by-one (boundary at start-of-
+        // Sunday with `<`) was dropping every Sunday-due task into
+        // `nextWeek` and every following-Sunday task out of the bucket
+        // entirely.
         let weekday = calendar.component(.weekday, from: now)
-        let daysUntilEndOfWeek = weekday == 1 ? 7 : (8 - weekday) // Sunday = 1
+        let daysUntilEndOfWeek = weekday == 1 ? 8 : (9 - weekday) // Sunday = 1; +1 day past upcoming Sunday
         let endOfThisWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday) ?? endOfToday
         let endOfNextWeek = calendar.date(byAdding: .day, value: 7, to: endOfThisWeek) ?? endOfThisWeek.addingTimeInterval(7 * 86_400)
 

--- a/apps/ios/BrettTests/DateHelpersTests.swift
+++ b/apps/ios/BrettTests/DateHelpersTests.swift
@@ -4,34 +4,65 @@ import Foundation
 
 @Suite("DateHelpers")
 struct DateHelpersTests {
+    /// Pin `now` and `dueDate` fixtures to fixed UTC moments so assertions
+    /// don't depend on when the suite runs — the helper is UTC-based, so
+    /// `Calendar.current` fixtures drifted across UTC midnight. Same
+    /// fixture style as `TodaySectionsTests` so both helpers — the
+    /// section bucketer and the urgency-only helper used by detail-card
+    /// colors — share a parity story.
+    private static func utcDate(_ y: Int, _ m: Int, _ d: Int, _ h: Int = 12) -> Date {
+        var c = DateComponents()
+        c.year = y; c.month = m; c.day = d; c.hour = h
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private static let saturdayNoon: Date = utcDate(2026, 4, 25, 12)
+
     @Test func computeUrgencyOverdue() {
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-        #expect(DateHelpers.computeUrgency(dueDate: yesterday, isCompleted: false) == .overdue)
+        let yesterday = Self.utcDate(2026, 4, 24, 12)
+        #expect(DateHelpers.computeUrgency(dueDate: yesterday, isCompleted: false, now: Self.saturdayNoon) == .overdue)
     }
 
     @Test func computeUrgencyToday() {
-        let today = Calendar.current.startOfDay(for: Date())
-        #expect(DateHelpers.computeUrgency(dueDate: today, isCompleted: false) == .today)
+        let laterToday = Self.utcDate(2026, 4, 25, 18)
+        #expect(DateHelpers.computeUrgency(dueDate: laterToday, isCompleted: false, now: Self.saturdayNoon) == .today)
     }
 
     @Test func computeUrgencyThisWeek() {
-        let calendar = Calendar.current
-        let today = Date()
-        let weekday = calendar.component(.weekday, from: today)
-        let daysUntilEndOfWeek = 7 - weekday
-        if daysUntilEndOfWeek > 0 {
-            let laterThisWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: today)!
-            #expect(DateHelpers.computeUrgency(dueDate: laterThisWeek, isCompleted: false) == .thisWeek)
-        }
+        // Sunday-on-Saturday — the inclusive boundary case. Old
+        // `Calendar.current` + `7 - weekday` formula collapsed this to
+        // `endOfWeek == today`, dropping Sunday into `.nextWeek` and
+        // diverging from desktop's `computeUrgency`.
+        let sunday = Self.utcDate(2026, 4, 26, 18)
+        #expect(DateHelpers.computeUrgency(dueDate: sunday, isCompleted: false, now: Self.saturdayNoon) == .thisWeek)
     }
 
     @Test func computeUrgencyDone() {
-        let today = Date()
-        #expect(DateHelpers.computeUrgency(dueDate: today, isCompleted: true) == .done)
+        // `done` short-circuits before any date math, so a stale
+        // `Date()` here can't drift the result.
+        #expect(DateHelpers.computeUrgency(dueDate: Self.saturdayNoon, isCompleted: true) == .done)
     }
 
     @Test func computeUrgencyNoDueDate() {
         #expect(DateHelpers.computeUrgency(dueDate: nil, isCompleted: false) == .later)
+    }
+
+    // MARK: - Boundary parity with desktop
+
+    @Test func mondayDueOnSaturdayIsNextWeek() {
+        // Sanity check the upper edge — Monday must still classify as
+        // `.nextWeek`. Catches over-correcting the boundary by +2 days.
+        let mondayDue = Self.utcDate(2026, 4, 27, 0)
+        #expect(DateHelpers.computeUrgency(dueDate: mondayDue, isCompleted: false, now: Self.saturdayNoon) == .nextWeek)
+    }
+
+    @Test func nextSundayDueOnSundayIsThisWeek() {
+        // On Sunday, "this week" extends a full 7 days through next
+        // Sunday. Verifies the `weekday == 1` branch matches desktop.
+        let sunday = Self.utcDate(2026, 4, 26, 12)
+        let nextSundayDue = Self.utcDate(2026, 5, 3, 0)
+        #expect(DateHelpers.computeUrgency(dueDate: nextSundayDue, isCompleted: false, now: sunday) == .thisWeek)
     }
 
     @Test func formatRelativeDate() {

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -23,27 +23,20 @@ struct TodaySectionsBadgeTests {
     private var startOfToday: Date { calendar.startOfDay(for: Date()) }
     private var yesterday: Date { calendar.date(byAdding: .day, value: -1, to: startOfToday)! }
     private var noonToday: Date { calendar.date(byAdding: .hour, value: 12, to: startOfToday)! }
-    /// A date strictly inside "this week" but after today. If today is
-    /// Saturday (UTC), "+1 day" lands in next week — clamp to
-    /// end-of-week-minus-1h.
-    ///
-    /// NOTE: On Saturday the `thisWeek` bucket is structurally empty
-    /// (`endOfThisWeek == endOfToday` in `bucket()`), so this fixture
-    /// falls into `today` rather than `thisWeek`. `badgeCount` still
-    /// returns the right number because it sums overdue + today +
-    /// thisWeek, but `countsThisWeek` is effectively exercising the
-    /// `today` bucket on Saturdays. That's acceptable for this helper.
+    /// A date strictly inside "this week" but after today. Mirrors the
+    /// `bucket()` formula: end-of-this-week is start-of-Monday UTC (one
+    /// day past the upcoming Sunday, matching desktop's inclusive
+    /// `<= endOfThisWeek` boundary). Returning one hour before that lands
+    /// inside `thisWeek` on every weekday including Saturday and Sunday.
     private var laterThisWeek: Date {
         let weekday = calendar.component(.weekday, from: Date())
-        // Mirror bucket()'s "if Sunday, next Sunday; else upcoming Sunday"
-        let daysUntilEndOfWeek = weekday == 1 ? 7 : (8 - weekday)
+        let daysUntilEndOfWeek = weekday == 1 ? 8 : (9 - weekday)
         let endOfWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday)!
-        // One hour before end-of-week — guaranteed inside the bucket on every weekday.
         return calendar.date(byAdding: .hour, value: -1, to: endOfWeek)!
     }
     private var nextWeek: Date {
         let weekday = calendar.component(.weekday, from: Date())
-        let daysUntilEndOfWeek = weekday == 1 ? 7 : (8 - weekday)
+        let daysUntilEndOfWeek = weekday == 1 ? 8 : (9 - weekday)
         let endOfWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday)!
         return calendar.date(byAdding: .day, value: 2, to: endOfWeek)!
     }

--- a/apps/ios/BrettTests/Views/TodaySectionsTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsTests.swift
@@ -127,6 +127,98 @@ struct TodaySectionsTests {
         #expect(sections.activeCount == 0)
     }
 
+    // MARK: - Boundary parity with desktop
+
+    /// Fixed UTC moments used by the boundary parity tests. Date math
+    /// here is fully deterministic — these tests must hold regardless of
+    /// what day or hour the suite runs.
+    private static func utcDate(_ y: Int, _ m: Int, _ d: Int, _ h: Int = 12) -> Date {
+        var c = DateComponents()
+        c.year = y; c.month = m; c.day = d; c.hour = h
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    @Test func sundayDueOnSaturdayBucketsAsThisWeek() throws {
+        // The exact bug we shipped against: on Saturday, a task due the
+        // upcoming Sunday must land in `thisWeek` to match desktop's
+        // `computeUrgency` (`packages/business/src/index.ts`), which treats
+        // `dueMs <= endOfThisWeek` (Sunday midnight UTC) as inclusive.
+        let ctx = try makeContext()
+        let saturday = Self.utcDate(2026, 4, 25, 12)         // Sat noon UTC
+        let sundayDue = Self.utcDate(2026, 4, 26, 0)         // Sun 00:00 UTC — boundary
+        let item = itemDue(sundayDue)
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
+
+        #expect(sections.thisWeek.map(\.id) == [item.id])
+        #expect(sections.nextWeek.isEmpty)
+    }
+
+    @Test func sundayDueLaterInDayOnSaturdayBucketsAsThisWeek() throws {
+        // Same day-of-week boundary, but with a non-midnight time on the
+        // due date. Desktop strips to `utcDay(dueDate)` so any moment on
+        // Sunday counts as "this week" today (Saturday).
+        let ctx = try makeContext()
+        let saturday = Self.utcDate(2026, 4, 25, 12)
+        let sundayLate = Self.utcDate(2026, 4, 26, 23)       // Sun 23:00 UTC
+        let item = itemDue(sundayLate)
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
+
+        #expect(sections.thisWeek.map(\.id) == [item.id])
+        #expect(sections.nextWeek.isEmpty)
+    }
+
+    @Test func mondayDueOnSaturdayBucketsAsNextWeek() throws {
+        // Sanity check the upper edge — Monday must still fall to
+        // `nextWeek`. Catches an over-correction (e.g. +2 days instead of
+        // +1) that would also pull Monday in.
+        let ctx = try makeContext()
+        let saturday = Self.utcDate(2026, 4, 25, 12)
+        let mondayDue = Self.utcDate(2026, 4, 27, 0)
+        let item = itemDue(mondayDue)
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
+
+        #expect(sections.nextWeek.map(\.id) == [item.id])
+        #expect(sections.thisWeek.isEmpty)
+    }
+
+    @Test func nextSundayDueOnSaturdayBucketsAsNextWeek() throws {
+        // Desktop puts a task on the *following* Sunday into `nextWeek`
+        // (`dueMs <= endOfNextWeek`, where `endOfNextWeek = endOfThisWeek
+        // + 7 days`). Before parity work iOS dropped this row entirely.
+        let ctx = try makeContext()
+        let saturday = Self.utcDate(2026, 4, 25, 12)
+        let nextSunday = Self.utcDate(2026, 5, 3, 0)
+        let item = itemDue(nextSunday)
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
+
+        #expect(sections.nextWeek.map(\.id) == [item.id])
+    }
+
+    @Test func sundayTodayPutsTodayItemInTodayNotThisWeek() throws {
+        // When today *is* Sunday, an item dated today must still land in
+        // `today`, not `thisWeek` — verifies the `weekday == 1` branch
+        // doesn't pull today's row forward.
+        let ctx = try makeContext()
+        let sunday = Self.utcDate(2026, 4, 26, 12)
+        let sundayDue = Self.utcDate(2026, 4, 26, 18)
+        let item = itemDue(sundayDue)
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: sunday)
+
+        #expect(sections.today.map(\.id) == [item.id])
+        #expect(sections.thisWeek.isEmpty)
+    }
+
     @Test func sortingPutsNewestCreatedFirst() throws {
         // Within-bucket sort matches desktop's `/things` route — `createdAt
         // DESC`, with stable secondary `id`. Was previously `dueDate ASC`,


### PR DESCRIPTION
## Summary
- Sunday-due tasks (and following-Sunday tasks) bucketed differently between iOS and electron — root cause was a strict-less-than vs inclusive comparison against start-of-Sunday UTC.
- Fixed in both `TodaySections.bucket` (Today page sections + home-screen badge) and `DateHelpers.computeUrgency` (detail-card accent color), plus added `now: Date` parameters mirroring electron's `computeUrgency` signature.
- 5 new deterministic boundary-parity tests; pre-existing TZ-flaky fixtures stabilized.

The two prod tasks Brent reported ($20 at riley cru, Buy lulu in April) almost certainly have `dueDate ≈ 2026-04-26T00:00:00Z` — both clients now agree they belong in **This Week** today.

## Test plan
- [x] `xcodebuild -only-testing:BrettTests` → 580/580 pass
- [x] New boundary tests fail before fix (verified RED then GREEN)
- [x] No production callers needed updating — `now` parameter defaults preserve existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)