### PR TITLE
fix: clip multi-day calendar events to the visible day window (#130)

### DIFF
--- a/apps/ios/Brett/Views/Calendar/DayTimeline.swift
+++ b/apps/ios/Brett/Views/Calendar/DayTimeline.swift
@@ -32,16 +32,55 @@ struct DayTimeline: View {
     }
 
     private func resolveStartHour(timed: [CalendarEvent]) -> Int {
-        let base = 6
-        let minHour = timed.map { calendar.component(.hour, from: $0.startTime) }.min() ?? base
-        return min(base, minHour)
+        Self.resolveStartHour(timed: timed, selectedDate: selectedDate, calendar: calendar)
     }
 
     private func resolveEndHour(timed: [CalendarEvent]) -> Int {
+        Self.resolveEndHour(timed: timed, selectedDate: selectedDate, calendar: calendar)
+    }
+
+    /// First hour shown in the visible window. Defaults to 6 AM, expanded
+    /// earlier when an event in the day starts before then. Multi-day
+    /// events are clipped to the day's start (00:00) so a flight that
+    /// began before midnight pulls the window down to hour 0 rather than
+    /// reading the *original* start hour from a previous day.
+    static func resolveStartHour(
+        timed: [CalendarEvent],
+        selectedDate: Date,
+        calendar: Calendar
+    ) -> Int {
+        let base = 6
+        let dayStart = calendar.startOfDay(for: selectedDate)
+        let minHour = timed.map { evt -> Int in
+            let clipped = max(evt.startTime, dayStart)
+            return calendar.component(.hour, from: clipped)
+        }.min() ?? base
+        return min(base, minHour)
+    }
+
+    /// Last hour shown in the visible window. Defaults to 11 PM, capped
+    /// at 23 even when an event runs past midnight (the chip itself is
+    /// clipped to the day's end).
+    static func resolveEndHour(
+        timed: [CalendarEvent],
+        selectedDate: Date,
+        calendar: Calendar
+    ) -> Int {
         let base = 23
+        let dayStart = calendar.startOfDay(for: selectedDate)
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else {
+            return base
+        }
         let maxHour = timed.compactMap { evt -> Int? in
-            let endHour = calendar.component(.hour, from: evt.endTime)
-            let endMin = calendar.component(.minute, from: evt.endTime)
+            let clipped = min(evt.endTime, dayEnd)
+            let endHour = calendar.component(.hour, from: clipped)
+            let endMin = calendar.component(.minute, from: clipped)
+            // An event that ends exactly at midnight (the day's `dayEnd`)
+            // returns hour 0 from `component(.hour:)`. Treat it as 24 so
+            // the visible window doesn't silently shrink to the base 23.
+            if calendar.isDate(clipped, equalTo: dayEnd, toGranularity: .second) {
+                return 24
+            }
             return endMin > 0 ? endHour + 1 : endHour
         }.max() ?? base
         return max(base, min(maxHour, 23))
@@ -142,12 +181,16 @@ struct DayTimeline: View {
 
     @ViewBuilder
     private func eventChip(_ event: CalendarEvent, startHour: Int) -> some View {
-        let startHourD = Double(calendar.component(.hour, from: event.startTime))
-        let startMin = Double(calendar.component(.minute, from: event.startTime))
-        let offset = CGFloat((startHourD - Double(startHour)) * Double(hourHeight) + (startMin / 60.0) * Double(hourHeight))
-
-        let durationMin = max(Double(event.endTime.timeIntervalSince(event.startTime) / 60.0), 15)
-        let height = CGFloat(durationMin / 60.0) * hourHeight
+        let layout = Self.chipLayout(
+            eventStart: event.startTime,
+            eventEnd: event.endTime,
+            selectedDate: selectedDate,
+            startHour: startHour,
+            hourHeight: hourHeight,
+            calendar: calendar
+        )
+        let offset = layout.offset
+        let height = layout.height
         let meta = Self.metaLine(for: event)
         let minHeight = Self.chipMinHeight(hasMeta: meta != nil)
 
@@ -195,6 +238,61 @@ struct DayTimeline: View {
     /// (13pt, one line), while a chip with a meta line needs room for both.
     static func chipMinHeight(hasMeta: Bool) -> CGFloat {
         hasMeta ? 46 : 28
+    }
+
+    /// Vertical placement (offset from grid top) and height for a timed-event
+    /// chip on a single-day timeline.
+    ///
+    /// Multi-day events (e.g. a flight from Mon 5pm to Wed 9am) are clipped
+    /// to the selected day's window before the offset / height are computed.
+    /// Without clipping the chip would render at the *original* start hour
+    /// (5pm) with the *full* duration's height (44h * hourHeight) on every
+    /// day the event overlaps — so a 12h flight viewed on the day it ends
+    /// would render a 720pt-tall chip starting at 5pm, completely
+    /// overflowing the visible grid.
+    ///
+    /// - `eventStart` / `eventEnd`: the event's wall-clock range.
+    /// - `selectedDate`: any moment inside the day being rendered (the day's
+    ///   start is computed via `calendar.startOfDay`).
+    /// - `startHour`: the first hour shown in the visible grid window.
+    /// - Returns the chip's `offset` from the top of the grid (in points)
+    ///   and its raw `height` (caller still applies `chipMinHeight` as a
+    ///   floor for short events).
+    static func chipLayout(
+        eventStart: Date,
+        eventEnd: Date,
+        selectedDate: Date,
+        startHour: Int,
+        hourHeight: CGFloat,
+        calendar: Calendar
+    ) -> (offset: CGFloat, height: CGFloat) {
+        let dayStart = calendar.startOfDay(for: selectedDate)
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else {
+            return (0, 0)
+        }
+
+        // Clip the event to the visible day so multi-day events render
+        // only their in-day portion.
+        let clippedStart = max(eventStart, dayStart)
+        let clippedEnd = min(eventEnd, dayEnd)
+        // Defensive: an event that doesn't overlap the day shouldn't reach
+        // this helper (the timed-events filter already excludes it), but if
+        // it does we return a zero-sized layout rather than negative values.
+        guard clippedEnd > clippedStart else { return (0, 0) }
+
+        // Minutes from the start of the day to the clipped event start.
+        let minutesFromDayStart = clippedStart.timeIntervalSince(dayStart) / 60.0
+        // Minutes from the start of the visible window to the clipped start.
+        let minutesFromWindow = minutesFromDayStart - Double(startHour) * 60.0
+        let offset = CGFloat(minutesFromWindow / 60.0 * Double(hourHeight))
+
+        // 15-min minimum mirrors the previous behaviour so very-short events
+        // still render a tappable chip; the rendered chip also enforces a
+        // text-driven floor via `chipMinHeight`.
+        let durationMin = max(clippedEnd.timeIntervalSince(clippedStart) / 60.0, 15)
+        let height = CGFloat(durationMin / 60.0 * Double(hourHeight))
+
+        return (offset, height)
     }
 
     @ViewBuilder

--- a/apps/ios/BrettTests/Views/DayTimelineLayoutTests.swift
+++ b/apps/ios/BrettTests/Views/DayTimelineLayoutTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Pins the contract for `DayTimeline.chipLayout`, `resolveStartHour`, and
+/// `resolveEndHour`. The shared bug they guard against: events that span
+/// past the visible day's edges (overnight, multi-day flights, hotel
+/// holds) used to render a chip positioned at the *original* start hour
+/// with the *full* duration's height — so a 36-hour conference viewed on
+/// its second day would render a 2160pt-tall chip starting at the
+/// original start hour, completely overflowing the grid.
+///
+/// Clipping the event range to the selected day's window before the
+/// position math fixes both the offset and the height. The visible-window
+/// resolvers also clip so the start-of-day pull-down for early events
+/// uses the in-day start, not the original.
+@Suite("DayTimelineLayout", .tags(.views))
+struct DayTimelineLayoutTests {
+    private let cal = Calendar(identifier: .gregorian)
+    private let hourHeight: CGFloat = 60
+
+    // MARK: - chipLayout
+
+    @Test func eventEntirelyInsideDayUsesUnclippedRange() {
+        // 9 AM - 10 AM on the selected day. Visible window starts at 6 AM.
+        let day = makeDate(year: 2026, month: 5, day: 5)
+        let start = makeDate(year: 2026, month: 5, day: 5, hour: 9)
+        let end = makeDate(year: 2026, month: 5, day: 5, hour: 10)
+
+        let layout = DayTimeline.chipLayout(
+            eventStart: start,
+            eventEnd: end,
+            selectedDate: day,
+            startHour: 6,
+            hourHeight: hourHeight,
+            calendar: cal
+        )
+
+        // 9 AM is 3 hours past the 6 AM window start.
+        #expect(layout.offset == 180)
+        #expect(layout.height == 60)
+    }
+
+    @Test func multiDayEventClipsToDayStartOnFollowingDay() {
+        // Conference: Mon May 4 5 PM → Wed May 6 9 AM. Viewed on Tue May 5.
+        // The chip should render from 00:00 (negative offset relative to
+        // the 6 AM window start) through 24:00 — the entire day.
+        let mon5pm = makeDate(year: 2026, month: 5, day: 4, hour: 17)
+        let wed9am = makeDate(year: 2026, month: 5, day: 6, hour: 9)
+        let tue = makeDate(year: 2026, month: 5, day: 5, hour: 12)
+
+        let layout = DayTimeline.chipLayout(
+            eventStart: mon5pm,
+            eventEnd: wed9am,
+            selectedDate: tue,
+            startHour: 0,
+            hourHeight: hourHeight,
+            calendar: cal
+        )
+
+        // Offset zero: the event starts at the day's 00:00 (clipped).
+        #expect(layout.offset == 0)
+        // Height: 24 hours * 60pt = 1440pt — the full visible day.
+        #expect(layout.height == 1440)
+    }
+
+    @Test func eventEndingPastMidnightClipsToDayEnd() {
+        // Late party: 10 PM Tue May 5 → 2 AM Wed May 6.
+        // Viewed on Tue May 5: chip should run from 22:00 to 24:00 (4h
+        // would be wrong; only 2h is in-day).
+        let tue10pm = makeDate(year: 2026, month: 5, day: 5, hour: 22)
+        let wed2am = makeDate(year: 2026, month: 5, day: 6, hour: 2)
+        let tue = makeDate(year: 2026, month: 5, day: 5, hour: 12)
+
+        let layout = DayTimeline.chipLayout(
+            eventStart: tue10pm,
+            eventEnd: wed2am,
+            selectedDate: tue,
+            startHour: 6,
+            hourHeight: hourHeight,
+            calendar: cal
+        )
+
+        // Offset = (22 - 6) * 60 = 960
+        #expect(layout.offset == 960)
+        // Height = 2 hours (clipped) * 60 = 120 — NOT 4 hours (240).
+        // Pre-fix this would have been 240, overflowing into the next day.
+        #expect(layout.height == 120)
+    }
+
+    @Test func eventStartingBeforeDayClipsToDayStart() {
+        // Overnight: 10 PM Mon May 4 → 7 AM Tue May 5.
+        // Viewed on Tue May 5: chip should run from 00:00 to 7:00 (NOT
+        // from 22:00 with 9h height).
+        let mon10pm = makeDate(year: 2026, month: 5, day: 4, hour: 22)
+        let tue7am = makeDate(year: 2026, month: 5, day: 5, hour: 7)
+        let tue = makeDate(year: 2026, month: 5, day: 5, hour: 12)
+
+        let layout = DayTimeline.chipLayout(
+            eventStart: mon10pm,
+            eventEnd: tue7am,
+            selectedDate: tue,
+            startHour: 0,
+            hourHeight: hourHeight,
+            calendar: cal
+        )
+
+        #expect(layout.offset == 0)
+        // 7 hours in-day * 60pt
+        #expect(layout.height == 420)
+    }
+
+    @Test func shortEventEnforces15MinuteFloor() {
+        // 5-minute event: the raw height would be 5pt, but the chip
+        // floor is 15 minutes (15pt) so very-short events stay tappable.
+        let day = makeDate(year: 2026, month: 5, day: 5)
+        let start = makeDate(year: 2026, month: 5, day: 5, hour: 9)
+        let end = makeDate(year: 2026, month: 5, day: 5, hour: 9, minute: 5)
+
+        let layout = DayTimeline.chipLayout(
+            eventStart: start,
+            eventEnd: end,
+            selectedDate: day,
+            startHour: 6,
+            hourHeight: hourHeight,
+            calendar: cal
+        )
+
+        // 15min / 60min * 60pt = 15pt
+        #expect(layout.height == 15)
+    }
+
+    // MARK: - resolveStartHour / resolveEndHour
+
+    @Test func resolveStartHourPullsDownForEarlyInDayEvent() {
+        // 4 AM event starts before the 6 AM default window — pull down to 4.
+        let day = makeDate(year: 2026, month: 5, day: 5)
+        let early = makeEvent(
+            start: makeDate(year: 2026, month: 5, day: 5, hour: 4),
+            end: makeDate(year: 2026, month: 5, day: 5, hour: 5)
+        )
+
+        let result = DayTimeline.resolveStartHour(
+            timed: [early],
+            selectedDate: day,
+            calendar: cal
+        )
+
+        #expect(result == 4)
+    }
+
+    @Test func resolveStartHourClampsMultiDayEventToZero() {
+        // Multi-day event starting 5 PM the previous day. On the
+        // selected day it's running since midnight — the visible window
+        // should pull down to 0, NOT read the original 17.
+        let day = makeDate(year: 2026, month: 5, day: 5)
+        let multiDay = makeEvent(
+            start: makeDate(year: 2026, month: 5, day: 4, hour: 17),
+            end: makeDate(year: 2026, month: 5, day: 6, hour: 9)
+        )
+
+        let result = DayTimeline.resolveStartHour(
+            timed: [multiDay],
+            selectedDate: day,
+            calendar: cal
+        )
+
+        #expect(result == 0)
+    }
+
+    @Test func resolveEndHourReportsBaseWhenNoLateEvents() {
+        let day = makeDate(year: 2026, month: 5, day: 5)
+        let normal = makeEvent(
+            start: makeDate(year: 2026, month: 5, day: 5, hour: 9),
+            end: makeDate(year: 2026, month: 5, day: 5, hour: 10)
+        )
+
+        let result = DayTimeline.resolveEndHour(
+            timed: [normal],
+            selectedDate: day,
+            calendar: cal
+        )
+
+        #expect(result == 23)
+    }
+
+    @Test func resolveEndHourCapsAtBaseEvenForOvernightEvent() {
+        // Event runs through to 2 AM next day — clipped end is the day's
+        // 24:00. The resolver caps at base (23) per the implementation
+        // contract; the chip itself extends through midnight via
+        // chipLayout's clipping.
+        let day = makeDate(year: 2026, month: 5, day: 5)
+        let overnight = makeEvent(
+            start: makeDate(year: 2026, month: 5, day: 5, hour: 22),
+            end: makeDate(year: 2026, month: 5, day: 6, hour: 2)
+        )
+
+        let result = DayTimeline.resolveEndHour(
+            timed: [overnight],
+            selectedDate: day,
+            calendar: cal
+        )
+
+        #expect(result == 23)
+    }
+
+    // MARK: - helpers
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0
+    ) -> Date {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = day
+        comps.hour = hour
+        comps.minute = minute
+        return cal.date(from: comps)!
+    }
+
+    private func makeEvent(start: Date, end: Date) -> CalendarEvent {
+        CalendarEvent(
+            id: UUID().uuidString,
+            userId: "u1",
+            googleAccountId: "ga1",
+            calendarListId: "cal1",
+            googleEventId: UUID().uuidString,
+            title: "Event",
+            startTime: start,
+            endTime: end
+        )
+    }
+}


### PR DESCRIPTION
Closes #130

## Root cause

`DayTimeline.eventChip` positioned every chip using the event's *original* start hour (`calendar.component(.hour, from: event.startTime)`) and sized it using the event's *full* duration (`event.endTime.timeIntervalSince(event.startTime)`). For a multi-day event — a flight, hotel hold, multi-day conference, or anything that crosses midnight — that produces a chip:

- positioned at the previous day's start hour interpreted as today's start hour
- sized to the event's full multi-day duration (potentially thousands of points tall)

A 36-hour conference viewed on its second day rendered a 2160pt-tall chip starting at the original start hour, completely overflowing the timeline. The user's report ("size of the card is massive and not for the specific times the events are for") matches exactly: chips that bear no resemblance to the in-day window the event actually occupies.

`resolveStartHour` / `resolveEndHour` had the same bug — they read the original `startTime` / `endTime` hours, so a multi-day event's "min hour" was its original start hour from a previous day, not 0 (it's running since midnight on the day being viewed).

## Approach

Three options considered:

1. **Clip the event's range to the selected day before computing offset/height** (chosen). Pure-data fix in the layout helper; no surface-level reshaping.
2. Filter multi-day events out entirely from the timed grid and surface them in the all-day band. Wrong: a flight that overlaps three days is a *timed* event with real start/end times, not an all-day commitment. Putting it in the all-day band loses the time information the user wants.
3. Render multi-segment chips (one per day). Higher effort, only marginally better UX (a lone bottom-cropped corner already communicates "continues into next day"), and the timeline's coordinate system would need a rewrite to support it.

Option 1 is also what every mature calendar UI (Google Calendar, Apple Calendar, Fantastical) does on a single-day view: clip to the day, render edges flush.

The new `chipLayout` helper takes the event range, the selected date, the visible-window start hour, and the hour height, and returns `(offset, height)` with both ends clipped to the day's `[00:00, 24:00)` window. Defensive `(0, 0)` return when the clipped range is empty (the `timedEvents` filter already excludes those, but the helper stays correct in isolation).

`resolveStartHour` / `resolveEndHour` get the same clipping treatment so a multi-day event's second day pulls the visible window down to 0 (instead of reading 17 from the original Monday-5pm start) and an overnight-into-tomorrow event reads the day's 24:00 (capped at 23 by design — the chip itself extends through midnight via `chipLayout`'s clipping).

## Tests

Added `apps/ios/BrettTests/Views/DayTimelineLayoutTests.swift` (`@Suite("DayTimelineLayout", .tags(.views))`):

- `eventEntirelyInsideDayUsesUnclippedRange` — regression guard: in-day events behave identically to before.
- `multiDayEventClipsToDayStartOnFollowingDay` — direct guard for the bug. A Mon-5pm → Wed-9am event viewed on Tue renders offset=0, height=1440 (the full day), not the pre-fix offset=1020, height=2640.
- `eventEndingPastMidnightClipsToDayEnd` — Tue-10pm → Wed-2am viewed on Tue: height=120 (2h in-day), not 240 (4h total).
- `eventStartingBeforeDayClipsToDayStart` — Mon-10pm → Tue-7am viewed on Tue: offset=0, height=420.
- `shortEventEnforces15MinuteFloor` — the 15-min minimum still applies after clipping.
- `resolveStartHourPullsDownForEarlyInDayEvent` / `resolveStartHourClampsMultiDayEventToZero` / `resolveEndHourReportsBaseWhenNoLateEvents` / `resolveEndHourCapsAtBaseEvenForOvernightEvent` — pin the visible-window resolvers.

**Test-prevention reflection:** could a test have caught this bug or one like it? Yes — the suite above fails against the pre-PR code for every multi-day case. Adding them for the *category* (clip-to-day in the timeline math) also guards against future regressions where someone refactors `eventChip` and accidentally drops the clipping.

## Verification

- Swift toolchain not available on this Linux agent runner. CI does not build iOS. Please run `Brett` scheme tests in Xcode (or on a Mac runner) before merging. The new test suite auto-registers via XcodeGen.
- No TypeScript touched. `pnpm typecheck` / `pnpm test` are unaffected (and not runnable in this environment — `node_modules` not installed).
- Visual verification pending — `gh pr checkout 130-multiday-event-clipping` and inspect Calendar tab on a day with a multi-day event. (Test fixtures don't exist for this in the iOS simulator dataset; easiest repro: create a Google Calendar event from yesterday 5 PM to tomorrow 9 AM and view today's date.)

## Self-review findings

1. First pass left `resolveStartHour` / `resolveEndHour` reading raw `startTime` / `endTime` hours. On review — those hit the same bug as `eventChip` did. Fixed both with the same clipping pattern. Otherwise a multi-day event's *chip* would render correctly but the *visible window* would be wrong (e.g., chip sits at offset 0 but the grid's first row is still at 6 AM, leaving the chip's top above the grid).
2. The `resolveEndHour` cap at 23 is intentional and was already in the pre-PR code. Documented it explicitly so a future reader doesn't "fix" it. The chip itself extends through midnight via `chipLayout`'s clipping; the visible-hour grid stays at 24 rows because `endHour` of 23 produces 24 iterations of `startHour...endHour`.
3. `resolveEndHour` adds an `isDate(clipped, equalTo: dayEnd, .second)` check to handle the case where the clipped end equals exactly midnight — `calendar.component(.hour, from: midnight)` returns 0, which would silently shrink the visible window. Treats that as 24 instead.
4. The defensive `clippedEnd > clippedStart` guard is not strictly required (the `timedEvents` filter excludes non-overlapping events), but keeps the helper correct in isolation. Negligible cost; clearer contract.
5. No multi-user / auth implications — pure layout math, no per-user state.
6. Searched for other call sites of the changed functions: only `chipMinHeight` is called externally (`EventFormattingTests`), and its signature is unchanged.

## Risks / follow-ups

- **Risk:** test bundle uses `Calendar(identifier: .gregorian)` while production uses `Calendar.current`. Same answers in every modern locale; no DST cliff inside the helpers (everything is wall-clock minutes from `startOfDay`, which Foundation handles).
- **Follow-up (out of scope):** desktop has the same bug in `apps/desktop/src/components/calendar/CalendarDayView.tsx` (`parseToMinutes` reads minutes-of-day from raw start, `durationMinutes` returns full duration). The user's report is iOS-only so it's not addressed here — file separately if desktop sees the regression. The CLAUDE.md parity rule notes apply: a separate fix should mirror this one's clipping approach.
- **Follow-up (out of scope):** `WeekStrip` may have a similar issue when computing per-day event counts for multi-day events. Out of scope for this bug; not user-reported.

---
Generated by [Claude Code](https://claude.ai/code/session_01BLNjV5WCHB8pfcbLdv7mxA)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLNjV5WCHB8pfcbLdv7mxA)_