### PR TITLE
fix: align WeekStrip day labels and event dots on today's cell (#137)

### DIFF
--- a/apps/ios/Brett/Views/Calendar/WeekStrip.swift
+++ b/apps/ios/Brett/Views/Calendar/WeekStrip.swift
@@ -71,6 +71,7 @@ struct WeekStrip: View {
                         .font(.system(size: 15, weight: isToday ? .bold : .regular))
                         .foregroundStyle(isToday ? .black : Color.white.opacity(isSelected ? 1.0 : 0.85))
                 }
+                .frame(width: 34, height: 34)
 
                 HStack(spacing: 3) {
                     if dots.isEmpty {


### PR DESCRIPTION
Closes #137

## Root cause

In `apps/ios/Brett/Views/Calendar/WeekStrip.swift`, the `dayCell` view stacks three rows in a VStack:

1. Weekday label ("M", "T", …)
2. A ZStack with the day-number — and, for today/selected, a 34pt circle behind it
3. A 4pt-tall row of event-indicator dots

The ZStack had no explicit frame. When today's gold circle (or the selected-day translucent circle) was present, the ZStack measured 34pt tall. On regular days the ZStack only contained the day-number text, so it measured ~18pt tall. Inside the surrounding `HStack(spacing: 0)`, cells of unequal height center-align by default (`HStack`'s default vertical alignment is `.center`), so today's cell was 16pt taller and ended up:

- Day-label sitting higher than the labels on neighbouring cells
- Event dots sitting lower than the dots on neighbouring cells

That's the misalignment in the screenshot.

## Approach

Three options I considered:

1. **Pin the ZStack to 34x34 on every cell.** Every day reserves the same day-number slot regardless of whether a circle is drawn. Day-label above and dot-row below land on identical y-positions. Minimal surface area — one `.frame(width: 34, height: 34)`.
2. Add an invisible 34pt placeholder circle to non-today cells. Same visual outcome but more code, and easier to drift later.
3. Add `.frame(height: 34)` to the outer VStack. Wrong layer — would resize the whole cell including label and dots, with unintended effects.

Picked option 1.

## Diff

```swift
                ZStack {
                    if isToday {
                        Circle().fill(BrettColors.gold).frame(width: 34, height: 34)
                    } else if isSelected {
                        Circle().fill(Color.white.opacity(0.15)).frame(width: 34, height: 34)
                    }
                    Text("\(calendar.component(.day, from: day))")
                        .font(.system(size: 15, weight: isToday ? .bold : .regular))
                        .foregroundStyle(isToday ? .black : Color.white.opacity(isSelected ? 1.0 : 0.85))
                }
+               .frame(width: 34, height: 34)
```

## Tests

UI-only change — no test added. Reason: this is a SwiftUI layout fix; a snapshot or assertion would either mirror the implementation (`.frame(...)` set to `.frame(...)`) without proving anything user-facing, or require a UI-test target that runs on a simulator. Verify visually via Xcode preview / on-device.

## Test-prevention reflection

A pragmatic test would not have caught this — the bug is about geometric alignment of three sibling rows in an HStack, which only shows up at render time. The category of "implicit layout drift when a conditional view changes a sibling's intrinsic size" is hard to assert without snapshot/UI tests, which are explicitly out of scope for this codebase.

## Verification

- `pnpm typecheck` / `pnpm test` not run: this is a Swift-only change in `apps/ios/`. The TS monorepo is unaffected; no Swift toolchain available in this environment.
- Visual verification pending — `gh pr checkout 137` (or the PR number) and run the iOS app; today's cell should align with neighbours.

## Risks / follow-ups

- None expected. The 34pt slot was already the rendered height for today and selected — this just makes the regular-day cell match.
- Only WeekStrip uses this pattern; no equivalent horizontal day-strip on desktop, so no parity work required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkU3TyLJiRSyJkJw91foos)_