### PR TITLE
fix(ios): show calendar timeline offline when cache has events (#120, #122)

### DIFF
--- a/apps/ios/Brett/Views/Calendar/CalendarPage.swift
+++ b/apps/ios/Brett/Views/Calendar/CalendarPage.swift
@@ -37,13 +37,34 @@ struct CalendarPage: View {
         return now
     }
 
+    /// Pure helper — public for test access. Decides whether the calendar
+    /// should render the timeline (with whatever events are in the local
+    /// cache) versus the "Connect Google Calendar" CTA.
+    ///
+    /// Account metadata isn't part of the sync-pull (`/calendar/accounts`
+    /// is fetched on demand), so when offline `hasAnyAccount` is false even
+    /// if the user actually has accounts and cached events. Falling back
+    /// on cached-events presence handles that case: if there's any event
+    /// in the local SwiftData store, the user must have a connected
+    /// account, so show the timeline.
+    ///
+    /// Edge case: a connected account with zero events in the visible
+    /// window (rare) still shows the CTA when offline. Not a regression
+    /// vs. the old behaviour — both old and new code hit the CTA there.
+    static func shouldShowTimeline(hasAccount: Bool, hasCachedEvents: Bool) -> Bool {
+        hasAccount || hasCachedEvents
+    }
+
     var body: some View {
         VStack(spacing: 16) {
             monthHeader
 
             WeekStrip(selectedDate: $selectedDate, events: events)
 
-            if accountsStore.hasAnyAccount {
+            if Self.shouldShowTimeline(
+                hasAccount: accountsStore.hasAnyAccount,
+                hasCachedEvents: !events.isEmpty
+            ) {
                 DayTimeline(events: events, selectedDate: selectedDate)
                     .background {
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
@@ -148,7 +169,15 @@ struct CalendarPage: View {
     }
 
     private func refresh() async {
+        // Hydrate from local cache first, BEFORE any network call.
+        // `accountsStore.fetchAccounts()` hits `/calendar/accounts`, which can
+        // hang or fail when offline — if we awaited it before reading the
+        // cache, the timeline would render empty until the network call
+        // resolved (or timed out). Reading SwiftData first means cached
+        // events show immediately on cold launch, even with no connectivity.
+        loadEventsFromCache()
         await accountsStore.fetchAccounts()
+        // Re-read after the fetch so any newly-pulled events are picked up.
         loadEventsFromCache()
     }
 

--- a/apps/ios/BrettTests/Views/CalendarOfflineFallbackTests.swift
+++ b/apps/ios/BrettTests/Views/CalendarOfflineFallbackTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Regression coverage for the offline calendar fallback (issues #120 and
+/// #122). `CalendarAccountsStore.fetchAccounts()` hits the network — when
+/// offline, `accountsStore.hasAnyAccount` resolves to false even if the
+/// user has connected accounts and cached events. The original gating
+/// `if accountsStore.hasAnyAccount { DayTimeline } else { connectCTA }`
+/// dropped users into the "Connect Google Calendar" CTA whenever they
+/// opened the calendar tab without connectivity, which surfaced as both
+/// "no calendar entries" (#122) and "stuck — couldn't swipe right or left"
+/// (#120 — there was no timeline to swipe on, only a static CTA).
+///
+/// `CalendarPage.shouldShowTimeline(hasAccount:hasCachedEvents:)` falls
+/// back on cached-events presence so the timeline survives offline.
+@Suite("CalendarOfflineFallback", .tags(.views))
+struct CalendarOfflineFallbackTests {
+
+    @Test func showsTimelineWhenAccountsAreLoaded() {
+        // Online happy path — accounts loaded successfully.
+        #expect(CalendarPage.shouldShowTimeline(hasAccount: true, hasCachedEvents: true))
+        #expect(CalendarPage.shouldShowTimeline(hasAccount: true, hasCachedEvents: false))
+    }
+
+    @Test func showsTimelineOfflineWhenCacheHasEvents() {
+        // The bug: offline launch, accounts haven't loaded yet, but the
+        // local SwiftData cache has events from a prior sync. The
+        // timeline must render — cached events imply a connected account.
+        #expect(CalendarPage.shouldShowTimeline(hasAccount: false, hasCachedEvents: true))
+    }
+
+    @Test func showsConnectCTAWhenNoAccountsAndNoEvents() {
+        // True "first run" / "never connected" state — no accounts, no
+        // events. CTA is correct. This is the only state where the CTA
+        // should still render after the fix.
+        #expect(!CalendarPage.shouldShowTimeline(hasAccount: false, hasCachedEvents: false))
+    }
+}


### PR DESCRIPTION
Closes #120
Closes #122

## Root cause (one bug, two reports)

`/calendar/accounts` is fetched on demand from the API every time the calendar tab renders — it is **not** part of the sync-pull, so account metadata isn't cached locally. From `CalendarAccountsStore.swift`:

> Unlike `CalendarStore` (which reads local SwiftData), account metadata isn't part of the sync-pull flow — it's fetched on demand whenever the Calendar page renders or Settings needs to list connected accounts.

When the user opens the calendar offline (cold launch with no connectivity, or backgrounded session that wakes offline), `fetchAccounts()` fails silently into `lastError`. `accounts` stays empty, so `accountsStore.hasAnyAccount` is `false`. The page renders the "Connect Google Calendar" CTA instead of the timeline — even though the local SwiftData cache has events from prior syncs.

That single behaviour produced two separate user reports:

- **#122 ("No calendar entries when no WiFi")** — exactly the symptom: open offline, see empty/CTA; reconnect, events return.
- **#120 ("Stuck on calendar on no WiFi — couldn't swipe right or left")** — same root cause from a different angle. The week strip + day timeline is what the user swipes through. With the timeline replaced by the static CTA, there's nothing to swipe on. "Stuck" because the swipe-able surface was hidden.

A second contributing factor: `refresh()` did `await accountsStore.fetchAccounts()` **before** `loadEventsFromCache()`. So even on cold launch online, the timeline was empty until the network call resolved. Offline, the network call would hang on URLSession's default timeout (60s) before the cache read ever happened.

## Approach: options considered

1. **Persist account list to local storage** (UserDefaults / SwiftData), hydrate on init, fetch network in background. The "proper" offline-first solution. Heavier: new persistence layer for account metadata, sign-out wipe to extend, multi-user scoping (account-list keyed per `userId`). Roughly 3× the diff for the same user-visible result.
2. **Use cached-events presence as a signal of "user has accounts"** (chosen). If `events.isEmpty == false`, the user must have connected accounts (events only land in the cache via the sync pull, which only pulls them for connected accounts). Show the timeline regardless of whether `accountsStore.hasAnyAccount` has loaded yet. Plus reorder `refresh()` to hit the cache before the network so the timeline never blanks while waiting on a network call.
3. **Keep the hard gate but show a different "you're offline" empty state** instead of the connect CTA. Worse UX — user sees neither their cached events nor the CTA, just a "we can't reach the server" message. Loses the value of the local cache entirely.

Picked (2). Single conditional flip + a refresh-order swap. Same user-visible result as option (1) for the realistic failure modes, with a fraction of the surface area.

**Edge case (acknowledged in the helper's doc-comment):** a connected account whose user happens to have **zero** events in the visible ±60-day window still hits the CTA when offline. Vanishingly rare in practice (anyone with a calendar has *something* in 4 months) and not a regression — the old code hit the CTA there too.

## What changed

`apps/ios/Brett/Views/Calendar/CalendarPage.swift`:
- New static helper `shouldShowTimeline(hasAccount: Bool, hasCachedEvents: Bool) -> Bool` next to the existing `snapForwardIfStale` pattern. Returns `hasAccount || hasCachedEvents`.
- Body's gating switched from `if accountsStore.hasAnyAccount` to `if Self.shouldShowTimeline(hasAccount: accountsStore.hasAnyAccount, hasCachedEvents: !events.isEmpty)`.
- `refresh()` now reads the cache **before** awaiting `fetchAccounts()`, then re-reads afterwards so newly-pulled events from a mid-cycle sync are picked up.

## Tests

New suite: `apps/ios/BrettTests/Views/CalendarOfflineFallbackTests.swift` (`@Suite(.tags(.views))`).

Three tests covering all four input combinations:

- `showsTimelineWhenAccountsAreLoaded` — happy path: account loaded, with or without cache, → timeline.
- `showsTimelineOfflineWhenCacheHasEvents` — the bug being fixed: account NOT loaded but cache has events → timeline. This test fails against the pre-fix code.
- `showsConnectCTAWhenNoAccountsAndNoEvents` — true first-run state → CTA. Regression guard so the gate doesn't get loosened to "always show timeline".

**Test-prevention reflection:** could a pragmatic test have caught the underlying bug? Yes — `showsTimelineOfflineWhenCacheHasEvents` would fail against the pre-PR `if accountsStore.hasAnyAccount` gate. The category of bug (gating local-cached UI on a network-resolved signal) is now caught for any future regression that flips the OR back to AND or removes the cached-events branch.

## `pnpm typecheck` / `pnpm test`

Not run — diff is Swift-only (`apps/ios/**`):

```
 apps/ios/Brett/Views/Calendar/CalendarPage.swift            | 31 ++++++-
 apps/ios/BrettTests/Views/CalendarOfflineFallbackTests.swift | 39 ++++++++++++
```

The pnpm scripts cover the TypeScript workspace (API, desktop, packages); they don't build or test the Xcode project. iOS test suite registers the new file automatically via XcodeGen — please run the `Brett` scheme tests in Xcode before merging.

## Self-review findings

1. **First pass put the cache read only at the start of `refresh()`.** Caught on review: a successful `fetchAccounts()` could pull in fresh events via a parallel sync cycle, and we'd miss them. Added a second `loadEventsFromCache()` after the await so newly-pulled events are picked up.
2. **Considered using `events.count > 0` directly instead of `!events.isEmpty`.** They're equivalent for `Array`, but `isEmpty` is the idiomatic Swift form and reads the same as the existing `events.filter { ... }` boundary. Kept `!events.isEmpty`.
3. **Considered using the unfiltered cache size** (events from `calendarStore.fetchEvents` before the `myResponseStatus != declined` filter) as the cached-events signal — that way "user has only declined events offline" still shows the timeline. Rejected: adds a second query path, the post-filter `events` array is what the timeline actually renders, and the user with only declined events sees an empty timeline either way.
4. **Auth scoping intact.** `loadEventsFromCache` already passes `userId: authManager.currentUser?.id` per the multi-user mindset. The new helper takes Bools, so it has nothing to scope. ✓
5. **No backwards-compat concern** — gating logic is in-app only, no API surface change.

## Risks / follow-ups

- **Minor:** if a user disconnects all calendar accounts and the disconnect tombstones haven't been pulled yet, offline they'd see orphaned events instead of the CTA. Same race window exists today (a sign-out wipe would fix it on sign-out, but mid-session disconnect doesn't trigger that). Not a regression. Could add follow-up: have `disconnect()` purge events for that account from local SwiftData.
- **Possible follow-up #1**: persist `accounts` to local storage as the proper "offline-first" treatment. Worth doing if we hit other places that gate UI on `accountsStore.hasAnyAccount` and the cached-events trick doesn't fit.
- **Possible follow-up #2**: `accountsStore.fetchAccounts()` doesn't have a per-call timeout. If the network has high latency (captive portal, slow cell), the second `loadEventsFromCache()` is delayed. Cached events still show via the first call so user-visible impact is bounded.

## Visual verification pending — `gh pr checkout 120` (or 122)

Reviewer should confirm in the simulator/device:
- With Wi-Fi off, cold-launch the app → calendar tab shows your events from the local cache (not the Connect CTA).
- With Wi-Fi off, swipe between days on the week strip → works (day-timeline navigates, no blank screen).
- Disconnect all calendar accounts → offline still shows events for the brief race window before the next sync (acknowledged).
- True first-run, never-connected user, with Wi-Fi off → still shows the Connect CTA (regression guard).

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01J722mdfNJEWZH9iDjPnU9g)_