### PR TITLE
fix(ios-auth): refreshIfStale must not signOut when currentUser is nil (#134)

### DIFF
--- a/apps/desktop/src/lib/diagnostics.ts
+++ b/apps/desktop/src/lib/diagnostics.ts
@@ -210,7 +210,7 @@ export function collectDiagnostics(electronVersion?: string): DiagnosticSnapshot
     consoleLogs: consoleLogs.snapshot(),
     failedApiCalls: failedApiCalls.snapshot(),
     breadcrumbs: breadcrumbs.snapshot(),
-    appVersion: import.meta.env.VITE_APP_VERSION || "unknown",
+    appVersion: __APP_VERSION__,
     electronVersion: electronVersion || "unknown",
     os: navigator.userAgent,
     currentRoute: window.location.pathname + window.location.hash,

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("./package.json");
 
 export default defineConfig({
   plugins: [react()],
+  // Mirror the `define` from vite.config.ts so `__APP_VERSION__` is
+  // substituted in test runs. Without this, modules that read the macro
+  // (diagnostics.ts, settings/UpdatesSection.tsx) ReferenceError at import.
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/apps/ios/Brett/Auth/AuthManager.swift
+++ b/apps/ios/Brett/Auth/AuthManager.swift
@@ -553,7 +553,19 @@ final class AuthManager {
             // plugin today (the token string stays the same across
             // extensions). If that changes in a future endpoint contract,
             // persist the new token here.
-            if session.user.id != currentUser?.id {
+            //
+            // currentUser is in-memory only and starts nil on every cold
+            // launch. If an earlier refreshCurrentUser hit a non-401
+            // transient error its silent catch leaves currentUser nil; the
+            // user-switch comparison below would then read `validId != nil`
+            // as TRUE and run signOut() with a full data wipe — the exact
+            // bug from issue #134. Treat nil as "haven't hydrated yet" and
+            // recover by fetching the full profile.
+            guard let existingId = currentUser?.id else {
+                await refreshCurrentUser()
+                return
+            }
+            if existingId != session.user.id {
                 // User id changed under us — full sign-out (including data
                 // wipe). This shouldn't happen but covers the case where
                 // the server reassigned the token to a different account,

--- a/apps/ios/Brett/Views/Shared/FeedbackSheet.swift
+++ b/apps/ios/Brett/Views/Shared/FeedbackSheet.swift
@@ -233,7 +233,15 @@ struct FeedbackSheet: View {
         }
     }
 
+    /// Marketing version + Fastlane-bumped build number.
+    /// `MARKETING_VERSION` is hardcoded at "1.0.0" today, so the build
+    /// number is the part that actually identifies which TestFlight upload
+    /// a reporter is on (`fastlane/Fastfile` sets it to one above the
+    /// highest TestFlight build for this marketing version).
     private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        let info = Bundle.main.infoDictionary
+        let marketing = info?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return "\(marketing) (\(build))"
     }
 }

--- a/apps/ios/BrettTests/Auth/AuthManagerTests.swift
+++ b/apps/ios/BrettTests/Auth/AuthManagerTests.swift
@@ -150,6 +150,74 @@ struct AuthManagerTests {
         #expect(itemCount() == 2, "cold-launch 401 must NOT wipe local data — that was the regression")
     }
 
+    /// **Regression guard for the silent cold-launch user-switch race.**
+    ///
+    /// The setup that bites:
+    ///   1. Cold launch — fresh `AuthManager`, token in keychain,
+    ///      `currentUser == nil` (in-memory only, never persisted).
+    ///   2. `hydrateFromKeychain` reads the token and calls
+    ///      `refreshCurrentUser`.
+    ///   3. `/users/me` hits a transient *non-401* error (timeout, weak
+    ///      signal, DNS hiccup). `refreshCurrentUser` falls into the silent
+    ///      catch-all — `currentUser` stays nil, `hasSuccessfullyRefreshed`
+    ///      stays false.
+    ///   4. Network recovers. The scene-active hook fires `refreshIfStale`.
+    ///   5. `/api/auth/ios/session` returns 200 with the user's real id.
+    ///   6. The bug: `if session.user.id != currentUser?.id` evaluates as
+    ///      `"u1" != nil` → TRUE → `signOut()` runs → keychain wiped,
+    ///      SwiftData wiped, user dumped to SignInView with no data.
+    ///
+    /// The intent of that comparison is "detect a token reassigned to a
+    /// different account." A nil `currentUser` is "we never managed to
+    /// hydrate this process," not "user switched." Recovery path: fetch
+    /// the full profile via `refreshCurrentUser`, leave data alone.
+    @Test func refreshIfStaleWithNilCurrentUserDoesNotSignOut() async throws {
+        resetState()
+        defer { resetState() }
+
+        let (mgr, client) = makeTestManager()
+
+        // Reproduce step (1)–(3): keychain token + transient /users/me failure.
+        try KeychainStore.writeToken("tok-cold")
+        MockURLProtocol.stub(url: usersMeURL(for: client), error: URLError(.notConnectedToInternet))
+        await mgr.hydrateFromKeychain(authContext: nil)
+
+        #expect(mgr.token == "tok-cold", "hydrate must load the keychain token")
+        #expect(mgr.currentUser == nil, "transient network error must leave currentUser nil")
+
+        seedItem(userId: "u1", title: "task A")
+        seedItem(userId: "u1", title: "task B")
+        #expect(itemCount() == 2)
+
+        // Step (4)–(5): network recovers, refreshIfStale gets a clean
+        // session response. Re-stubbing /users/me replaces the prior
+        // network-error stub so the recovery refreshCurrentUser call (added
+        // by the fix) succeeds. /api/auth/sign-out is stubbed so a
+        // regression that takes the buggy signOut path doesn't fail with a
+        // stub-not-found error and obscure the real assertion.
+        MockURLProtocol.stub(
+            url: iosSessionURL(for: client),
+            statusCode: 200,
+            body: validIOSSessionBody(token: "tok-cold", userId: "u1", email: "a@b.com")
+        )
+        MockURLProtocol.stub(
+            url: usersMeURL(for: client),
+            statusCode: 200,
+            body: validUserMeBody(id: "u1", email: "a@b.com")
+        )
+        MockURLProtocol.stub(url: signOutURL(for: client), statusCode: 200, body: Data())
+
+        await mgr.refreshIfStale(threshold: 0)
+
+        #expect(mgr.token == "tok-cold",
+                "session-success on a nil-currentUser must NOT trigger signOut")
+        #expect(mgr.currentUser?.id == "u1",
+                "fix should hydrate currentUser from the recovery refresh")
+        #expect(mgr.isAuthenticated)
+        #expect(itemCount() == 2,
+                "data must NOT be wiped — that was the original bug")
+    }
+
     /// Mirror of the above for the foreground-keepalive path
     /// (`refreshIfStale` → `/api/auth/ios/session`). Both refresh paths
     /// fire on cold launch so both need the lenience gate.


### PR DESCRIPTION
Closes #134.

## Root cause

[`AuthManager.refreshIfStale`](apps/ios/Brett/Auth/AuthManager.swift) ran `signOut()` — with full SwiftData wipe — whenever `currentUser` was nil at session-success time. Because `currentUser` is in-memory only and starts nil on every cold launch, a single transient non-401 error from the earlier `refreshCurrentUser` call was enough to set up the trap. Once the network recovered, the next `refreshIfStale` evaluated ``"validId" != currentUser?.id`` as ``"validId" != nil`` → TRUE → user-switch detected → keychain wiped + SwiftData wiped + back to SignInView.

The full race:

1. Cold launch → fresh `AuthManager`, token in keychain, `currentUser == nil`, `hasSuccessfullyRefreshed == false`.
2. `hydrateFromKeychain(authContext: nil)` reads the token and calls `refreshCurrentUser()`.
3. `/users/me` returns a transient non-401 (timeout, weak signal, DNS hiccup). `refreshCurrentUser`'s catch-all silently returns. `currentUser` stays nil.
4. Network recovers. Scene-active hook calls `refreshIfStale()`.
5. `/api/auth/ios/session` returns 200. `session.user.id != currentUser?.id` is `"u1" != nil` → TRUE → `signOut()` runs → data wipe.

The 401 path got cold-launch lenience added in #111/#121/#123. The success path didn't. No test covered this combination.

## Fix

Treat `currentUser == nil` as "profile not hydrated yet" rather than "user switched":

```swift
guard let existingId = currentUser?.id else {
    await refreshCurrentUser()
    return
}
if existingId != session.user.id {
    BrettLog.auth.error("Session endpoint returned different user id — signing out")
    await signOut()
}
```

The original user-switch defense still fires when there genuinely is a stale `currentUser` to compare against.

## Test

`refreshIfStaleWithNilCurrentUserDoesNotSignOut` reproduces the exact race: writes a keychain token, stubs `/users/me` to throw `URLError(.notConnectedToInternet)`, hydrates (which leaves currentUser nil), then re-stubs to make the recovery succeed and runs `refreshIfStale`. Asserts token, currentUser, and SwiftData all survive. Verified loudly failing before the fix (4 expectation failures matching the symptom), passing after. Full `AuthManagerTests` suite is 26/26 green.

## Bug-report telemetry: now actually useful

Issue #134 reported `App Version: 1.0.0`. That's `MARKETING_VERSION` (hardcoded), with the Fastlane-bumped `CURRENT_PROJECT_VERSION` (the part that varies per TestFlight upload) thrown away. Two fixes:

- **iOS** — `FeedbackSheet` now sends ``"1.0.0 (47)"``. Build number identifies the TestFlight upload.
- **Desktop** — `diagnostics.ts` was reading `import.meta.env.VITE_APP_VERSION`, which is set nowhere; every desktop bug report said `"unknown"`. Swapped for `__APP_VERSION__`, the macro [vite.config.ts:28](apps/desktop/vite.config.ts:28) injects from `package.json`. Mirror the `define` in `vitest.config.ts` so tests don't ReferenceError.

## Security & risk notes

- **Auth/infra change** — `signOut()` is the most destructive path in the app (keychain wipe + SwiftData wipe). Risk surface is the new `guard let existingId = currentUser?.id` branch: the test pins the recovery path, and the original user-switch comparison is preserved when `currentUser` is non-nil. Worth a fresh-eyes review on `refreshIfStale` specifically.
- No API changes. No schema changes. iOS-only behavior change ships when next TestFlight build is cut; desktop change ships in next desktop release.

## Pre-existing typecheck breakage (NOT introduced here)

`pnpm --filter @brett/desktop typecheck` fails on `apps/desktop/src/views/UpcomingView.tsx` with implicit-any errors (lines 31/42/92/102). Verified those errors exist on `origin/main` HEAD without this PR's diff applied. Not addressed here so this PR stays scoped to the auth bug + bug-report telemetry, but worth a follow-up.

## Test plan

- [x] Local: `xcodebuild test -only-testing:BrettTests/AuthManagerTests` → 26/26 pass.
- [x] Local: `pnpm --filter @brett/desktop test src/lib/__tests__/diagnostics.test.ts` → 31/31 pass.
- [ ] Cut a TestFlight build, confirm bug-report submission shows ``"1.0.0 (<build>)"``.
- [ ] Cut a desktop release, confirm bug-report submission shows the actual `package.json` version instead of `"unknown"`.
- [ ] Hard-kill the iOS app on a poor network, foreground it (so `/users/me` fails transiently), then move to good network and foreground again. Should NOT sign out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)