### PR TITLE
fix: exclude non-busy events from iOS Today meeting hour count (#102)

### DIFF
--- a/apps/ios/Brett/Models/CalendarEvent.swift
+++ b/apps/ios/Brett/Models/CalendarEvent.swift
@@ -97,6 +97,28 @@ final class CalendarEvent {
         Int(endTime.timeIntervalSince(startTime) / 60)
     }
 
+    /// Whether this event blocks time on the user's calendar.
+    ///
+    /// Mirrors Google Calendar's `transparency` field: `"transparent"` means
+    /// the event does not block time (e.g. Gmail-derived flight / hotel
+    /// holds, working-location markers). `"opaque"` (the default) means the
+    /// user is busy. Anything else — including a missing field or a non-
+    /// Google event with no `rawGoogleEventJSON` — falls back to busy so we
+    /// don't silently drop manually-created events from totals.
+    ///
+    /// The transparency value is preserved server-side in the scrubbed
+    /// `rawGoogleEvent` JSON (see `apps/api/src/services/calendar-sync.ts`
+    /// `scrubRawEvent`) and shipped to clients via the standard sync pull.
+    var isBusy: Bool {
+        guard let json = rawGoogleEventJSON,
+              let data = json.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let transparency = dict["transparency"] as? String else {
+            return true
+        }
+        return transparency != "transparent"
+    }
+
     var syncStatusEnum: SyncStatus {
         SyncStatus(rawValue: _syncStatus) ?? .synced
     }

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -338,11 +338,15 @@ struct TodayPage: View {
         // `sections.*` reads share one bucket and the two event accesses
         // (count + duration sum) share one filter pass.
         let s = sections
-        let events = todaysEvents
+        // Only include events that block time on the calendar. Google
+        // auto-creates `transparent` events for flights / hotels / working
+        // location from Gmail; counting those as meetings (and summing
+        // their hours) confuses the day's commitment summary.
+        let events = todaysEvents.filter { $0.isBusy }
         let total = s.activeCount + s.doneToday.count
         let done = s.doneToday.count
         let base = "\(done) of \(total) done"
-        guard !userEvents.isEmpty else { return base }
+        guard !events.isEmpty else { return base }
         let meetingCount = events.count
         let suffix = meetingCount == 1 ? "meeting" : "meetings"
         return "\(base) · \(meetingCount) \(suffix) (\(Self.formatMeetingDuration(events: events)))"

--- a/apps/ios/BrettTests/Models/CalendarEventTests.swift
+++ b/apps/ios/BrettTests/Models/CalendarEventTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Pins the contract for `CalendarEvent.isBusy`. Google Calendar's
+/// `transparency` field travels server-side as part of the scrubbed
+/// `rawGoogleEvent` JSON (see `apps/api/src/services/calendar-sync.ts`
+/// `scrubRawEvent`), reaches iOS via the standard sync pull, and lands
+/// in `CalendarEvent.rawGoogleEventJSON`. `isBusy` reads it.
+///
+/// The category of bug these tests guard against: silently counting
+/// Gmail-derived flight / hotel / working-location holds in the Today
+/// summary's "X meetings (Yh)" line. Those events are stored with
+/// `transparency: "transparent"` upstream — anything else, including
+/// no rawGoogleEvent at all, must default to busy so manually-created
+/// or non-Google events keep counting.
+@Suite("CalendarEvent.isBusy", .tags(.models))
+struct CalendarEventTests {
+
+    @Test func opaqueTransparencyIsBusy() {
+        let event = makeEvent(rawGoogleEventJSON: #"{"transparency":"opaque"}"#)
+        #expect(event.isBusy == true)
+    }
+
+    @Test func transparentTransparencyIsNotBusy() {
+        let event = makeEvent(rawGoogleEventJSON: #"{"transparency":"transparent"}"#)
+        #expect(event.isBusy == false)
+    }
+
+    @Test func missingRawGoogleEventDefaultsToBusy() {
+        // Manually-created / non-Google events have no rawGoogleEventJSON.
+        // We must keep counting them or every non-Google event silently
+        // disappears from the totals.
+        let event = makeEvent(rawGoogleEventJSON: nil)
+        #expect(event.isBusy == true)
+    }
+
+    @Test func rawGoogleEventWithoutTransparencyKeyDefaultsToBusy() {
+        let event = makeEvent(rawGoogleEventJSON: #"{"id":"abc","status":"confirmed"}"#)
+        #expect(event.isBusy == true)
+    }
+
+    @Test func malformedRawGoogleEventDefaultsToBusy() {
+        let event = makeEvent(rawGoogleEventJSON: "not-json")
+        #expect(event.isBusy == true)
+    }
+
+    @Test func emptyStringRawGoogleEventDefaultsToBusy() {
+        let event = makeEvent(rawGoogleEventJSON: "")
+        #expect(event.isBusy == true)
+    }
+
+    @Test func unknownTransparencyValueDefaultsToBusy() {
+        // Future-proofing: if Google introduces a third value, we'd rather
+        // count it than drop it.
+        let event = makeEvent(rawGoogleEventJSON: #"{"transparency":"future-value"}"#)
+        #expect(event.isBusy == true)
+    }
+
+    @Test func filteringMixedListKeepsOnlyBusyEvents() {
+        // The user-facing behavior the bug report cares about: feeding a
+        // mixed set into `.filter { $0.isBusy }` drops the flight / hotel
+        // entries and keeps the actual meetings.
+        let realMeeting = makeEvent(
+            title: "Sprint planning",
+            rawGoogleEventJSON: #"{"transparency":"opaque"}"#
+        )
+        let flight = makeEvent(
+            title: "Flight to SFO",
+            rawGoogleEventJSON: #"{"transparency":"transparent","eventType":"fromGmail"}"#
+        )
+        let hotel = makeEvent(
+            title: "Marriott San Francisco",
+            rawGoogleEventJSON: #"{"transparency":"transparent","eventType":"fromGmail"}"#
+        )
+        let manualMeeting = makeEvent(title: "1:1", rawGoogleEventJSON: nil)
+
+        let busy = [realMeeting, flight, hotel, manualMeeting].filter { $0.isBusy }
+
+        #expect(busy.count == 2)
+        #expect(busy.contains { $0.title == "Sprint planning" })
+        #expect(busy.contains { $0.title == "1:1" })
+    }
+
+    private func makeEvent(
+        title: String = "Event",
+        rawGoogleEventJSON: String? = nil
+    ) -> CalendarEvent {
+        let event = CalendarEvent(
+            id: UUID().uuidString,
+            userId: "u1",
+            googleAccountId: "ga1",
+            calendarListId: "cal1",
+            googleEventId: "ge1",
+            title: title,
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600)
+        )
+        event.rawGoogleEventJSON = rawGoogleEventJSON
+        return event
+    }
+}


### PR DESCRIPTION
Closes #102

## Root cause

Google Calendar auto-creates events from Gmail confirmations (flights, hotels, working-location markers) and ships them with `transparency: "transparent"` so they don't block time on the calendar. The Today summary's `statsLine` (apps/ios/Brett/Views/Today/TodayPage.swift:336) summed `durationMinutes` across **all** of today's events and counted them all as meetings — so the user's "5 meetings (8h 20m)" badge was inflated by the auto-created flight / hotel rows.

The `transparency` field is preserved server-side in the scrubbed `rawGoogleEvent` JSON (`apps/api/src/services/calendar-sync.ts` `scrubRawEvent`, line 666) and shipped to clients via the standard sync pull, landing in `CalendarEvent.rawGoogleEventJSON` on iOS. We just weren't reading it.

## Approach: options considered

**A. Add a `transparency` Prisma column + propagate through API + sync mapper + iOS model + filter.** Cleaner long-term data model, but: (a) ships a Prisma migration to production immediately on `release` merge, which the root CLAUDE.md flags as a "never do this unless explicitly required" path, (b) cross-cutting blast radius (API + sync + iOS), (c) the data is *already* preserved server-side — no schema change is required to fix the bug.

**B. Read `transparency` from the existing `rawGoogleEventJSON` on iOS and filter at the call site.** Smallest possible blast radius. iOS-only. No DB / API / sync surface area. Backwards-compatible by construction.

**C. Hybrid — B now, file follow-up to add a typed `transparency` column later.** Same as B; the typed column would be marginal cleanup.

**Picked B.** The bug is iOS-only and the data is already there. A schema migration to fix a display bug is overscoped per CLAUDE.md's "never touch Prisma migrations unless the issue explicitly demands it" rule.

## Changes

1. **`apps/ios/Brett/Models/CalendarEvent.swift`** — new computed `isBusy: Bool`. Decodes `rawGoogleEventJSON`, reads `transparency`, returns `transparency != "transparent"`. **Defaults to busy** when JSON is missing / malformed / lacks the key / has an unknown value, so manually-created and non-Google events keep counting.
2. **`apps/ios/Brett/Views/Today/TodayPage.swift`** — `statsLine` now filters `todaysEvents.filter { $0.isBusy }` before computing both the count and the duration sum. The empty-guard tightens from `userEvents.isEmpty` (across-all-days, was a latent bug — would render `· 0 meetings (0m)` if the user had events on other days but none today) to `events.isEmpty`.
3. **`apps/ios/BrettTests/Models/CalendarEventTests.swift`** — new test suite pinning the `isBusy` contract.

## Tests

Added `apps/ios/BrettTests/Models/CalendarEventTests.swift` covering:
- `transparency: "opaque"` → busy (counted)
- `transparency: "transparent"` → not busy (excluded)
- Missing `rawGoogleEventJSON` → busy (default)
- `rawGoogleEventJSON` without a `transparency` key → busy
- Malformed JSON → busy
- Empty string JSON → busy
- Unknown transparency value → busy (graceful)
- Mixed list filter test using realistic flight/hotel/meeting payloads

**Test-prevention reflection:** these guard the *category* of bug — anyone tightening `isBusy` to default-not-busy, or breaking the JSON parse, fails CI before users see "0 meetings" rendered.

## Self-review findings

- Initially considered filtering only the duration but leaving the count untouched. The summary string is `"X meetings (Yh Zm)"` — if the count includes flights but the duration excludes them, the math reads wrong to the user. Filter both, derived from one filtered list.
- Considered also filtering `nextUpcomingEvent` and `DayTimeline` per-event durations. Decided against: a flight is genuinely "next up" and a real time block on the timeline. The bug is specifically the aggregate display.
- The `userEvents.isEmpty` empty-guard was a latent bug (across-all-days check applied to today's events) — replaced with `events.isEmpty` since the new local needs that anyway. Strict improvement.
- `DateHelpers.meetingDurationText` (line 94, zero callers) is identical to `formatMeetingDuration` — left untouched, out of scope. Should be deleted in a separate cleanup PR.

## `pnpm typecheck` + `pnpm test` output

Pre-existing breakage on `main` in this Linux dev environment — unrelated to this change:
- `pnpm typecheck` fails because `@brett/api-core/dist` isn't built (verified by `git stash` + re-run on baseline `main`).
- `pnpm test` fails because Postgres + outbound network aren't available locally.

This PR touches **only Swift files under `apps/ios/`**. CI's iOS test runner (manual / Xcode-driven, per the constraint described in PR #86) is the canonical check. **Run `Brett` scheme tests in Xcode before merging.** The new `CalendarEventTests` suite auto-registers via XcodeGen.

## Risks / follow-ups

- **Risk:** if `scrubRawEvent` ever drops `transparency`, iOS silently regresses to "all events busy" — the same behavior as before this fix, so non-catastrophic. Could add an API-side regression test that asserts `scrubRawEvent` keeps `transparency`. Not in this PR.
- **Risk:** if Google introduces a third `transparency` value, we count it as busy. Acceptable default — better to over-count than silently drop.
- **Follow-up:** delete the dead `DateHelpers.meetingDurationText`.
- **Follow-up (optional, low value):** promote `transparency` to a typed Prisma column if other surfaces need it. The fact that the JSON parse is the *only* `rawGoogleEventJSON` consumer suggests the cost of the parse isn't a concern at present.

Visual verification pending — `gh pr checkout 106` (or whatever PR # this lands at) and load the Today screen with a known transparent event in the day's calendar.

---
_Generated by [Claude Code](https://claude.ai/code/session_012h9yZYcMfjSbkFUK7Ybgnf)_