### PR TITLE
release: scout-filter hotfix

### DIFF
--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -276,9 +276,14 @@ export const sync = new Hono<AuthEnv>()
         ];
       } else if (table === "lists") {
         extraWhere.archivedAt = null;
-      } else if (table === "scouts") {
-        extraWhere.status = { not: "archived" };
       }
+      // No filter for scouts: the `ScoutStatus` enum is
+      // active|paused|completed|expired (no "archived"), so a `status:
+      // { not: "archived" }` clause throws Prisma validation. Soft-
+      // delete via `deletedAt` is the only mechanism that hides a
+      // scout, and `paginatedPull` handles tombstones natively. All
+      // other live statuses are still worth syncing — a completed
+      // or expired scout is read-only context the user may revisit.
 
       // Keyset-merged pull: live + tombstones in one ordered stream, single
       // monotonic cursor. See `paginated-pull.ts` for the algorithm and


### PR DESCRIPTION
## Summary

Promotes [#100](https://github.com/brentbarkman/brett/pull/100) — the hotfix for the scouts \`extraWhere\` clause that was 500'ing /sync/pull post-#96.

\`ScoutStatus\` enum has no \`archived\` member (active|paused|completed|expired), so \`{ status: { not: "archived" } }\` failed Prisma validation. Soft-delete via \`deletedAt\` already hides removed scouts.

## Test plan

- [x] API typecheck green
- [x] Main CI green (post-fix run)
- [ ] Railway deploy lands cleanly
- [ ] Smoke /sync/pull on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)