### PR TITLE
fix(calendar): align /sync/pull with /calendar/events visibility filter

### DIFF
--- a/apps/api/prisma/migrations/20260506222541_cascade_calendar_visibility_to_events/migration.sql
+++ b/apps/api/prisma/migrations/20260506222541_cascade_calendar_visibility_to_events/migration.sql
@@ -1,0 +1,29 @@
+-- One-time cleanup for the calendar-visibility cascade.
+--
+-- Background: until this release, /sync/pull (used by iOS) ignored the
+-- CalendarList.isVisible flag — only /calendar/events (used by desktop)
+-- respected it. iOS therefore replicated events from calendars the user
+-- had hidden via the visibility toggle, and showed them on the timeline
+-- where desktop did not.
+--
+-- The code change adds the visibility filter to /sync/pull. But that
+-- filter alone only gates *future* upserts; rows already replicated to
+-- iOS clients persist locally. Toggling a calendar from visible→hidden
+-- now cascades a soft-delete (PATCH /calendar/accounts/.../calendars/...
+-- in calendar-accounts.ts) so the next /sync/pull emits tombstones and
+-- iOS evicts them. This migration applies the same cascade once for
+-- calendars that were ALREADY hidden at deploy time — without it,
+-- existing iOS users keep seeing leaked events forever.
+--
+-- Safety: only soft-deletes events whose parent CalendarList is
+-- isVisible=false AND aren't already tombstoned. Idempotent — a re-run
+-- is a no-op. Reversible via the toggle: re-showing a calendar clears
+-- the syncToken and the next incrementalSync's upsertEvents path
+-- restores deletedAt=null on rows Google still has.
+
+UPDATE "CalendarEvent"
+SET "deletedAt" = NOW(), "updatedAt" = NOW()
+WHERE "calendarListId" IN (
+  SELECT id FROM "CalendarList" WHERE "isVisible" = false
+)
+AND "deletedAt" IS NULL;

--- a/apps/api/src/__tests__/calendar-accounts.test.ts
+++ b/apps/api/src/__tests__/calendar-accounts.test.ts
@@ -3,6 +3,11 @@ import { prisma } from "../lib/prisma.js";
 import { createRelinkTask } from "../lib/connection-health.js";
 import { encryptToken } from "../lib/encryption.js";
 import { createTestUser, authRequest } from "./helpers.js";
+import { generateId } from "@brett/utils";
+
+// Required for encryptToken used by the GoogleAccount fixtures below.
+process.env.CALENDAR_TOKEN_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 describe("Calendar Accounts routes", () => {
   describe("DELETE /calendar/accounts/:id", () => {
@@ -53,6 +58,123 @@ describe("Calendar Accounts routes", () => {
         },
       });
       expect(activeAfter).toBeNull();
+    });
+  });
+
+  describe("PATCH /calendar/accounts/:accountId/calendars/:calId", () => {
+    it("hiding a calendar soft-deletes its events so iOS sync-pull tombstones them", async () => {
+      const user = await createTestUser("Vis Toggle User");
+
+      const accountId = generateId();
+      await prisma.googleAccount.create({
+        data: {
+          id: accountId,
+          userId: user.userId,
+          googleEmail: `vis-toggle-${accountId}@example.com`,
+          googleUserId: `google-vis-toggle-${accountId}`,
+          accessToken: encryptToken("fake-access-token"),
+          refreshToken: encryptToken("fake-refresh-token"),
+          tokenExpiresAt: new Date(Date.now() + 3600_000),
+        },
+      });
+
+      const calendarListId = generateId();
+      await prisma.calendarList.create({
+        data: {
+          id: calendarListId,
+          googleAccountId: accountId,
+          googleCalendarId: "vis-toggle-cal",
+          name: "Toggle Test",
+          color: "#4285f4",
+          isVisible: true,
+          isPrimary: true,
+        },
+      });
+
+      const eventId = generateId();
+      const now = new Date();
+      await prisma.calendarEvent.create({
+        data: {
+          id: eventId,
+          userId: user.userId,
+          googleAccountId: accountId,
+          calendarListId,
+          googleEventId: `vis-toggle-evt-${eventId}`,
+          title: "Should disappear when calendar hidden",
+          startTime: now,
+          endTime: new Date(now.getTime() + 3600_000),
+        },
+      });
+
+      // Toggle visibility off.
+      const res = await authRequest(
+        `/calendar/accounts/${accountId}/calendars/${calendarListId}`,
+        user.token,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ isVisible: false }),
+        },
+      );
+      expect(res.status).toBe(200);
+
+      // Bypass the soft-delete extension to assert the row was tombstoned
+      // rather than hard-deleted (sync-pull needs the tombstone to emit
+      // a delete to the iOS client).
+      const tombstoned = await prisma.calendarEvent.findFirst({
+        where: { id: eventId, deletedAt: { not: null } },
+      });
+      expect(tombstoned).not.toBeNull();
+      expect(tombstoned?.deletedAt).not.toBeNull();
+    });
+
+    it("re-showing a calendar clears syncToken so the next incrementalSync full-fetches", async () => {
+      const user = await createTestUser("Vis Restore User");
+
+      const accountId = generateId();
+      await prisma.googleAccount.create({
+        data: {
+          id: accountId,
+          userId: user.userId,
+          googleEmail: `vis-restore-${accountId}@example.com`,
+          googleUserId: `google-vis-restore-${accountId}`,
+          accessToken: encryptToken("fake-access-token"),
+          refreshToken: encryptToken("fake-refresh-token"),
+          tokenExpiresAt: new Date(Date.now() + 3600_000),
+        },
+      });
+
+      const calendarListId = generateId();
+      await prisma.calendarList.create({
+        data: {
+          id: calendarListId,
+          googleAccountId: accountId,
+          googleCalendarId: "vis-restore-cal",
+          name: "Restore Test",
+          color: "#4285f4",
+          isVisible: false, // already hidden
+          isPrimary: false,
+          syncToken: "stale-token-from-before-hide",
+        },
+      });
+
+      const res = await authRequest(
+        `/calendar/accounts/${accountId}/calendars/${calendarListId}`,
+        user.token,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ isVisible: true }),
+        },
+      );
+      expect(res.status).toBe(200);
+
+      const updated = await prisma.calendarList.findUnique({
+        where: { id: calendarListId },
+      });
+      expect(updated?.isVisible).toBe(true);
+      // Cleared so the next periodic incrementalSync does a full re-fetch
+      // from Google. Without this, an incremental fetch using the stale
+      // token would skip the events the user wants to see again.
+      expect(updated?.syncToken).toBeNull();
     });
   });
 });

--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -317,6 +317,93 @@ describe("POST /sync/pull", () => {
     expect(eventIds).toContain(recentEventId);
   });
 
+  it("excludes calendar events from invisible calendars (matches /calendar/events filter)", async () => {
+    clearAllRateLimits();
+
+    const visUser = await createTestUser("Visibility Sync User");
+
+    const googleAccountId = generateId();
+    await prisma.googleAccount.create({
+      data: {
+        id: googleAccountId,
+        userId: visUser.userId,
+        googleEmail: "vis-test@gmail.com",
+        googleUserId: `google-vis-${googleAccountId}`,
+        accessToken: encryptToken("fake-access-token"),
+        refreshToken: encryptToken("fake-refresh-token"),
+        tokenExpiresAt: new Date(Date.now() + 3600 * 1000),
+      },
+    });
+
+    // Two calendars: one visible (should sync), one hidden (should not).
+    const visibleCalId = generateId();
+    const hiddenCalId = generateId();
+    await prisma.calendarList.createMany({
+      data: [
+        {
+          id: visibleCalId,
+          googleAccountId,
+          googleCalendarId: "vis-primary",
+          name: "Mine",
+          color: "#4285f4",
+          isVisible: true,
+          isPrimary: true,
+        },
+        {
+          id: hiddenCalId,
+          googleAccountId,
+          googleCalendarId: "vis-shared",
+          name: "Shared (hidden)",
+          color: "#a142f4",
+          isVisible: false,
+          isPrimary: false,
+        },
+      ],
+    });
+
+    const visibleEventId = generateId();
+    const hiddenEventId = generateId();
+    const now = new Date();
+    await prisma.calendarEvent.createMany({
+      data: [
+        {
+          id: visibleEventId,
+          userId: visUser.userId,
+          googleAccountId,
+          calendarListId: visibleCalId,
+          googleEventId: `vis-evt-${visibleEventId}`,
+          title: "Visible event",
+          startTime: now,
+          endTime: new Date(now.getTime() + 3600 * 1000),
+        },
+        {
+          id: hiddenEventId,
+          userId: visUser.userId,
+          googleAccountId,
+          calendarListId: hiddenCalId,
+          googleEventId: `hid-evt-${hiddenEventId}`,
+          title: "Event on hidden calendar",
+          startTime: now,
+          endTime: new Date(now.getTime() + 3600 * 1000),
+        },
+      ],
+    });
+
+    const res = await authRequest("/sync/pull", visUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    const eventIds = body.changes.calendar_events.upserted.map((e: any) => e.id);
+    expect(eventIds).toContain(visibleEventId);
+    // Pre-fix: iOS replicated this row even though desktop's
+    // /calendar/events filter hides it. Post-fix: /sync/pull also
+    // applies the visibility filter so the two clients agree.
+    expect(eventIds).not.toContain(hiddenEventId);
+  });
+
   // ── On-demand sync filters (perf-driven hot/cold split) ──
 
   it("items filter: archived items are excluded from sync", async () => {

--- a/apps/api/src/lib/calendar-visibility.ts
+++ b/apps/api/src/lib/calendar-visibility.ts
@@ -1,0 +1,14 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * Where-clause fragment selecting only events on user-visible calendars.
+ *
+ * Shared between the REST `/calendar/events` endpoint (used by desktop)
+ * and the `/sync/pull` calendar_events branch (used by iOS) so the two
+ * clients agree on which events are user-visible. Without sharing the
+ * filter, iOS sync-pulls everything the user owns and silently shows
+ * events from calendars desktop has hidden via `CalendarList.isVisible`.
+ */
+export const eventsOnVisibleCalendars: Prisma.CalendarEventWhereInput = {
+  calendarList: { isVisible: true },
+};

--- a/apps/api/src/lib/calendar-visibility.ts
+++ b/apps/api/src/lib/calendar-visibility.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import type { Prisma } from "@brett/api-core";
 
 /**
  * Where-clause fragment selecting only events on user-visible calendars.

--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -9,7 +9,7 @@ import {
   stopWatch,
 } from "../lib/google-calendar.js";
 import { encryptToken } from "../lib/encryption.js";
-import { initialSync } from "../services/calendar-sync.js";
+import { initialSync, incrementalSync } from "../services/calendar-sync.js";
 import { resolveRelinkTask } from "../lib/connection-health.js";
 import { generateId } from "@brett/utils";
 import { google } from "googleapis";
@@ -328,11 +328,48 @@ calendarAccounts.patch("/:accountId/calendars/:calId", authMiddleware, async (c)
 
   const body = await c.req.json();
   const isVisible = typeof body.isVisible === "boolean" ? body.isVisible : calendar.isVisible;
+  const flipped = calendar.isVisible !== isVisible;
 
   const updated = await prisma.calendarList.update({
     where: { id: calendar.id },
     data: { isVisible },
   });
+
+  // Cascade visibility into the events table.
+  //
+  // Hide → soft-delete every event on the calendar. iOS clients pick up
+  // tombstones via /sync/pull and remove the events from their local
+  // cache; without this, sync-pull's `isVisible` filter only gates
+  // *future* events, leaving already-replicated rows behind forever.
+  //
+  // Show → clear the calendar's syncToken so the next incrementalSync
+  // does a full re-fetch from Google, then trigger the sync.
+  // `upsertEvents` clears `deletedAt` on the UPDATE branch, so events
+  // Google still has come back to life; events Google deleted during
+  // the hidden window stay tombstoned because they're never returned
+  // by the full fetch (Google omits hard-deleted events from
+  // `events.list` without a syncToken). Avoids zombie ghost entries
+  // a blanket un-soft-delete would create.
+  if (flipped) {
+    const now = new Date();
+    if (!isVisible) {
+      await prisma.calendarEvent.updateMany({
+        where: { calendarListId: calendar.id, deletedAt: null },
+        data: { deletedAt: now, updatedAt: now },
+      });
+    } else {
+      await prisma.calendarList.update({
+        where: { id: calendar.id },
+        data: { syncToken: null },
+      });
+      // Fire-and-forget — best-effort, not awaited so the PATCH stays
+      // snappy. If it fails (rate limit, network), the next periodic
+      // incrementalSync picks the cleared syncToken up and full-fetches.
+      incrementalSync(accountId).catch((err) => {
+        console.error("[calendar-accounts] post-toggle sync failed:", err);
+      });
+    }
+  }
 
   return c.json({
     id: updated.id,

--- a/apps/api/src/routes/calendar.ts
+++ b/apps/api/src/routes/calendar.ts
@@ -4,6 +4,7 @@ import { rateLimiter } from "../middleware/rate-limit.js";
 import { prisma } from "../lib/prisma.js";
 import { getCalendarClient, updateRsvp } from "../lib/google-calendar.js";
 import { onDemandFetch } from "../services/calendar-sync.js";
+import { eventsOnVisibleCalendars } from "../lib/calendar-visibility.js";
 import {
   validateRsvpInput,
   validateCalendarNoteInput,
@@ -59,24 +60,14 @@ calendar.get("/events", authMiddleware, async (c) => {
     return c.json({ error: "Invalid date format" }, 400);
   }
 
-  // Get visible calendar IDs for this user
-  const visibleCalendars = await prisma.calendarList.findMany({
-    where: {
-      googleAccount: { userId: user.id },
-      isVisible: true,
-    },
-    select: { id: true },
-  });
-
-  const calendarListIds = visibleCalendars.map((cal) => cal.id);
-  if (calendarListIds.length === 0) {
-    return c.json({ events: [] });
-  }
-
+  // Visibility filter is shared with /sync/pull via `eventsOnVisibleCalendars`
+  // so iOS and desktop see the same set of events. The relation filter
+  // replaces the previous two-step (fetch IDs → IN clause) with a single
+  // query — Prisma compiles it to a JOIN on `CalendarList.isVisible`.
   const events = await prisma.calendarEvent.findMany({
     where: {
       userId: user.id,
-      calendarListId: { in: calendarListIds },
+      ...eventsOnVisibleCalendars,
       startTime: { lte: end },
       endTime: { gte: start },
       status: { not: "cancelled" },

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -8,6 +8,7 @@ import { publishSSE } from "../lib/sse.js";
 import { detectContentType } from "@brett/utils";
 import { runExtraction } from "../lib/content-extractor.js";
 import { paginatedPull, parseCursor } from "../lib/sync/paginated-pull.js";
+import { eventsOnVisibleCalendars } from "../lib/calendar-visibility.js";
 import type {
   SyncPullRequest, SyncPullResponse, SyncTableChanges,
   SyncPushRequest, SyncPushResponse, SyncMutation, SyncMutationResult,
@@ -266,6 +267,11 @@ export const sync = new Hono<AuthEnv>()
       const extraWhere: Record<string, unknown> = {};
       if (table === "calendar_events") {
         extraWhere.startTime = { gte: fourteenDaysAgo, lte: fourteenDaysAhead };
+        // Match the /calendar/events REST filter so iOS and desktop agree
+        // on which events the user can see. Without this, sync-pull returns
+        // every event the user owns — including events on shared calendars
+        // the user has hidden via the calendar list visibility toggle.
+        Object.assign(extraWhere, eventsOnVisibleCalendars);
       } else if (table === "items") {
         // Active work + just-completed. Excludes archived entirely;
         // older done items are fetched on-demand via /things and via

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -586,7 +586,13 @@ export async function upsertEvents(
     // until resolveAttendeePhotos re-resolves them. myResponseStatus IS
     // updated from Google so RSVPs made outside Brett (Gmail, Calendar app,
     // phone) propagate.
-    const { attendees: _att, ...updateData } = eventData;
+    //
+    // Also clear `deletedAt`: events soft-deleted by the calendar
+    // visibility cascade (see PATCH /calendar/accounts/:id/calendars/:calId)
+    // get restored when the user re-shows the calendar and the next
+    // sync re-fetches them. Events Google has hard-deleted aren't in
+    // the fetch result, so they stay tombstoned naturally.
+    const { attendees: _att, ...updateData } = { ...eventData, deletedAt: null };
 
     const result = await prisma.calendarEvent.upsert({
       where: {


### PR DESCRIPTION
## Summary

iOS replicates calendar events via `/sync/pull` and was ignoring the `CalendarList.isVisible` flag — desktop's `/calendar/events` REST endpoint correctly filtered by it, causing the two clients to disagree on which events the user could see. Events on shared calendars the user had hidden via Settings → Calendar showed up on the iOS timeline but not on desktop.

The architectural answer to "why isn't this unified" is that it now *is* — both endpoints share the same Prisma `where` fragment (`eventsOnVisibleCalendars`). The transports stay separate (REST for desktop, replication for iOS) because they serve different use cases, but they agree on the filter.

## Changes

- **Shared filter helper** (`apps/api/src/lib/calendar-visibility.ts`) used by both endpoints
- **`/sync/pull`** applies the `isVisible` filter to the `calendar_events` branch — closes the iOS leak
- **`/calendar/events`** simplified to use the shared helper (single relation filter instead of two-step IN clause; same behavior)
- **PATCH visibility toggle** cascades:
  - **Hide** → soft-delete events on the calendar so iOS sync-pull tombstones them
  - **Show** → clear `syncToken` + kick `incrementalSync`. `upsertEvents` now clears `deletedAt` on the UPDATE branch so events Google still has come back; events Google deleted during the hidden window stay tombstoned (not in the fetch result, so never updated)
- **One-time migration** soft-deletes events on already-hidden calendars at deploy time so existing iOS users get cleaned up

## Test plan

- [x] `pnpm test` (API): 768 tests pass, 3 new (sync filter, hide cascade, show clears syncToken)
- [x] `pnpm typecheck` (monorepo): clean
- [x] Migration applied locally without warnings (soft-delete cascade is idempotent + reversible via the toggle)
- [ ] After merge: verify desktop calendar still shows the same events as before (no behavior change for desktop)
- [ ] After merge + iOS rebuild: verify previously-leaking shared calendar events disappear from the iOS timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)