### PR TITLE
fix: keep organizer-owned declined events visible (#131)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,7 +4,7 @@ import { slugify, getEventGlassColor, getTaskDestinationLabel } from "@brett/uti
 import { useAutoUpdate } from "./hooks/useAutoUpdate";
 import { useTodayKey } from "./hooks/useTodayKey";
 import { usePinnedDate } from "./hooks/usePinnedDate";
-import { getEndOfWeekUTC } from "@brett/business";
+import { getEndOfWeekUTC, isHiddenDeclined } from "@brett/business";
 import type { BackgroundStyle } from "@brett/business";
 import {
   DndContext,
@@ -394,16 +394,18 @@ export function App() {
   const { data: sidebarCalendarData, isLoading: isLoadingSidebarCalendar } = useCalendarEvents(sidebarBounds);
   // Hide events the user declined — matches Google Calendar's default. The
   // event still exists server-side; we just don't surface it in any timeline.
+  // Events the user organized stay visible even when declined; Google
+  // Calendar never hides organizer-owned events from "Hide declined".
   const sidebarCalendarEvents: CalendarEventDisplay[] =
     (sidebarCalendarData?.events ?? [])
-      .filter((e: CalendarEventRecord) => !e.isAllDay && e.myResponseStatus !== "declined")
+      .filter((e: CalendarEventRecord) => !e.isAllDay && !isHiddenDeclined(e))
       .map(recordToDisplay);
 
   // Today's events for Next Up — always pinned to today, independent of sidebar navigation
   const { data: todayCalendarData } = useCalendarEvents(todayBounds);
   const todayCalendarEvents: CalendarEventDisplay[] =
     (todayCalendarData?.events ?? [])
-      .filter((e: CalendarEventRecord) => !e.isAllDay && e.myResponseStatus !== "declined")
+      .filter((e: CalendarEventRecord) => !e.isAllDay && !isHiddenDeclined(e))
       .map(recordToDisplay);
 
   // Next Up: find the next upcoming event from TODAY (not the sidebar date)

--- a/apps/desktop/src/pages/CalendarPage.tsx
+++ b/apps/desktop/src/pages/CalendarPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { CalendarDays } from "lucide-react";
 import type { CalendarEventRecord } from "@brett/types";
+import { isHiddenDeclined } from "@brett/business";
 import { useCalendarEvents } from "../api/calendar";
 import { useCalendarAccounts, useConnectCalendar, useToggleCalendarVisibility } from "../api/calendar-accounts";
 import { CalendarConnectModal } from "../components/CalendarConnectModal";
@@ -89,8 +90,10 @@ export default function CalendarPage({ onEventClick }: CalendarPageProps) {
 
   const { data } = useCalendarEvents({ startDate, endDate });
   // Hide events the user declined — matches Google Calendar's default.
+  // Events the user organized stay visible even when declined; Google
+  // Calendar never hides organizer-owned events from "Hide declined".
   const events: CalendarEventRecord[] = (data?.events ?? []).filter(
-    (e) => e.myResponseStatus !== "declined",
+    (e) => !isHiddenDeclined(e),
   );
 
   const handleToday = () => setCurrentDate(new Date());

--- a/apps/ios/Brett/Models/CalendarEvent.swift
+++ b/apps/ios/Brett/Models/CalendarEvent.swift
@@ -136,6 +136,18 @@ final class CalendarEvent {
         guard let data = organizerJSON?.data(using: .utf8) else { return nil }
         return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
     }
+
+    /// Whether the signed-in Google account organized this event.
+    ///
+    /// Reads `organizer.self` from the JSON the server hydrates from
+    /// Google's API. `selfAttendee?.responseStatus` already drives the
+    /// per-attendee RSVP UI; this flag is for filters that need to keep
+    /// organizer-owned events visible regardless of declined status —
+    /// matches Google Calendar's behaviour of never hiding events you
+    /// organized, even when "Hide declined events" is on.
+    var isOrganizer: Bool {
+        (organizer?["self"] as? Bool) == true
+    }
 }
 
 // MARK: - Codable (sync wire format)

--- a/apps/ios/Brett/Views/Calendar/CalendarPage.swift
+++ b/apps/ios/Brett/Views/Calendar/CalendarPage.swift
@@ -103,8 +103,15 @@ private struct CalendarPageBody: View {
     /// filtered out (matches Google Calendar's default). Done in Swift
     /// rather than the predicate so a future "show declined" toggle can
     /// flip without re-initing the @Query.
+    ///
+    /// Events the user organized stay visible even when declined. Google
+    /// Calendar behaves the same way — "Hide declined events" never hides
+    /// events you organized, because declining your own event is unusual
+    /// and the user almost always still wants to see it on their calendar.
     private var visibleEvents: [CalendarEvent] {
-        events.filter { $0.myResponseStatus != CalendarRsvpStatus.declined.rawValue }
+        events.filter {
+            $0.myResponseStatus != CalendarRsvpStatus.declined.rawValue || $0.isOrganizer
+        }
     }
 
     /// Pure helper — public for test access. Given the currently-selected

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -423,10 +423,12 @@ private struct TodayPageBody: View {
         let start = calendar.startOfDay(for: Date())
         let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start.addingTimeInterval(86_400)
         // Hide events the user declined — matches Google Calendar's default.
+        // Events the user organized stay visible even when declined; Google
+        // Calendar never hides organizer-owned events from "Hide declined".
         return events.filter {
             $0.startTime >= start
                 && $0.startTime < end
-                && $0.myResponseStatus != CalendarRsvpStatus.declined.rawValue
+                && ($0.myResponseStatus != CalendarRsvpStatus.declined.rawValue || $0.isOrganizer)
         }
     }
 
@@ -440,7 +442,7 @@ private struct TodayPageBody: View {
         let now = Date()
         return events.first {
             $0.startTime > now.addingTimeInterval(-60)
-                && $0.myResponseStatus != CalendarRsvpStatus.declined.rawValue
+                && ($0.myResponseStatus != CalendarRsvpStatus.declined.rawValue || $0.isOrganizer)
         }
     }
 

--- a/apps/ios/BrettTests/Models/CalendarEventOrganizerTests.swift
+++ b/apps/ios/BrettTests/Models/CalendarEventOrganizerTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Pins the contract for `CalendarEvent.isOrganizer`. Read by the
+/// timeline filters in `CalendarPage.visibleEvents`,
+/// `TodayPage.todaysEvents`, and `TodayPage.nextUpcomingEvent` so a
+/// user-organized event stays visible even when declined — matches
+/// Google Calendar's behaviour of never hiding events you organized
+/// from "Hide declined events".
+///
+/// The category of bug these tests guard against: events the user
+/// organized (with or without other attendees) silently disappearing
+/// from every list surface because of an over-broad declined filter.
+@Suite("CalendarEvent.isOrganizer", .tags(.models))
+struct CalendarEventOrganizerTests {
+
+    @Test func selfTrueOrganizerIsTrue() {
+        let event = makeEvent(organizerJSON: #"{"email":"you@example.com","self":true}"#)
+        #expect(event.isOrganizer == true)
+    }
+
+    @Test func selfFalseOrganizerIsFalse() {
+        let event = makeEvent(organizerJSON: #"{"email":"alice@example.com","self":false}"#)
+        #expect(event.isOrganizer == false)
+    }
+
+    @Test func missingSelfFieldIsFalse() {
+        // Google's API only includes `self: true` when it applies; a
+        // missing `self` field means not me. Treat as false so a
+        // declined event from a shared calendar (where organizer info
+        // simply doesn't spell out `self: false`) stays hidden.
+        let event = makeEvent(organizerJSON: #"{"email":"alice@example.com"}"#)
+        #expect(event.isOrganizer == false)
+    }
+
+    @Test func nilOrganizerIsFalse() {
+        let event = makeEvent(organizerJSON: nil)
+        #expect(event.isOrganizer == false)
+    }
+
+    @Test func malformedOrganizerJSONIsFalse() {
+        let event = makeEvent(organizerJSON: "not-json")
+        #expect(event.isOrganizer == false)
+    }
+
+    @Test func filteringDeclinedKeepsOrganizerOwnedEvents() {
+        // The user-facing behaviour the bug report cares about: feeding
+        // a mixed list into a `myResponseStatus != declined || isOrganizer`
+        // filter keeps the user's own declined events visible while
+        // hiding declined invitations from others.
+        let myDeclined = makeEvent(
+            myResponseStatus: .declined,
+            organizerJSON: #"{"email":"you@example.com","self":true}"#
+        )
+        let theirDeclined = makeEvent(
+            myResponseStatus: .declined,
+            organizerJSON: #"{"email":"alice@example.com","self":false}"#
+        )
+        let theirAccepted = makeEvent(
+            myResponseStatus: .accepted,
+            organizerJSON: #"{"email":"alice@example.com","self":false}"#
+        )
+
+        let visible = [myDeclined, theirDeclined, theirAccepted].filter {
+            $0.myResponseStatus != CalendarRsvpStatus.declined.rawValue || $0.isOrganizer
+        }
+
+        #expect(visible.count == 2)
+        #expect(visible.contains { $0.id == myDeclined.id })
+        #expect(visible.contains { $0.id == theirAccepted.id })
+        #expect(!visible.contains { $0.id == theirDeclined.id })
+    }
+
+    private func makeEvent(
+        myResponseStatus: CalendarRsvpStatus = .needsAction,
+        organizerJSON: String? = nil
+    ) -> CalendarEvent {
+        let event = CalendarEvent(
+            id: UUID().uuidString,
+            userId: "u1",
+            googleAccountId: "ga1",
+            calendarListId: "cal1",
+            googleEventId: UUID().uuidString,
+            title: "Event",
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 3600),
+            myResponseStatus: myResponseStatus
+        )
+        event.organizerJSON = organizerJSON
+        return event
+    }
+}

--- a/packages/business/src/__tests__/calendar-validation.test.ts
+++ b/packages/business/src/__tests__/calendar-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateRsvpInput, validateCalendarNoteInput } from "../calendar-validation";
+import { validateRsvpInput, validateCalendarNoteInput, isHiddenDeclined } from "../calendar-validation";
 
 describe("validateRsvpInput", () => {
   it("accepts valid RSVP with status only", () => {
@@ -43,5 +43,75 @@ describe("validateCalendarNoteInput", () => {
   it("rejects content over 50KB", () => {
     const result = validateCalendarNoteInput({ content: "x".repeat(50 * 1024 + 1) });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("isHiddenDeclined", () => {
+  // Pins the timeline-visibility rule shared by every list/timeline
+  // surface (desktop sidebar, today, main calendar; iOS Today, Calendar,
+  // Next Up). The rule mirrors Google Calendar: declined events are
+  // hidden EXCEPT when the user organized them — declining your own
+  // event is unusual and the user almost always still wants to see it.
+  it("hides events the user declined and someone else organized", () => {
+    expect(
+      isHiddenDeclined({
+        myResponseStatus: "declined",
+        organizer: { name: "Alice", email: "alice@example.com", self: false },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps declined events the user organized visible", () => {
+    // The bug this guards against: events you created (e.g. a solo
+    // focus block you later said 'no' to) silently disappearing from
+    // your own calendar.
+    expect(
+      isHiddenDeclined({
+        myResponseStatus: "declined",
+        organizer: { name: "You", email: "you@example.com", self: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats declined-with-no-organizer-info as hidden (defensive)", () => {
+    // If we have no organizer info we can't prove ownership — fall back
+    // to the declined-hide default rather than silently leaking.
+    expect(
+      isHiddenDeclined({
+        myResponseStatus: "declined",
+        organizer: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps non-declined events visible regardless of organizer", () => {
+    for (const status of ["accepted", "tentative", "needsAction"] as const) {
+      expect(
+        isHiddenDeclined({
+          myResponseStatus: status,
+          organizer: { name: "Alice", email: "alice@example.com", self: false },
+        }),
+      ).toBe(false);
+      expect(
+        isHiddenDeclined({
+          myResponseStatus: status,
+          organizer: { name: "You", email: "you@example.com", self: true },
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("treats organizer.self omitted as not-organizer (matches Google API absent-default)", () => {
+    // Google's Calendar API only sets `self: true` when the organizer
+    // matches the calendar this copy of the event lives on. Missing /
+    // undefined `self` means "not me" — treat as such, otherwise we'd
+    // un-hide every declined event from a shared calendar where the
+    // organizer info merely doesn't bother to spell out `self: false`.
+    expect(
+      isHiddenDeclined({
+        myResponseStatus: "declined",
+        organizer: { name: "Someone", email: "someone@example.com" },
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/business/src/calendar-validation.ts
+++ b/packages/business/src/calendar-validation.ts
@@ -1,4 +1,4 @@
-import type { RsvpInput, CalendarEventNoteInput } from "@brett/types";
+import type { RsvpInput, CalendarEventNoteInput, CalendarEventRecord } from "@brett/types";
 
 const VALID_RSVP_STATUSES = ["accepted", "declined", "tentative", "needsAction"];
 const MAX_COMMENT_LENGTH = 500;
@@ -24,4 +24,26 @@ export function validateCalendarNoteInput(input: CalendarEventNoteInput): Valida
     return { ok: false, error: `content must be ${MAX_NOTE_SIZE} bytes or fewer` };
   }
   return { ok: true, data: input };
+}
+
+/**
+ * Whether an event should be hidden from a timeline because the user
+ * declined it.
+ *
+ * Mirrors Google Calendar's "Hide declined events" default: events the
+ * user explicitly declined are hidden, but events the user organized
+ * stay visible regardless of declined status. Declining your own event
+ * is unusual — most users still want to see it on their calendar (e.g.
+ * because they're hosting it for others, or as a placeholder they
+ * might re-accept later).
+ *
+ * Pass any object that exposes `myResponseStatus` and `organizer.self`
+ * — both `CalendarEventRecord` and `CalendarEventDisplay`-shaped values
+ * fit. Returns `true` when the timeline should hide the event.
+ */
+export function isHiddenDeclined(
+  event: Pick<CalendarEventRecord, "myResponseStatus" | "organizer">
+): boolean {
+  if (event.myResponseStatus !== "declined") return false;
+  return event.organizer?.self !== true;
 }

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -895,7 +895,7 @@ export function detectUrl(input: string): { isUrl: true; url: string } | { isUrl
 
 // ── Calendar validation ──
 
-export { validateRsvpInput, validateCalendarNoteInput } from "./calendar-validation";
+export { validateRsvpInput, validateCalendarNoteInput, isHiddenDeclined } from "./calendar-validation";
 
 // ── Things 3 Import validation ──
 


### PR DESCRIPTION
Closes #131

## Root cause

PR `d4a8f81` ("hide declined events to match Google Calendar default") added `myResponseStatus !== "declined"` filters to every timeline surface (desktop sidebar, today, main calendar; iOS Today, Calendar, Next Up). That correctly hides invitations the user declined — but it also hides events the user *organized* and then declined themselves.

The reporter's exact wording: *"Missing events I created with no attendees. Those should show."*

Two real-world paths produce a declined organizer-owned event:

1. The user creates an event with a single self-attendee row (Google sometimes auto-adds the organizer when you save the event), later RSVPs No to it as a placeholder, but keeps the event on their calendar. Pre-`d4a8f81` it stayed visible; after the fix it silently disappears.
2. The user organized a meeting, declined themselves because they can't make it personally, but is still hosting it for others / wants the time slot blocked. Same disappearance.

Google Calendar itself doesn't hide organizer-owned events from the "Hide declined events" toggle — declining your own event is rare enough that the user almost always still wants to see it.

## Approach

Three options considered:

1. **Filter "declined" only when the user did NOT organize the event** (chosen). Matches Google Calendar's actual behavior; the simplest semantic that keeps the original fix's intent intact for the common case (declined invitations from others).
2. Add a "show declined" toggle in Settings. Higher effort; the existing `myResponseStatus !== "declined"` filter site is already in 5 different files, so building a setting + plumbing it through every surface is overkill for a bug whose correct default is unambiguous.
3. Stop hiding declined events entirely (revert `d4a8f81`). Loses the user-affirming behavior of `d4a8f81`. The reporter explicitly likes the `d4a8f81` behavior — they just want the organizer carve-out.

Option 1 also matches the existing data we have: the server already computes `event.organizer.self === true` for events the user organized (see `apps/api/src/services/calendar-sync.ts` line 519). No new server work, no schema change, no migration.

## Implementation

Single-source-of-truth helper in `@brett/business`:

```ts
export function isHiddenDeclined(
  event: Pick<CalendarEventRecord, "myResponseStatus" | "organizer">
): boolean {
  if (event.myResponseStatus !== "declined") return false;
  return event.organizer?.self !== true;
}
```

iOS gets its own typed `CalendarEvent.isOrganizer` computed property since Swift can't import the JS helper:

```swift
var isOrganizer: Bool {
    (organizer?["self"] as? Bool) == true
}
```

Then every filter site updated:

| Surface | Before | After |
|---|---|---|
| `apps/desktop/src/App.tsx` sidebar | `e.myResponseStatus !== "declined"` | `!isHiddenDeclined(e)` |
| `apps/desktop/src/App.tsx` today | `e.myResponseStatus !== "declined"` | `!isHiddenDeclined(e)` |
| `apps/desktop/src/pages/CalendarPage.tsx` | `e.myResponseStatus !== "declined"` | `!isHiddenDeclined(e)` |
| `apps/ios/.../CalendarPage.visibleEvents` | `myResponseStatus != .declined` | `myResponseStatus != .declined \|\| isOrganizer` |
| `apps/ios/.../TodayPage.todaysEvents` | `myResponseStatus != .declined` | `myResponseStatus != .declined \|\| isOrganizer` |
| `apps/ios/.../TodayPage.nextUpcomingEvent` | `myResponseStatus != .declined` | `myResponseStatus != .declined \|\| isOrganizer` |

## Tests

Added 5 tests for `isHiddenDeclined` in `packages/business/src/__tests__/calendar-validation.test.ts`:

- `hides events the user declined and someone else organized` — preserves `d4a8f81`'s intent
- `keeps declined events the user organized visible` — direct guard for the bug
- `treats declined-with-no-organizer-info as hidden (defensive)` — null organizer falls back to hide
- `keeps non-declined events visible regardless of organizer` — covers the (status × organizer) matrix
- `treats organizer.self omitted as not-organizer` — Google API absent-default semantics

Added 6 tests for `CalendarEvent.isOrganizer` in `apps/ios/BrettTests/Models/CalendarEventOrganizerTests.swift`:

- `selfTrueOrganizerIsTrue` / `selfFalseOrganizerIsFalse` — happy paths
- `missingSelfFieldIsFalse` / `nilOrganizerIsFalse` / `malformedOrganizerJSONIsFalse` — defensive defaults
- `filteringDeclinedKeepsOrganizerOwnedEvents` — end-to-end behaviour: a mixed list of `[my-declined, their-declined, their-accepted]` filtered with the new predicate keeps the right two and hides the right one

**Test-prevention reflection:** could a test have caught this bug? Yes — `keeps declined events the user organized visible` fails against the pre-PR filter for every variant of the data. Adding tests for the *category* (declined + organizer matrix) also guards against future regressions where someone tightens the filter again without thinking through organizer events.

## Verification

- `pnpm --filter @brett/business test` — 212 passed (212), including the 5 new ones
- `pnpm --filter @brett/business typecheck` — clean
- `pnpm --filter @brett/desktop typecheck` — clean (after building `@brett/ui` first to populate `.d.ts` cache)
- Pre-existing `@brett/api-core` `prisma.ts` typecheck errors are present on `main` and unrelated to this change.
- Swift toolchain not available on this Linux agent runner. CI does not build iOS. Please run `Brett` scheme tests in Xcode (or on a Mac runner) before merging. The new test suite auto-registers via XcodeGen.

## Self-review findings

1. First pass put `isHiddenDeclined` as a private helper in `apps/desktop/src/api/calendar.ts`. On review — it's the same predicate iOS needs (semantically) and is pure domain logic. Moved to `@brett/business/calendar-validation.ts` so there's one source of truth for the rule. iOS still has its own implementation because Swift can't import JS, but the test contract pins the same behaviour on both.
2. The `Pick<CalendarEventRecord, "myResponseStatus" | "organizer">` parameter type lets the helper accept any compatible shape — both `CalendarEventRecord` and `CalendarEventDetail` (which extends `CalendarEventRecord`) work without coercion.
3. iOS `isOrganizer` defensively returns `false` for nil organizer JSON and missing `self` field, matching the test expectations. A cast failure (e.g. `self: 1` instead of `true`) also returns false rather than crashing.
4. Considered making `myResponseStatus !== "declined" || isOrganizer` an inline expression at every site rather than extracting a helper. Five call sites with the same predicate is the kind of duplication that drifts — better to centralize, especially given the reasoning for the carve-out is non-obvious.
5. Multi-user safety: no `userId` scoping concerns — purely per-event display.
6. Backwards-compatible: API unchanged. The wire format still ships `myResponseStatus = "declined"` for declined events; only the client-side filter changes.
7. iOS ↔ desktop parity: both clients now apply the same rule. No drift.
8. Searched for every other `myResponseStatus` reference in the codebase; only AI / intelligence filters use `myResponseStatus !== "observer"` (different rule) and the RSVP UI reads it for badge display. No other timeline filters need updating.

## Risks / follow-ups

- **Risk:** for events created on a *secondary* calendar (where the user is the calendar owner but not necessarily the organizer email), Google's `organizer.self` may be `true` if the organizer email matches the calendar's email, but `false` if it doesn't. Edge case — out of scope for this bug.
- **Risk:** if Google ever changes the meaning of `organizer.self`, the carve-out drifts. Documented in the helper's docstring; the `treats organizer.self omitted as not-organizer` test pins the expected behaviour.
- **Follow-up (out of scope):** if Brent later wants a "show declined" toggle in Settings, the helper is the natural extension point — add a `showDeclined?: boolean` parameter and short-circuit when true.

---
Generated by [Claude Code](https://claude.ai/code/session_01BLNjV5WCHB8pfcbLdv7mxA)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLNjV5WCHB8pfcbLdv7mxA)_