### PR TITLE
fix(sync): drop scouts status filter — ScoutStatus has no "archived"

### DIFF
--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -276,9 +276,14 @@ export const sync = new Hono<AuthEnv>()
         ];
       } else if (table === "lists") {
         extraWhere.archivedAt = null;
-      } else if (table === "scouts") {
-        extraWhere.status = { not: "archived" };
       }
+      // No filter for scouts: the `ScoutStatus` enum is
+      // active|paused|completed|expired (no "archived"), so a `status:
+      // { not: "archived" }` clause throws Prisma validation. Soft-
+      // delete via `deletedAt` is the only mechanism that hides a
+      // scout, and `paginatedPull` handles tombstones natively. All
+      // other live statuses are still worth syncing — a completed
+      // or expired scout is read-only context the user may revisit.
 
       // Keyset-merged pull: live + tombstones in one ordered stream, single
       // monotonic cursor. See `paginated-pull.ts` for the algorithm and


### PR DESCRIPTION
## Summary

CI broke after [#96](https://github.com/brentbarkman/brett/pull/96). My scouts `extraWhere` passed `{ status: { not: "archived" } }`, but Prisma's `ScoutStatus` enum is `active|paused|completed|expired` — no `archived` member. Every `/sync/pull` 500'd with `Invalid value for argument \`not\`. Expected ScoutStatus.`

Soft-delete via `deletedAt` already hides removed scouts, and `paginatedPull` handles tombstones natively. Drop the clause; the other table filters are unaffected.

## Test plan

- [x] API typecheck green
- [ ] Sync tests pass in CI (will verify on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)