### PR TITLE
fix(ios): friendlier offline banner copy (#119)

### DIFF
--- a/apps/ios/Brett/Views/Shared/OfflineBanner.swift
+++ b/apps/ios/Brett/Views/Shared/OfflineBanner.swift
@@ -5,8 +5,13 @@ import SwiftData
 ///
 /// The banner is a glass card with a red tint, a "wifi.slash" icon, and a
 /// message. If there are pending mutations, the count is surfaced inline:
-/// "Offline — 3 changes waiting to sync". Tap to toggle a detailed view with
-/// the last-sync timestamp.
+/// "You're offline — 3 changes saved". Tap to toggle a detailed view with
+/// the last-update timestamp.
+///
+/// Copy is intentionally human, not technical — users shouldn't see words
+/// like "mutations", "queue", "pending" in the headline. The expanded
+/// detail uses "sync" only because it's the standard consumer-app term
+/// ("we'll sync when you're back online") and still reads as plain English.
 ///
 /// The banner uses `safeAreaInset(edge: .top)` so content is pushed down —
 /// it never overlaps list content.
@@ -83,35 +88,57 @@ struct OfflineBanner: View {
     // MARK: - Copy
 
     private var headlineText: String {
-        if pendingCount > 0 {
-            let unit = pendingCount == 1 ? "change" : "changes"
-            return "Offline — \(pendingCount) \(unit) waiting to sync"
-        }
-        return "Offline — changes will sync when you're back"
+        Self.headline(pendingCount: pendingCount)
     }
 
     private var detailText: String {
-        let mutationsLine: String = {
-            if pendingCount == 0 {
-                return "No mutations pending."
-            }
-            let unit = pendingCount == 1 ? "mutation" : "mutations"
-            return "\(pendingCount) \(unit) pending."
-        }()
-
-        let lastSyncLine: String = {
-            guard let lastSyncedAt else { return "No sync recorded yet." }
-            let minutes = max(0, Int(Date().timeIntervalSince(lastSyncedAt) / 60))
-            if minutes < 1 { return "Last sync: moments ago." }
-            if minutes == 1 { return "Last sync: 1 minute ago." }
-            return "Last sync: \(minutes) minutes ago."
-        }()
-
-        return "\(mutationsLine) \(lastSyncLine)"
+        Self.detail(pendingCount: pendingCount, lastSyncedAt: lastSyncedAt)
     }
 
     private var accessibilityLabel: String {
-        "Offline. \(pendingCount) changes waiting to sync."
+        Self.accessibility(pendingCount: pendingCount)
+    }
+
+    // MARK: - Pure copy helpers (testable)
+
+    /// Headline shown next to the wifi-slash icon. Avoids the words
+    /// "sync", "queue", "mutation" — consumer-friendly only.
+    static func headline(pendingCount: Int) -> String {
+        if pendingCount <= 0 {
+            return "You're offline"
+        }
+        let unit = pendingCount == 1 ? "change" : "changes"
+        return "You're offline — \(pendingCount) \(unit) saved"
+    }
+
+    /// Detail line shown when the banner is expanded. Combines the saved-
+    /// changes status with the last-update relative time.
+    static func detail(pendingCount: Int, lastSyncedAt: Date?, now: Date = Date()) -> String {
+        let savedLine: String = {
+            if pendingCount <= 0 {
+                return "We'll sync when you're back online."
+            }
+            let unit = pendingCount == 1 ? "change" : "changes"
+            return "\(pendingCount) \(unit) saved on this device. We'll sync when you're back online."
+        }()
+
+        let lastUpdateLine: String = {
+            guard let lastSyncedAt else { return "No previous update yet." }
+            let minutes = max(0, Int(now.timeIntervalSince(lastSyncedAt) / 60))
+            if minutes < 1 { return "Last update: moments ago." }
+            if minutes == 1 { return "Last update: 1 minute ago." }
+            return "Last update: \(minutes) minutes ago."
+        }()
+
+        return "\(savedLine) \(lastUpdateLine)"
+    }
+
+    static func accessibility(pendingCount: Int) -> String {
+        if pendingCount <= 0 {
+            return "You're offline."
+        }
+        let unit = pendingCount == 1 ? "change" : "changes"
+        return "You're offline. \(pendingCount) \(unit) saved on this device."
     }
 }
 

--- a/apps/ios/BrettTests/Views/OfflineBannerTests.swift
+++ b/apps/ios/BrettTests/Views/OfflineBannerTests.swift
@@ -122,32 +122,93 @@ struct OfflineBannerTests {
 
     // MARK: - Headline copy
 
-    @MainActor
-    @Test func bannerHeadlineWithNoPendingUsesBaseCopy() {
-        // Construct a view with the public init; read the internal property
-        // via the same mechanism the view body uses so copy regressions are
-        // caught without rendering.
-        let stub = StubPathMonitor()
-        let monitor = NetworkMonitor(pathMonitor: stub)
-        let banner = OfflineBanner(
-            networkMonitor: monitor,
-            pendingCount: 0,
-            lastSyncedAt: nil
-        )
-        // View bodies can't be inspected directly, but we can sanity-check
-        // the input state the headline helper pulls from.
-        #expect(banner.pendingCount == 0)
+    @Test func headlineWithNoPendingIsHumanFriendly() {
+        // Issue #119: regression guard for "Offline — N changes waiting to
+        // sync" wording. The new copy avoids the technical "sync" /
+        // "waiting" framing in the headline.
+        #expect(OfflineBanner.headline(pendingCount: 0) == "You're offline")
+        #expect(OfflineBanner.headline(pendingCount: -1) == "You're offline")
     }
 
-    @MainActor
-    @Test func bannerHeadlineWithPendingShowsCount() {
-        let stub = StubPathMonitor()
-        let monitor = NetworkMonitor(pathMonitor: stub)
-        let banner = OfflineBanner(
-            networkMonitor: monitor,
-            pendingCount: 5,
-            lastSyncedAt: Date()
-        )
-        #expect(banner.pendingCount == 5)
+    @Test func headlineWithSinglePendingUsesSingularUnit() {
+        #expect(OfflineBanner.headline(pendingCount: 1) == "You're offline — 1 change saved")
+    }
+
+    @Test func headlineWithMultiplePendingPluralizes() {
+        #expect(OfflineBanner.headline(pendingCount: 3) == "You're offline — 3 changes saved")
+        #expect(OfflineBanner.headline(pendingCount: 12) == "You're offline — 12 changes saved")
+    }
+
+    @Test func headlineHasNoTechnicalJargon() {
+        // Regression for #119: no leakage of "mutation", "queue", or
+        // "pending" into user-visible headline copy.
+        let samples = [0, 1, 2, 7, 100].map { OfflineBanner.headline(pendingCount: $0) }
+        for s in samples {
+            #expect(!s.lowercased().contains("mutation"))
+            #expect(!s.lowercased().contains("queue"))
+            #expect(!s.lowercased().contains("pending"))
+            #expect(!s.lowercased().contains("waiting to sync"))
+        }
+    }
+
+    // MARK: - Detail copy
+
+    @Test func detailWithNoPendingShowsReassurance() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = OfflineBanner.detail(pendingCount: 0, lastSyncedAt: nil, now: now)
+        #expect(result.contains("We'll sync when you're back online."))
+        #expect(result.contains("No previous update yet."))
+    }
+
+    @Test func detailWithSinglePendingPluralizesCorrectly() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = OfflineBanner.detail(pendingCount: 1, lastSyncedAt: nil, now: now)
+        #expect(result.contains("1 change saved on this device."))
+    }
+
+    @Test func detailWithMultiplePendingPluralizesCorrectly() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = OfflineBanner.detail(pendingCount: 4, lastSyncedAt: nil, now: now)
+        #expect(result.contains("4 changes saved on this device."))
+    }
+
+    @Test func detailLastUpdateUsesMomentsAgoForRecent() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let recent = now.addingTimeInterval(-30) // 30s ago → < 1 min
+        let result = OfflineBanner.detail(pendingCount: 0, lastSyncedAt: recent, now: now)
+        #expect(result.contains("Last update: moments ago."))
+    }
+
+    @Test func detailLastUpdateUsesSingularMinute() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let oneMin = now.addingTimeInterval(-60)
+        let result = OfflineBanner.detail(pendingCount: 0, lastSyncedAt: oneMin, now: now)
+        #expect(result.contains("Last update: 1 minute ago."))
+    }
+
+    @Test func detailLastUpdatePluralizesMinutes() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let fiveMin = now.addingTimeInterval(-5 * 60)
+        let result = OfflineBanner.detail(pendingCount: 0, lastSyncedAt: fiveMin, now: now)
+        #expect(result.contains("Last update: 5 minutes ago."))
+    }
+
+    @Test func detailHandlesClockSkew() {
+        // Defensive: if the device clock jumps backward (NTP correction,
+        // user editing the system clock), `lastSyncedAt > now`. Should not
+        // crash or render a negative-minutes string.
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let future = now.addingTimeInterval(300)
+        let result = OfflineBanner.detail(pendingCount: 0, lastSyncedAt: future, now: now)
+        #expect(result.contains("Last update: moments ago."))
+        #expect(!result.contains("-"))
+    }
+
+    // MARK: - Accessibility copy
+
+    @Test func accessibilityLabelMatchesHeadline() {
+        #expect(OfflineBanner.accessibility(pendingCount: 0) == "You're offline.")
+        #expect(OfflineBanner.accessibility(pendingCount: 1) == "You're offline. 1 change saved on this device.")
+        #expect(OfflineBanner.accessibility(pendingCount: 7) == "You're offline. 7 changes saved on this device.")
     }
 }


### PR DESCRIPTION
Closes #119

## Root cause

The offline banner copy was written in implementation language, not user language:

- Headline: `"Offline — N changes waiting to sync"` / `"Offline — changes will sync when you're back"`
- Detail (no pending): `"No mutations pending."`
- Detail (pending): `"N mutations pending."`
- Last sync line: `"Last sync: X minutes ago."` / `"No sync recorded yet."`
- Accessibility label: `"Offline. N changes waiting to sync."`

`mutation`, `queue`, `pending`, `waiting to sync` are all words from the codebase's mental model — `MutationQueueEntry`, `MutationStatus.pending`, `SyncManager.lastSyncedAt`. Brent's report is correct: those leak through the UI.

## Approach: options considered

1. **Tweak the words but keep the structure** (chosen). Replace technical jargon with consumer-friendly equivalents. "Mutations pending" → "changes saved on this device". "Waiting to sync" → just "saved" (the implicit promise is that they'll sync). "Last sync" → "Last update" (less Dropbox-API, more iCloud-Photos). Keep the headline / expanded-detail split because it works.
2. **Remove the count from the headline entirely.** Cleaner but loses useful information — the user wants to know their work is safe, and "5 changes saved" delivers that reassurance.
3. **Replace with a single icon + "Offline" indicator, no pending count anywhere.** Minimal but loses the reassurance signal completely. Saved-on-device is exactly what users want to know when offline.

Picked (1). Final copy:

| State | Headline | Detail (when expanded) | Accessibility |
|---|---|---|---|
| Offline, 0 pending | `You're offline` | `We'll sync when you're back online. Last update: 5 minutes ago.` | `You're offline.` |
| Offline, 1 pending | `You're offline — 1 change saved` | `1 change saved on this device. We'll sync when you're back online. Last update: …` | `You're offline. 1 change saved on this device.` |
| Offline, N pending | `You're offline — 4 changes saved` | `4 changes saved on this device. We'll sync when you're back online. Last update: …` | `You're offline. 4 changes saved on this device.` |

The expanded detail does still use the word "sync" once — kept intentionally because it's the standard consumer-app term for what's happening (Apple Photos, iCloud, Dropbox, Google Drive all use it in user-facing copy). The technical bits — `mutation`, `queue`, `pending` — are gone.

## Implementation

The three private computed properties (`headlineText`, `detailText`, `accessibilityLabel`) are now thin wrappers over pure static helpers (`headline(pendingCount:)`, `detail(pendingCount:lastSyncedAt:now:)`, `accessibility(pendingCount:)`). The static helpers carry the singular/plural and minute-rounding logic. `detail` accepts an injectable `now` so tests don't depend on the wall clock.

## Tests

Added 12 tests in `OfflineBannerTests.swift` covering the new copy:

- Headline: zero/negative pending, singular pending, plural pending, regression guard that the headline never re-acquires `mutation` / `queue` / `pending` / `waiting to sync`.
- Detail: singular vs plural saved-line, "moments ago" / "1 minute ago" / "N minutes ago" branches, clock-skew safety (`lastSyncedAt > now` from NTP correction or user-edited clock — should round to "moments ago", not produce a negative-minute string).
- Accessibility: matches headline pluralization.

**Test-prevention reflection:** could a pragmatic test have caught the underlying bug (technical jargon leaking through to UI)? The taste judgement, no. But the *category* of bug — "the singular/plural unit string is wrong" or "the headline starts including DB terminology again because someone refactored MutationQueue and renamed everything" — is now caught by the jargon-guard test (`headlineHasNoTechnicalJargon`). That's the lasting value.

The pre-existing `bannerHeadlineWithNoPendingUsesBaseCopy` and `bannerHeadlineWithPendingShowsCount` tests just inspected `pendingCount` (because `headlineText` was private) — they didn't actually assert on the rendered string. Replaced with assertions that exercise the public static helpers.

## `pnpm typecheck` / `pnpm test`

Not run — diff is Swift-only (`apps/ios/**`). The pnpm scripts cover the TypeScript workspace (API, desktop, packages); they do not build or test the Xcode project. Verified with `git diff --stat main`:

```
 apps/ios/Brett/Views/Shared/OfflineBanner.swift    |  69 +++++++++----
 apps/ios/BrettTests/Views/OfflineBannerTests.swift | 111 ++++++++++++++++-----
```

iOS test suite registers the new tests automatically via XcodeGen — please run the `Brett` scheme tests in Xcode before merging.

## Self-review findings

1. **First pass had `headline(pendingCount: 0)` returning `"You're offline. Changes will sync here."`** — too wordy and the second sentence is a half-truth (changes only "sync here" if there are changes). Trimmed to just `"You're offline"`. The expanded detail line carries the reassurance.
2. **Initial version did not handle negative `pendingCount`.** Defensive: the call site is `OfflineBannerModifier.fetchPendingCount` which can't go negative, but if it ever does (unsigned-vs-signed type mismatch in a future refactor) the helper now treats it as zero rather than rendering `"-3 changes saved"`.
3. **Initial version did not have an injectable `now` parameter on `detail`.** That made the minute-rounding test depend on `Date()` which would flake on slow machines. Added `now: Date = Date()` so tests can pin the clock.
4. **Considered also softening `OfflineBanner.swift`'s color** from a red-tint glass card to amber — closer to "informational" than "error". Held off: that's a visual change, not a copy change, and Brent's report was specifically about wording. Leaving for a follow-up if the red still reads as "something is broken" rather than "you're offline".

## Visual verification pending — `gh pr checkout 119`

Please verify in the simulator/device:
- Toggle airplane mode → banner should read "You're offline" (not "Offline — changes will sync when you're back").
- Make a few edits while offline → banner headline updates to "You're offline — N changes saved".
- Tap to expand → detail line reads "N changes saved on this device. We'll sync when you're back online. Last update: …".
- Toggle VoiceOver → accessibility label matches.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01J722mdfNJEWZH9iDjPnU9g)_