### PR TITLE
fix(sync): let tombstones bypass calendar visibility filter

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -404,6 +404,75 @@ describe("POST /sync/pull", () => {
     expect(eventIds).not.toContain(hiddenEventId);
   });
 
+  it("emits tombstones for events on hidden calendars so iOS can purge them", async () => {
+    // Regression for the second iteration: the visibility filter was
+    // applied to BOTH the live AND the tombstone query, so iOS clients
+    // that already had a hidden-calendar event in local SwiftData never
+    // received the delete signal — the row would linger indefinitely
+    // even after the cascade soft-deleted it server-side. The fix moved
+    // the filter to `extraWhereLive` so tombstones bypass it.
+    clearAllRateLimits();
+
+    const tombUser = await createTestUser("Tombstone Visibility User");
+
+    const googleAccountId = generateId();
+    await prisma.googleAccount.create({
+      data: {
+        id: googleAccountId,
+        userId: tombUser.userId,
+        googleEmail: "tomb-test@gmail.com",
+        googleUserId: `google-tomb-${googleAccountId}`,
+        accessToken: encryptToken("fake-access-token"),
+        refreshToken: encryptToken("fake-refresh-token"),
+        tokenExpiresAt: new Date(Date.now() + 3600 * 1000),
+      },
+    });
+
+    // Hidden calendar with a soft-deleted event — mirrors the state the
+    // backfill migration produces for already-hidden calendars at deploy
+    // time, and the state the PATCH cascade produces on visibility toggle.
+    const hiddenCalId = generateId();
+    await prisma.calendarList.create({
+      data: {
+        id: hiddenCalId,
+        googleAccountId,
+        googleCalendarId: "tomb-shared",
+        name: "Hidden shared",
+        color: "#a142f4",
+        isVisible: false,
+        isPrimary: false,
+      },
+    });
+
+    const tombstonedEventId = generateId();
+    const now = new Date();
+    await prisma.calendarEvent.create({
+      data: {
+        id: tombstonedEventId,
+        userId: tombUser.userId,
+        googleAccountId,
+        calendarListId: hiddenCalId,
+        googleEventId: `tomb-evt-${tombstonedEventId}`,
+        title: "Tombstoned hidden-calendar event",
+        startTime: now,
+        endTime: new Date(now.getTime() + 3600 * 1000),
+        deletedAt: now,
+      },
+    });
+
+    const res = await authRequest("/sync/pull", tombUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    const upsertedIds = body.changes.calendar_events.upserted.map((e: any) => e.id);
+    const deletedIds: string[] = body.changes.calendar_events.deleted;
+    expect(upsertedIds).not.toContain(tombstonedEventId);
+    expect(deletedIds).toContain(tombstonedEventId);
+  });
+
   // ── On-demand sync filters (perf-driven hot/cold split) ──
 
   it("items filter: archived items are excluded from sync", async () => {

--- a/apps/api/src/lib/sync/paginated-pull.ts
+++ b/apps/api/src/lib/sync/paginated-pull.ts
@@ -93,10 +93,29 @@ export type PaginatedPullArgs = {
 
   /**
    * Additional Prisma `where` clauses, AND-layered onto `userId` and the
-   * cursor filter. Use to narrow by status, listId, etc. Do NOT include
-   * `deletedAt` here — internal logic owns that key.
+   * cursor filter for BOTH the live query AND the tombstone query.
+   * Use to narrow by criteria that apply to both states (e.g. time
+   * range — we don't want tombstones outside the visible window). Do
+   * NOT include `deletedAt` here — internal logic owns that key.
+   *
+   * For filters that should ONLY constrain live rows (e.g. relation
+   * filters where the relation may be invalid for soft-deleted rows,
+   * or visibility flags whose toggle-off cascades a soft-delete and so
+   * the tombstone needs to escape the filter), pass `extraWhereLive`.
    */
   extraWhere?: Record<string, unknown>;
+
+  /**
+   * Additional Prisma `where` clauses applied ONLY to the live query
+   * — never to the tombstone query. Use for filters where the
+   * tombstone needs to escape the constraint so the client can still
+   * receive the delete signal. Example: calendar event visibility —
+   * an event on a calendar the user has hidden is soft-deleted by the
+   * cascade, but if the visibility filter were applied to the
+   * tombstone query, iOS would never see the deletion and the event
+   * would linger in local storage forever.
+   */
+  extraWhereLive?: Record<string, unknown>;
 
   /**
    * If true (default), tombstones are merged into the keyset stream and
@@ -187,7 +206,16 @@ function compareKeyset(a: { updatedAt: Date; id: string }, b: { updatedAt: Date;
 export async function paginatedPull<
   T extends { id: string; updatedAt: Date; deletedAt: Date | null },
 >(args: PaginatedPullArgs): Promise<PaginatedPullResult<T>> {
-  const { prismaModel, prismaClient, userId, cursor, limit, extraWhere = {}, includeTombstones = true } = args;
+  const {
+    prismaModel,
+    prismaClient,
+    userId,
+    cursor,
+    limit,
+    extraWhere = {},
+    extraWhereLive = {},
+    includeTombstones = true,
+  } = args;
 
   if (!Number.isInteger(limit) || limit < 1) {
     throw new Error(`paginatedPull: limit must be a positive integer (got ${limit})`);
@@ -195,18 +223,18 @@ export async function paginatedPull<
   if (!userId) {
     throw new Error("paginatedPull: userId is required");
   }
-  if ("deletedAt" in extraWhere) {
+  if ("deletedAt" in extraWhere || "deletedAt" in extraWhereLive) {
     // Reserve `deletedAt` ownership — it's how we bypass the soft-delete
     // extension for the tombstone query. A caller passing it would
     // either be clobbered (silent) or break the bypass (insidious).
-    throw new Error("paginatedPull: extraWhere must not include `deletedAt`");
+    throw new Error("paginatedPull: extraWhere/extraWhereLive must not include `deletedAt`");
   }
-  if ("userId" in extraWhere) {
+  if ("userId" in extraWhere || "userId" in extraWhereLive) {
     // Reserve `userId` ownership. If a caller passes a different userId,
     // the wrap below would still apply — and we'd happily query someone
     // else's rows. Fail loud rather than expose a defense-in-depth hole
     // for a future refactor.
-    throw new Error("paginatedPull: extraWhere must not include `userId`");
+    throw new Error("paginatedPull: extraWhere/extraWhereLive must not include `userId`");
   }
 
   const cursorParts = parseCursor(cursor);
@@ -218,9 +246,18 @@ export async function paginatedPull<
   // spread `{ userId, ...extraWhere, AND: [cursor] }` would overwrite a
   // caller's top-level `AND` because object spread can't merge
   // same-key arrays. The wrap below sidesteps that entirely.
-  function buildWhere(): Record<string, unknown> {
+  //
+  // `liveOnly = true` adds `extraWhereLive` to the AND chain — used by
+  // the live query so caller-supplied filters constrain only the
+  // currently-visible rows, never the tombstone stream (which must
+  // pass through unfiltered so soft-deleted rows still emit a delete
+  // signal to replicating clients regardless of why they were hidden).
+  function buildWhere(opts: { liveOnly: boolean }): Record<string, unknown> {
     const clauses: Array<Record<string, unknown>> = [{ userId }];
     if (Object.keys(extraWhere).length > 0) clauses.push(extraWhere);
+    if (opts.liveOnly && Object.keys(extraWhereLive).length > 0) {
+      clauses.push(extraWhereLive);
+    }
     if (cursorClause) clauses.push(cursorClause);
     return clauses.length === 1 ? clauses[0] : { AND: clauses };
   }
@@ -232,7 +269,7 @@ export async function paginatedPull<
   // Live query — soft-delete extension auto-filters to `deletedAt: null`
   // because the resulting `where` has no top-level `deletedAt` key.
   const liveArgs = {
-    where: buildWhere(),
+    where: buildWhere({ liveOnly: true }),
     orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
     take: limit + 1,
   };
@@ -244,7 +281,7 @@ export async function paginatedPull<
   // the tombstone filter and silently returning zero rows.
   const deadArgs = includeTombstones
     ? {
-        where: { ...buildWhere(), deletedAt: { not: null } },
+        where: { ...buildWhere({ liveOnly: false }), deletedAt: { not: null } },
         orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
         take: limit + 1,
       }

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -265,13 +265,19 @@ export const sync = new Hono<AuthEnv>()
       const tableLimit = overrideLimit ?? DEFAULT_LIMIT_BY_TABLE[table] ?? FALLBACK_DEFAULT_LIMIT;
 
       const extraWhere: Record<string, unknown> = {};
+      const extraWhereLive: Record<string, unknown> = {};
       if (table === "calendar_events") {
         extraWhere.startTime = { gte: fourteenDaysAgo, lte: fourteenDaysAhead };
-        // Match the /calendar/events REST filter so iOS and desktop agree
-        // on which events the user can see. Without this, sync-pull returns
-        // every event the user owns — including events on shared calendars
-        // the user has hidden via the calendar list visibility toggle.
-        Object.assign(extraWhere, eventsOnVisibleCalendars);
+        // Visibility filter applies to LIVE rows only. The corresponding
+        // tombstones MUST escape this filter — when the user toggles a
+        // calendar to hidden, the cascade soft-deletes its events; iOS
+        // can only purge them locally if the tombstone reaches /sync/pull's
+        // `deleted[]` array. Constraining the tombstone query by the
+        // (now-false) calendarList.isVisible flag would block exactly the
+        // delete signal we need to send. Keep the filter on the live
+        // path so a race between the cascade and a concurrent insert
+        // never surfaces a hidden-calendar event to the client.
+        Object.assign(extraWhereLive, eventsOnVisibleCalendars);
       } else if (table === "items") {
         // Active work + just-completed. Excludes archived entirely;
         // older done items are fetched on-demand via /things and via
@@ -300,6 +306,7 @@ export const sync = new Hono<AuthEnv>()
       // for that page.
       const result = await paginatedPull({
         prismaModel: model,
+        extraWhereLive,
         prismaClient: prisma,
         userId: user.id,
         cursor,


### PR DESCRIPTION
## Summary

Follow-up to #139. The visibility filter I added to `/sync/pull` was applied to BOTH the live query AND the tombstone query — so iOS clients that already had a hidden-calendar event in local SwiftData never received the delete signal. The cascade tombstoned the row server-side, but the tombstone was filtered out of the `deleted[]` array by its own (now-false) `calendarList.isVisible` join. Events lingered on iOS forever.

Production state confirms the bug:

\`\`\`
SELECT cl.\"isVisible\", COUNT(*) FILTER (WHERE ce.\"deletedAt\" IS NOT NULL) AS tombstoned
FROM \"CalendarList\" cl LEFT JOIN \"CalendarEvent\" ce ON ce.\"calendarListId\" = cl.id
GROUP BY cl.\"isVisible\";
 isVisible | tombstoned
-----------+------------
 f         |         84
 t         |          0
\`\`\`

84 events correctly tombstoned on the server, but iOS still showed them because the tombstones never reached the client.

## Fix

Add `extraWhereLive` to `paginatedPull` — Prisma `where` clauses applied ONLY to the live query, never to the tombstone query. Move the calendar visibility filter there. Tombstones now flow through unfiltered so the client can purge them; live rows still respect the filter as defense-in-depth against any race where a hidden-calendar event might be live.

## Test plan

- [x] New test: \`emits tombstones for events on hidden calendars so iOS can purge them\` — asserts a soft-deleted event on an isVisible:false calendar appears in \`deleted[]\` (and not in \`upserted[]\`)
- [x] Existing visibility-exclusion test still passes
- [x] Full API suite (769 tests) passes
- [x] Typecheck clean
- [ ] After deploy: iOS pulls should drop the lingering hidden-calendar events

🤖 Generated with [Claude Code](https://claude.com/claude-code)