### PR TITLE
fix: remove newsletter accent stripe from iOS inbox rows (#117)

### DIFF
--- a/apps/ios/Brett/Views/Inbox/InboxPage.swift
+++ b/apps/ios/Brett/Views/Inbox/InboxPage.swift
@@ -275,7 +275,7 @@ private struct InboxPageBody: View {
         } content: {
             VStack(spacing: 0) {
                 ForEach(Array(filteredItems.enumerated()), id: \.element.id) { index, item in
-                    rowWithAccent(item: item, isLast: index == filteredItems.count - 1)
+                    inboxRow(item: item, isLast: index == filteredItems.count - 1)
                 }
             }
             .padding(.bottom, 8)
@@ -283,48 +283,35 @@ private struct InboxPageBody: View {
     }
 
     @ViewBuilder
-    private func rowWithAccent(item: Item, isLast: Bool) -> some View {
-        let isNewsletter = (item.contentType == "newsletter") ||
-            (item.itemType == .content && item.source.lowercased().contains("newsletter"))
-
+    private func inboxRow(item: Item, isLast: Bool) -> some View {
         VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                if isNewsletter {
-                    Rectangle()
-                        .fill(BrettColors.cerulean)
-                        .frame(width: 2)
-                        .padding(.vertical, 4)
-                }
-
-                TaskRow(
-                    item: item,
-                    listName: nil,
-                    allowSwipeRight: false,
-                    allowSwipeLeft: false,
-                    allowDrag: false,
-                    isSelectMode: isSelectMode,
-                    isSelected: selectedIDs.contains(item.id),
-                    onToggle: {
-                        if isSelectMode {
-                            toggleSelection(item.id)
-                        } else {
-                            HapticManager.light()
-                            itemStore.toggleStatus(id: item.id, userId: userId)
-                        }
-                    },
-                    onSelect: {
-                        if isSelectMode {
-                            toggleSelection(item.id)
-                        } else {
-                            // Wave D Phase 3: single source of truth —
-                            // `go(to:)` dispatches to `currentDestination`
-                            // because `.taskDetail` is a sheet case.
-                            NavStore.shared.go(to: .taskDetail(id: item.id))
-                        }
+            TaskRow(
+                item: item,
+                listName: nil,
+                allowSwipeRight: false,
+                allowSwipeLeft: false,
+                allowDrag: false,
+                isSelectMode: isSelectMode,
+                isSelected: selectedIDs.contains(item.id),
+                onToggle: {
+                    if isSelectMode {
+                        toggleSelection(item.id)
+                    } else {
+                        HapticManager.light()
+                        itemStore.toggleStatus(id: item.id, userId: userId)
                     }
-                )
-                .padding(.leading, isNewsletter ? 6 : 0)
-            }
+                },
+                onSelect: {
+                    if isSelectMode {
+                        toggleSelection(item.id)
+                    } else {
+                        // Wave D Phase 3: single source of truth —
+                        // `go(to:)` dispatches to `currentDestination`
+                        // because `.taskDetail` is a sheet case.
+                        NavStore.shared.go(to: .taskDetail(id: item.id))
+                    }
+                }
+            )
             // Inbox owns the row-level swipe actions — TaskRow's default
             // Today/Lists swipe set (schedule leading, delete/archive
             // trailing) is turned off above via the allowSwipe* = false


### PR DESCRIPTION
Closes #117

## Root cause

`InboxPage.rowWithAccent` rendered a 2pt cerulean `Rectangle` on the leading edge of any inbox row whose `contentType == "newsletter"` (or whose source string contained "newsletter"). It also applied a 6pt leading padding to the `TaskRow` only on newsletter rows. Two consequences:

1. **Mystery blue line.** The accent has no on-screen explanation — users see a colored stripe on some rows and not others with no legend, no tap behavior, nothing. The user filed this issue asking what they were and asked us to remove them.
2. **Row alignment drift.** Because the leading padding was conditional, newsletter row content shifted 6pt right relative to non-newsletter rows in the same card. This is the visual misalignment called out in the issue ("They also throw alignment off as shown in the screenshot").

The treatment was also iOS-only — desktop's `packages/ui/src/InboxItemRow.tsx` has no equivalent stripe — so this violated the iOS↔desktop parity rule in `CLAUDE.md`.

## Approach: options considered

1. **Remove the stripe entirely** (chosen). Aligns iOS with desktop, eliminates the alignment drift, removes the unexplained UI affordance. Newsletter type is still communicated via `TaskRow`'s content icon (the cerulean document glyph at `TaskRow.swift:320`), which both platforms render — so we keep the type cue without the misaligned rail.
2. **Keep the stripe but pad both branches** so non-newsletter rows align with newsletter rows. Fixes alignment but leaves the unexplained blue line in place — directly contradicts the user's "kill them" request.
3. **Replace the stripe with a desktop-side equivalent** — i.e., add an accent on desktop instead of removing on iOS. This expands scope, the user explicitly asked for removal, and it doesn't address the unexplained-affordance problem on either side.

Picked option 1.

## What changed

- Deleted the `if isNewsletter { Rectangle().fill(BrettColors.cerulean)... }` block.
- Deleted the now-unused `isNewsletter` derivation and the conditional `.padding(.leading, isNewsletter ? 6 : 0)`.
- Collapsed the single-element `HStack` wrapper that only existed to host the rectangle next to the row.
- Renamed the helper `rowWithAccent` → `inboxRow` since the accent is gone.

## Tests

UI-only change — no test added. Reason: the only thing to assert is "this view doesn't render a `Rectangle` in this slot," which mirrors the implementation rather than verifying user-facing behavior. The category of bug here (one platform sprouts a visual flourish the other doesn't have) is a parity / code-review concern, not a unit-test concern. Verify visually via `gh pr checkout 117` and inspect the inbox with at least one newsletter and one non-newsletter row in the list — newsletter rows should now align with their non-newsletter siblings.

`pnpm typecheck` / `pnpm test` not run: the diff is Swift-only (single file under `apps/ios/Brett/Views/Inbox/`), and the pnpm scripts cover the TS workspace, not the Xcode project. Verified with `git diff --stat main` — single file changed.

## Self-review findings

- Confirmed no other call sites referenced `rowWithAccent` (`grep -rn "rowWithAccent" apps/ios`).
- Confirmed `isNewsletter` was only used for the rectangle and the leading padding — both gone, so dropping the derivation has no other effect (`grep -rn "isNewsletter" apps/ios`).
- Confirmed desktop's `InboxItemRow.tsx` has no equivalent newsletter accent (`grep -n "newsletter" packages/ui/src/InboxItemRow.tsx`) — removal is a parity restoration, not a regression.
- Newsletter rows still carry a visual type cue via `TaskRow.swift:320`'s cerulean glyph.

## Visual verification pending — `gh pr checkout 117`

Reviewer should confirm in the simulator/device:
- Newsletter rows in the inbox no longer have a blue stripe.
- Newsletter and non-newsletter rows in the same inbox card align flush on the leading edge.
- Newsletter type is still recognizable (TaskRow's cerulean document glyph).

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Z7iQdcMr3rfZBF6K6X6R)_