### PR TITLE
release: fix tweet extraction (SSRF guard + iOS metadata drift)

### DIFF
--- a/apps/api/src/__tests__/ssrf-guard.test.ts
+++ b/apps/api/src/__tests__/ssrf-guard.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { safeFetch, _isPrivateIPForTesting as isPrivateIP } from "../lib/ssrf-guard.js";
+import {
+  safeFetch,
+  _isPrivateIPForTesting as isPrivateIP,
+  _guardedLookupForTesting as guardedLookup,
+} from "../lib/ssrf-guard.js";
 
 describe("isPrivateIP", () => {
   // IPv4 ranges that must be blocked
@@ -50,6 +54,61 @@ describe("isPrivateIP", () => {
   });
 });
 
+describe("guardedLookup callback shape", () => {
+  // undici 7's connect path calls our lookup with `{ all: true }` and expects
+  // the callback to return an ARRAY of `{address, family}` records. Returning
+  // the classic `(err, addressString, family)` shape causes undici to throw
+  // ERR_INVALID_IP_ADDRESS — silently breaks every safeFetch in production.
+  // These tests pin both call shapes.
+
+  function callLookup(
+    hostname: string,
+    options: any,
+  ): Promise<{ err: NodeJS.ErrnoException | null; result: unknown[] }> {
+    return new Promise((resolve) => {
+      // Capture all callback args so we can assert on the second-arg shape,
+      // not just (err, address, family). undici calls back with (err, addresses[]).
+      guardedLookup(hostname, options, (...args: unknown[]) => {
+        resolve({ err: args[0] as NodeJS.ErrnoException | null, result: args.slice(1) });
+      });
+    });
+  }
+
+  it("returns an array when called with { all: true } (undici 7 contract)", async () => {
+    const { err, result } = await callLookup("example.com", { all: true });
+    expect(err).toBeNull();
+    // Second callback arg must be an array of {address, family} records.
+    expect(Array.isArray(result[0])).toBe(true);
+    const addresses = result[0] as Array<{ address: string; family: number }>;
+    expect(addresses.length).toBeGreaterThan(0);
+    for (const addr of addresses) {
+      expect(typeof addr.address).toBe("string");
+      expect(addr.family).toBe(4);
+    }
+  });
+
+  it("returns (address, family) when called without all (classic Node contract)", async () => {
+    const { err, result } = await callLookup("example.com", {});
+    expect(err).toBeNull();
+    // Classic shape: callback(null, addressString, family).
+    expect(typeof result[0]).toBe("string");
+    expect(result[1]).toBe(4);
+  });
+
+  it("blocks single private IPv4 in classic shape", async () => {
+    // localhost resolves to 127.0.0.1 — must be rejected with EBLOCKED_PRIVATE_IP.
+    const { err } = await callLookup("localhost", {});
+    expect(err).not.toBeNull();
+    expect(err?.code).toBe("EBLOCKED_PRIVATE_IP");
+  });
+
+  it("blocks all-private results in array shape", async () => {
+    const { err } = await callLookup("localhost", { all: true });
+    expect(err).not.toBeNull();
+    expect(err?.code).toBe("EBLOCKED_PRIVATE_IP");
+  });
+});
+
 describe("safeFetch", () => {
   it("rejects non-http(s) protocols before resolving DNS", async () => {
     await expect(safeFetch("ftp://example.com/foo")).rejects.toThrow(/Blocked protocol/);
@@ -89,5 +148,15 @@ describe("safeFetch", () => {
       caught = err;
     }
     expect(caught).toBeDefined();
+  });
+
+  it("succeeds against a real public host (regression: undici 7 lookup contract)", async () => {
+    // Pins the bug where guardedLookup returned the classic shape while
+    // undici 7 called it with `{ all: true }` and expected an array — every
+    // safeFetch in production silently failed with ERR_INVALID_IP_ADDRESS.
+    // example.com is RFC-2606 reserved + IANA-stable, safe to hit from CI.
+    const res = await safeFetch("https://example.com/", { timeoutMs: 10_000 });
+    expect(res.status).toBeGreaterThanOrEqual(200);
+    expect(res.status).toBeLessThan(400);
   });
 });

--- a/apps/api/src/lib/content-extractor.ts
+++ b/apps/api/src/lib/content-extractor.ts
@@ -131,10 +131,16 @@ async function fetchTweetSyndication(url: string): Promise<TweetSyndicationResul
   const endpoint = `https://cdn.syndication.twimg.com/tweet-result?id=${id}&token=${token}&lang=en`;
   try {
     const res = await safeFetch(endpoint, { timeoutMs: 5000, maxSizeBytes: 500_000 });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      console.warn(`[content-extractor] tweet syndication non-ok ${res.status} for ${url}`);
+      return null;
+    }
     const data = (await res.json()) as Record<string, any>;
     const handle = data?.user?.screen_name as string | undefined;
-    if (!handle) return null;
+    if (!handle) {
+      console.warn(`[content-extractor] tweet syndication missing user.screen_name for ${url}`);
+      return null;
+    }
 
     const article = (() => {
       const a = data?.article;
@@ -160,7 +166,11 @@ async function fetchTweetSyndication(url: string): Promise<TweetSyndicationResul
       article,
       mediaImageUrl,
     };
-  } catch {
+  } catch (err) {
+    const reason = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    const cause = (err as { cause?: { code?: string; message?: string } })?.cause;
+    const causeStr = cause ? ` (cause: ${cause.code ?? cause.message ?? "?"})` : "";
+    console.warn(`[content-extractor] tweet syndication threw for ${url}: ${reason}${causeStr}`);
     return null;
   }
 }
@@ -178,14 +188,24 @@ async function fetchTweetOgTags(url: string): Promise<OgTags | null> {
         "User-Agent": "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
       },
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      console.warn(`[content-extractor] tweet OG fallback non-ok ${response.status} for ${url}`);
+      return null;
+    }
     const html = await readBodyWithLimit(response, 2 * 1024 * 1024);
     const tags = parseOgTags(html, url);
     // Require at least a description OR an image — a lone title ("X") is
     // the generic homepage fallback and not worth returning.
-    if (!tags.description && !tags.imageUrl) return null;
+    if (!tags.description && !tags.imageUrl) {
+      console.warn(`[content-extractor] tweet OG fallback returned no description/image for ${url}`);
+      return null;
+    }
     return tags;
-  } catch {
+  } catch (err) {
+    const reason = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    const cause = (err as { cause?: { code?: string; message?: string } })?.cause;
+    const causeStr = cause ? ` (cause: ${cause.code ?? cause.message ?? "?"})` : "";
+    console.warn(`[content-extractor] tweet OG fallback threw for ${url}: ${reason}${causeStr}`);
     return null;
   }
 }

--- a/apps/api/src/lib/ssrf-guard.ts
+++ b/apps/api/src/lib/ssrf-guard.ts
@@ -1,5 +1,5 @@
 import { lookup as dnsLookup } from "node:dns/promises";
-import type { LookupOptions } from "node:dns";
+import type { LookupAddress, LookupOptions } from "node:dns";
 import type { LookupFunction } from "node:net";
 import { Agent, fetch as undiciFetch } from "undici";
 
@@ -41,20 +41,42 @@ export const _isPrivateIPForTesting = isPrivateIP;
  * resolution happens, closing the DNS-rebinding TOCTOU window that a
  * separate "resolve, check, then fetch by hostname" sequence leaves open.
  *
- * Signature matches Node's `net.LookupFunction`.
+ * Two callback shapes, dispatched on `options.all`:
+ *  - `all !== true` (classic Node `net.LookupFunction`): `cb(err, address, family)`
+ *  - `all === true` (undici 7 `connect.lookup`): `cb(err, [{address, family}, ...])`
+ *
+ * Returning the wrong shape yields `ERR_INVALID_IP_ADDRESS` and silently
+ * breaks every outbound fetch. Pinned by tests in `ssrf-guard.test.ts`.
  */
 const guardedLookup: LookupFunction = (
   hostname: string,
   options: LookupOptions,
-  callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+  callback: (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void,
 ): void => {
-  // Ignore caller-provided family; force IPv4 so `isPrivateIP`'s IPv4
-  // table is authoritative. Dropping the caller's family prevents an
-  // attacker who can influence `hints`/`family` from coaxing undici into
-  // an IPv6 path where our checks are weaker.
-  void options;
-  dnsLookup(hostname, { family: 4 })
-    .then(({ address, family }) => {
+  // Force IPv4 regardless of caller hints/family so `isPrivateIP`'s IPv4
+  // table is authoritative — prevents an attacker who can influence
+  // `hints`/`family` from coaxing undici onto an IPv6 path where our
+  // checks are weaker.
+  const wantAll = (options as { all?: boolean })?.all === true;
+
+  dnsLookup(hostname, { family: 4, all: wantAll })
+    .then((result) => {
+      if (wantAll) {
+        const addresses = result as LookupAddress[];
+        const safe = addresses.filter((a) => !isPrivateIP(a.address));
+        if (safe.length === 0) {
+          const err = new Error(
+            `Blocked private IP(s): ${addresses.map((a) => a.address).join(", ") || "none"}`
+          ) as NodeJS.ErrnoException;
+          err.code = "EBLOCKED_PRIVATE_IP";
+          callback(err, []);
+          return;
+        }
+        callback(null, safe);
+        return;
+      }
+
+      const { address, family } = result as LookupAddress;
       if (isPrivateIP(address)) {
         const err = new Error(`Blocked private IP: ${address}`) as NodeJS.ErrnoException;
         err.code = "EBLOCKED_PRIVATE_IP";
@@ -63,7 +85,13 @@ const guardedLookup: LookupFunction = (
       }
       callback(null, address, family);
     })
-    .catch((err) => callback(err as NodeJS.ErrnoException, "", 0));
+    .catch((err) => {
+      if (wantAll) {
+        callback(err as NodeJS.ErrnoException, []);
+      } else {
+        callback(err as NodeJS.ErrnoException, "", 0);
+      }
+    });
 };
 
 /**
@@ -76,6 +104,18 @@ const ssrfAgent = new Agent({
     lookup: guardedLookup,
   },
 });
+
+/**
+ * Exported for unit testing the lookup-callback contract. Undici 7's connect
+ * path calls `lookup(hostname, { all: true }, cb)` and expects `cb(null, [
+ * {address, family}, ...])`. Earlier undici / classic Node use `cb(null,
+ * addressString, family)`. Returning the wrong shape yields
+ * `ERR_INVALID_IP_ADDRESS` and silently breaks every outbound fetch in
+ * production. Tests cover both call shapes — do not delete.
+ *
+ * Not for production use — go through `safeFetch`.
+ */
+export const _guardedLookupForTesting = guardedLookup;
 
 export interface SafeFetchOptions {
   timeoutMs?: number;

--- a/apps/ios/Brett/Models/ContentMetadata.swift
+++ b/apps/ios/Brett/Models/ContentMetadata.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Typed mirror of `ContentMetadata` from `packages/types/src/index.ts`.
+///
+/// `Item.contentMetadata` is stored as a JSON string (server union type
+/// discriminated by `type`). Reading it as a raw `[String: Any]` dictionary
+/// in every preview is how we ended up with `metadata["username"]` against
+/// an API that writes `author` — silent drift, no compile-time check.
+///
+/// This enum is the single decode point. Add a new variant here and Swift's
+/// exhaustiveness check forces every consumer to handle it.
+enum ContentMetadata: Decodable, Equatable {
+    case tweet(TweetMeta)
+    case video(VideoMeta)
+    case podcast(PodcastMeta)
+    case article(ArticleMeta)
+    case newsletter(NewsletterMeta)
+    case pdf
+    case webPage
+    /// Server sent a `type` we don't know yet — older clients on a newer
+    /// server. Treated as "no usable metadata" by callers.
+    case unknown(String)
+
+    struct TweetMeta: Decodable, Equatable {
+        let author: String?
+        let tweetText: String?
+        let embedHtml: String?
+    }
+
+    struct VideoMeta: Decodable, Equatable {
+        let embedUrl: String?
+        let channel: String?
+    }
+
+    struct PodcastMeta: Decodable, Equatable {
+        let embedUrl: String?
+        let provider: String?       // "spotify" | "apple"
+        let episodeName: String?
+        let showName: String?
+    }
+
+    struct ArticleMeta: Decodable, Equatable {
+        let wordCount: Int?
+    }
+
+    struct NewsletterMeta: Decodable, Equatable {
+        let senderName: String?
+        let receivedAt: String?
+    }
+
+    private enum DiscriminatorKey: String, CodingKey { case type }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiscriminatorKey.self)
+        let type = try container.decode(String.self, forKey: .type)
+        let single = try decoder.singleValueContainer()
+        switch type {
+        case "tweet":      self = .tweet(try single.decode(TweetMeta.self))
+        case "video":      self = .video(try single.decode(VideoMeta.self))
+        case "podcast":    self = .podcast(try single.decode(PodcastMeta.self))
+        case "article":    self = .article(try single.decode(ArticleMeta.self))
+        case "newsletter": self = .newsletter(try single.decode(NewsletterMeta.self))
+        case "pdf":        self = .pdf
+        case "web_page":   self = .webPage
+        default:           self = .unknown(type)
+        }
+    }
+}
+
+extension Item {
+    /// Decoded view of `contentMetadata`. Returns `nil` when the field is
+    /// empty, malformed, or missing the `type` discriminator. Cheap enough
+    /// to call per-render — JSON is small.
+    var contentMetadataTyped: ContentMetadata? {
+        guard let json = contentMetadata?.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ContentMetadata.self, from: json)
+    }
+
+    /// Convenience: tweet variant fields, or `nil` if not a tweet.
+    var tweetMetadata: ContentMetadata.TweetMeta? {
+        if case .tweet(let m) = contentMetadataTyped { return m }
+        return nil
+    }
+}

--- a/apps/ios/Brett/Views/Content/TweetPreview.swift
+++ b/apps/ios/Brett/Views/Content/TweetPreview.swift
@@ -5,26 +5,45 @@ import SwiftUI
 /// Rendering:
 /// - Cerulean-bordered glass card with a generic 𝕏 glyph (we don't sync
 ///   avatars today, so using a brand glyph keeps the card honest).
-/// - Tweet text at 16pt with 1.4× line height.
+/// - Heading title (X Article title or `contentTitle` from server) when
+///   meaningful — suppressed when the title is just `Tweet by @handle`,
+///   since the @handle row already says that.
+/// - Body text from `contentBody` → `contentDescription` → `tweetText` in
+///   metadata, in that order.
 /// - Optional inline media from `contentImageUrl`.
-/// - Tap opens the tweet's original URL in `SafariView`.
+/// - Tap opens the tweet's source URL via the SwiftUI `\.openURL`
+///   environment, which respects Apple's universal-link handoff — if the
+///   X app is installed it opens there, otherwise falls back to Safari.
+///   `SFSafariViewController` (the default for other content types) bypasses
+///   universal links, so we explicitly route around it for tweets.
 struct TweetPreview: View {
     let item: Item
+    /// Retained for API symmetry with sibling previews. Tweets bypass it
+    /// in favour of `\.openURL` so the X universal link can take over.
     var onOpenURL: (URL) -> Void
 
+    @Environment(\.openURL) private var systemOpenURL
+
+    private var meta: ContentMetadata.TweetMeta? { item.tweetMetadata }
+
     private var handle: String? {
-        if let metadata = item.contentMetadataDecoded,
-           let username = metadata["username"] as? String {
-            return "@\(username)"
-        }
-        return nil
+        guard let author = meta?.author, !author.isEmpty else { return nil }
+        return "@\(author)"
     }
 
-    private var timestampText: String? {
-        if let metadata = item.contentMetadataDecoded,
-           let iso = metadata["timestamp"] as? String {
-            return iso
-        }
+    /// Server fallback title is `Tweet by @<handle>`; the @handle row
+    /// already conveys that, so don't re-render it as a heading. Mirrors
+    /// the suppression rule in the desktop ContentPreview.
+    private var headingTitle: String? {
+        guard let title = item.contentTitle, !title.isEmpty else { return nil }
+        if let author = meta?.author, title == "Tweet by @\(author)" { return nil }
+        return title
+    }
+
+    private var bodyText: String? {
+        if let body = item.contentBody, !body.isEmpty { return body }
+        if let desc = item.contentDescription, !desc.isEmpty { return desc }
+        if let mt = meta?.tweetText, !mt.isEmpty { return mt }
         return nil
     }
 
@@ -32,14 +51,16 @@ struct TweetPreview: View {
         VStack(alignment: .leading, spacing: 12) {
             profileRow
 
-            if let body = item.contentBody, !body.isEmpty {
-                Text(body)
-                    .font(.system(size: 16))
-                    .foregroundStyle(Color.white.opacity(0.92))
-                    .lineSpacing(5)
+            if let headingTitle {
+                Text(headingTitle)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(BrettColors.textCardTitle)
+                    .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
-            } else if let description = item.contentDescription, !description.isEmpty {
-                Text(description)
+            }
+
+            if let bodyText {
+                Text(bodyText)
                     .font(.system(size: 16))
                     .foregroundStyle(Color.white.opacity(0.92))
                     .lineSpacing(5)
@@ -70,7 +91,11 @@ struct TweetPreview: View {
         .onTapGesture {
             if let raw = item.sourceUrl, let url = URL(string: raw) {
                 HapticManager.light()
-                onOpenURL(url)
+                // Bypass SafariView for tweets: `systemOpenURL` invokes
+                // UIApplication.openURL under the hood, which respects the
+                // X app's universal-link claim. SafariView would always
+                // render in-app and never hand off.
+                systemOpenURL(url)
             }
         }
     }
@@ -105,12 +130,6 @@ struct TweetPreview: View {
                     Text("Tweet")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(BrettColors.textCardTitle)
-                }
-
-                if let timestampText {
-                    Text(timestampText)
-                        .font(.system(size: 12))
-                        .foregroundStyle(Color.white.opacity(0.40))
                 }
             }
 

--- a/apps/ios/Brett/Views/Detail/ContentPreview.swift
+++ b/apps/ios/Brett/Views/Detail/ContentPreview.swift
@@ -21,7 +21,7 @@ struct ContentPreview: View {
         // No meaningful content → render nothing at all. Keeps the detail
         // view visually tight for plain tasks.
         if hasRenderableContent {
-            variant
+            content
                 .sheet(item: $externalURL) { identified in
                     SafariView(url: identified.url)
                         .ignoresSafeArea()
@@ -31,6 +31,63 @@ struct ContentPreview: View {
                         ArticleReaderView(item: item)
                     }
                 }
+        }
+    }
+
+    /// Failed extractions render an explicit error card with an "Open
+    /// original" link, mirroring the desktop `ErrorState`. Without this,
+    /// failed items fell through into the per-type variant which showed
+    /// a misleading empty card (e.g. "Tweet content unavailable") with
+    /// no signal that anything went wrong server-side.
+    @ViewBuilder
+    private var content: some View {
+        if item.contentStatus == ContentStatus.failed.rawValue {
+            extractionFailedCard
+        } else {
+            variant
+        }
+    }
+
+    @ViewBuilder
+    private var extractionFailedCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color(red: 0.95, green: 0.70, blue: 0.20).opacity(0.85))
+                Text("Preview unavailable")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.white.opacity(0.65))
+            }
+            if let raw = item.sourceUrl, let url = URL(string: raw) {
+                Button {
+                    HapticManager.light()
+                    externalURL = IdentifiedURL(url: url)
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("Open original")
+                            .font(.system(size: 12, weight: .medium))
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                    .foregroundStyle(BrettColors.cerulean.opacity(0.90))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.thinMaterial)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.white.opacity(0.03))
+                }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
         }
     }
 

--- a/apps/ios/BrettTests/Models/ContentMetadataTests.swift
+++ b/apps/ios/BrettTests/Models/ContentMetadataTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Pins the contract between the API's `contentMetadata` JSON shape (see
+/// `packages/types/src/index.ts` `ContentMetadata`) and Swift's typed
+/// decoder. Field-name drift between the two sides is exactly how iOS
+/// previously read `metadata["username"]` against an API that wrote
+/// `author` — silent rendering bug for every tweet. These tests fail the
+/// build instead of the user.
+@Suite("ContentMetadata decoding", .tags(.models))
+struct ContentMetadataTests {
+
+    private func decode(_ json: String) throws -> ContentMetadata? {
+        let item = TestFixtures.makeItem()
+        item.contentMetadata = json
+        return item.contentMetadataTyped
+    }
+
+    @Test func decodesTweetWithAuthorAndText() throws {
+        let json = """
+        {"type":"tweet","author":"_amankishore","tweetText":"hello world"}
+        """
+        let result = try decode(json)
+        guard case .tweet(let m) = result else {
+            Issue.record("expected .tweet, got \(String(describing: result))")
+            return
+        }
+        #expect(m.author == "_amankishore")
+        #expect(m.tweetText == "hello world")
+    }
+
+    @Test func tweetMetadataConvenienceUnwrapsAuthor() throws {
+        let item = TestFixtures.makeItem()
+        item.contentMetadata = #"{"type":"tweet","author":"vercel"}"#
+        #expect(item.tweetMetadata?.author == "vercel")
+    }
+
+    @Test func tweetMetadataConvenienceReturnsNilForOtherTypes() throws {
+        let item = TestFixtures.makeItem()
+        item.contentMetadata = #"{"type":"video","embedUrl":"https://x"}"#
+        #expect(item.tweetMetadata == nil)
+    }
+
+    @Test func decodesArticleWithWordCount() throws {
+        let json = #"{"type":"article","wordCount":1234}"#
+        let result = try decode(json)
+        guard case .article(let m) = result else {
+            Issue.record("expected .article")
+            return
+        }
+        #expect(m.wordCount == 1234)
+    }
+
+    @Test func decodesNewsletter() throws {
+        let json = #"{"type":"newsletter","senderName":"Stratechery","receivedAt":"2026-04-25T12:00:00Z"}"#
+        let result = try decode(json)
+        guard case .newsletter(let m) = result else {
+            Issue.record("expected .newsletter")
+            return
+        }
+        #expect(m.senderName == "Stratechery")
+        #expect(m.receivedAt == "2026-04-25T12:00:00Z")
+    }
+
+    @Test func decodesPdfAndWebPageMarkers() throws {
+        #expect({ if case .pdf = try? decode(#"{"type":"pdf"}"#) ?? .unknown("") { return true } else { return false } }())
+        #expect({ if case .webPage = try? decode(#"{"type":"web_page"}"#) ?? .unknown("") { return true } else { return false } }())
+    }
+
+    @Test func unknownTypeFallsThroughToUnknown() throws {
+        let json = #"{"type":"podcast_v2","embedUrl":"x"}"#
+        let result = try decode(json)
+        guard case .unknown(let t) = result else {
+            Issue.record("expected .unknown")
+            return
+        }
+        #expect(t == "podcast_v2")
+    }
+
+    @Test func malformedJsonReturnsNil() throws {
+        let result = try decode("not json")
+        #expect(result == nil)
+    }
+
+    @Test func missingTypeDiscriminatorReturnsNil() throws {
+        let result = try decode(#"{"author":"x"}"#)
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Single fix on `main` to ship to production:

- **#103** — fix(content,ios): tweet extraction silently broken by SSRF guard + iOS metadata drift

## Root cause (TL;DR)

Undici 7's `connect.lookup` calls our `guardedLookup` with `{ all: true }` and expects an array of `{address, family}`. We were returning a string. **Every** outbound `safeFetch` has been throwing `ERR_INVALID_IP_ADDRESS` since the SSRF guard rewrite landed — silently, because both fetch sites (`fetchTweetSyndication` / `fetchTweetOgTags`) wrap in `try { } catch { return null }`.

Tweets all fell back to the `Tweet by @<handle>` placeholder with no preview. iOS layered three more bugs on top (metadata field drift, no `failed`-status branch, in-app SafariView for tweet taps).

## Post-deploy step (REQUIRED)

7 production items are stuck in `contentStatus=extracted` with the wrong title and no retry button visible. Run after deploy:

\`\`\`sql
UPDATE \"Item\"
SET \"contentStatus\" = 'failed', \"updatedAt\" = NOW()
WHERE \"contentType\" = 'tweet'
  AND \"contentStatus\" = 'extracted'
  AND \"contentTitle\" LIKE 'Tweet by @%'
  AND (\"contentDescription\" IS NULL OR \"contentDescription\" = '')
  AND (\"contentImageUrl\" IS NULL OR \"contentImageUrl\" = '');
\`\`\`

Surfaces the retry button so user can re-extract from the UI.

## Test plan

- [ ] Deploy completes (Railway health check + Dockerfile migrations)
- [ ] Run the post-deploy SQL above
- [ ] Re-share `https://x.com/_amankishore/status/2047341809626448242` and confirm article title + preview + image render
- [ ] Tap tweet on iOS with X app installed; confirm universal-link handoff (opens X, not in-app Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)