### PR TITLE
fix(ios): cap calendar chip height so chips don't grow to end of day

### DIFF
--- a/apps/ios/Brett/Views/Calendar/DayTimeline.swift
+++ b/apps/ios/Brett/Views/Calendar/DayTimeline.swift
@@ -238,7 +238,19 @@ struct DayTimeline: View {
                 .padding(.vertical, 6)
                 Spacer()
             }
-            .frame(minHeight: max(height - 4, minHeight), alignment: .top)
+            // Use a fixed `height` (not `minHeight`) so the chip can't grow
+            // past its computed duration. The chip's HStack contains a
+            // vertical-fill `Rectangle` accent bar with no intrinsic height;
+            // when this frame had only a `minHeight`, the parent ZStack
+            // (sized to the full hour grid) proposed the grid's full height
+            // to the HStack, the Rectangle obligingly filled it, and every
+            // chip rendered from its `offset` down to the bottom of the
+            // visible window — regardless of the event's actual duration.
+            // PR #38 introduced the regression to fit a meta line; the fix
+            // is to keep PR #38's `minHeight` value as the floor (so short
+            // events with a meta line still fit their text inside the
+            // glass background) while pinning the upper bound to `height`.
+            .frame(height: max(height - 4, minHeight), alignment: .top)
             .background {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(.ultraThinMaterial)


### PR DESCRIPTION
## Summary

Every event on the iOS calendar timeline visually extended from its start time to the bottom of the visible window — a 12:30 PM 30-minute meeting drew a chip from 12:30 down to midnight. The "30min" subtitle text on the chip itself was correct (math right) and the event detail page showed the right time range — only the rendered chip background was wrong.

**Root cause:** [PR #38](https://github.com/brentbarkman/brett/pull/38) (commit 91f54a4, April 20) changed the chip's frame from `.frame(height:)` to `.frame(minHeight:)` so a short event with both a title and a meta line could grow to fit both. With only a minimum and no maximum, the frame became unbounded vertically. The chip's HStack contains a vertical-fill `Rectangle` accent bar with no intrinsic height; when the parent ZStack (sized to the full hour grid, ~1080pt) proposed its full height to the HStack, the Rectangle obligingly filled it, and every chip rendered from its `offset` down to the bottom of the grid.

**Fix:** Use `.frame(height:)` (fixed, not minimum) with PR #38's smart floor: `max(rawHeight - 4, chipMinHeight(hasMeta:))`. Short events still fit their meta line inside the glass background; long events render with their full duration; nothing grows past the computed height.

**Why the existing tests didn't catch it:** [`DayTimelineLayoutTests`](apps/ios/BrettTests/Views/DayTimelineLayoutTests.swift) tests `chipLayout` math (offset/height arithmetic). The bug was below the math — in the SwiftUI modifier choice. The math returned the right `height` value; the renderer just didn't honour the upper bound.

## Test plan

- [x] `xcodebuild test -only-testing:BrettTests` — all DayTimeline math tests still pass
- [x] iOS build clean
- [ ] After merge: install via TestFlight and verify chips render at their actual duration on the calendar timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)