### PR TITLE
fix(ios): privacy overlay no longer flickers on backgrounding (#110)

### DIFF
--- a/apps/ios/Brett/BrettApp.swift
+++ b/apps/ios/Brett/BrettApp.swift
@@ -191,14 +191,24 @@ private struct RootView: View {
             // thumbnail. Without this overlay, that snapshot shows whatever
             // the user had open — inbox contents, calendar events, chat
             // threads — to anyone who swipes to the app switcher while the
-            // phone is unlocked. Opaque BackgroundView matches our brand
-            // atmospheric chrome and avoids a flash of black.
+            // phone is unlocked.
+            //
+            // Why a Material instead of a fresh BackgroundView? A second
+            // BackgroundView spins up its own UserProfileStore, service
+            // load, displayedKey, and 60s tick timer, so it can land on a
+            // different image than MainContainer's BackgroundView and
+            // trigger a 1.5s crossfade just as the privacy cover fades in
+            // — the user-reported "background changes back and forth" on
+            // backgrounding. A Material blur sits over whatever's already
+            // mounted (MainContainer's wallpaper, SignInView, lock view)
+            // and obscures content without re-running the image pipeline.
             //
             // Intentionally outside the auth/lock switch so it covers
             // SignInView too (email field) and BiometricLockView (less
             // sensitive, but we may add recent-activity glances later).
             if scenePhase != .active {
-                BackgroundView()
+                Rectangle()
+                    .fill(.ultraThinMaterial)
                     .ignoresSafeArea()
                     .transition(.opacity)
                     .zIndex(1000)


### PR DESCRIPTION
Closes #110

## Root cause

`RootView`'s app-switcher privacy cover (apps/ios/Brett/BrettApp.swift:200) instantiated a **fresh** `BackgroundView()` every time `scenePhase != .active`. That second BackgroundView is independent of MainContainer's BackgroundView still mounted underneath — it has its own `@State profileStore = UserProfileStore()`, its own `@State service = BackgroundService.shared`, its own `displayedKey`, its own `Timer.publish(every: 60s)` tick, and its own `task { service.load(); refresh(initial: true) }`.

When the privacy overlay mounts on `.inactive`, two things race:
1. The `.transition(.opacity)` + `.animation(.easeInOut(duration: 0.15), value: scenePhase)` fades the overlay in over 150ms.
2. The new BackgroundView's `profileStore` hydrates async — `onChange(of: profileStore.current?.backgroundStyle)` fires `refresh(initial: false)`, which can flip `displayedKey` and trigger `BackgroundView`'s 1.5s crossfade animation.

So during backgrounding the user sees: original wallpaper → privacy overlay's wallpaper fading in (different image, because the new BackgroundView started from `BackgroundService.cachedRemoteURL` while MainContainer had already moved on) → 1.5s crossfade *inside* the privacy overlay. Visually that reads as "the background image changes back and forth" — the exact phrasing in the bug report. The "UI disappears" complaint is the same overlay covering everything underneath.

## Approach: options considered

**A. Pass an explicit `imageName:` to the overlay's BackgroundView so the service-driven refresh path is skipped.** Suppresses the flicker but still mounts a redundant `UserProfileStore`, hour-of-day asset chooser, and tick timer — the privacy cover is doing image-pipeline work it doesn't need to do. The asset would also drift from whatever MainContainer is actually showing (different time-of-day fallbacks at boundaries).

**B. Refactor BackgroundView so a single shared `displayedKey` source feeds every instance.** Correct in principle, but it's a structural change to a hot view used by SignInView, BiometricLockView, MainContainer, and now this overlay. Big blast radius for a UI bug.

**C. Replace the privacy overlay with a Material that sits over whatever's already mounted.** No fresh image pipeline. Uses the underlying view's wallpaper as the substrate, blurred for privacy. Smallest diff. Also doubles as a partial answer to the "UI disappears" complaint — `.ultraThinMaterial` keeps content faintly visible so the inactive transition reads as "blur" rather than "blank".

**Picked C** with `Rectangle().fill(.ultraThinMaterial)`. Brand atmosphere is preserved by the underlying BackgroundView; the privacy cover only adds the "obscuring" layer. The original comment claimed "Opaque BackgroundView matches our brand atmospheric chrome and avoids a flash of black" — Material achieves the same outcome without a second BackgroundView and no risk of a black flash (Material always has a substrate underneath).

## Tests

UI-only change — no test added. Reason: the bug is a layered-rendering / async-state-race issue that's only observable visually during scenePhase transitions on a real device. A unit test would have to assert "an `.ultraThinMaterial` rectangle exists when scenePhase != .active" — that just mirrors the implementation without proving the user-facing behavior.

Test-prevention reflection: a snapshot test of RootView with scenePhase set to .background would technically catch a regression, but Swift Testing / XCTest don't easily drive scenePhase, and our test target doesn't include any RootView-level rendering tests today. Adding the harness for one assertion would be over-engineering. Verify visually via `gh pr checkout <#>` and background the app on simulator + device.

## Self-review findings

1. **Privacy posture preserved.** `.ultraThinMaterial` blurs and tints the underlying content — sensitive UI (inbox titles, chat threads, calendar events) is no longer legible in the app-switcher snapshot. Stronger materials (`.thinMaterial`, `.regularMaterial`) would obscure more but also make the cover more "blank" — which is what the user explicitly complained about. Going lighter, not heavier, on purpose.

2. **No flash of black.** The original concern was that an empty cover would render black during the brief moment before BackgroundView's `displayedKey` resolved. Material is always rendered with a substrate (whatever's underneath) so there's no path to a black frame.

3. **SignInView path.** When unauthenticated, the substrate is SignInView (which also uses BackgroundView internally). Material blurs that the same way. No regression for sign-in privacy.

4. **BiometricLockView path.** Same — lock view uses BackgroundView underneath; Material blurs it.

5. **The original BackgroundView underneath still ticks every 60s.** That's existing behavior and the user didn't complain about it. Out of scope.

## `pnpm typecheck` + `pnpm test` output

This PR touches only `apps/ios/Brett/BrettApp.swift`. CI's iOS test runner (Xcode-driven) is the canonical check. No new test added; existing tests should still pass.

## Risks / follow-ups

- **Risk:** if the Material's blur doesn't fully obscure UI on some device classes (older iPhones with weaker GPUs may render Material differently), the privacy cover could leak details into the app-switcher snapshot. Mitigation: bump to `.regularMaterial` or `.thickMaterial` if a real-device check shows this. Acceptable to defer until evidence.
- **Risk:** during the 0.15s opacity transition, the user sees content briefly through a not-yet-fully-opaque Material. This was also true of the prior BackgroundView (also faded in via opacity). Net neutral.
- **Follow-up:** if Brent wants the privacy cover to fully hide UI (the original intent), swap `.ultraThinMaterial` → `.thickMaterial`. One-line change. The current pick errs toward the "I can still see my UI" half of the bug report.

Visual verification pending — `gh pr checkout <#>` and:
1. Open the app to Today / Inbox.
2. Swipe up to backgrounding gesture (don't fully background — scrub up halfway to trigger `.inactive`).
3. Confirm: no wallpaper crossfade, just a smooth blur over the existing UI.
4. Fully background, swipe to app switcher, confirm content is obscured.
5. Foreground, confirm smooth fade-out.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4SK9bSPyC9SmY2DmpS1TR)_