### PR TITLE
fix(calendar): tombstone cancelled events so iOS and desktop agree

### DIFF
--- a/apps/api/prisma/migrations/20260507040716_tombstone_cancelled_calendar_events/migration.sql
+++ b/apps/api/prisma/migrations/20260507040716_tombstone_cancelled_calendar_events/migration.sql
@@ -1,0 +1,25 @@
+-- One-time cleanup matching the calendar-visibility cascade in spirit.
+--
+-- Background: when Google cancels an event, calendar-sync's cancellation
+-- handler set `status = "cancelled"` but did NOT set `deletedAt`. The
+-- /calendar/events REST endpoint excluded those rows via `status: { not:
+-- "cancelled" }`, but /sync/pull had no such filter — so iOS replicated
+-- cancelled events as live rows and rendered them on the timeline,
+-- diverging from desktop.
+--
+-- The code change tombstones cancelled events going forward. This
+-- migration applies the same cascade once for events that were ALREADY
+-- cancelled at deploy time — without it, iOS keeps showing them
+-- forever (no tombstone signal will ever reach the client).
+--
+-- Idempotent: only flips `deletedAt` on rows that have status="cancelled"
+-- AND aren't already tombstoned. Re-running is a no-op.
+--
+-- Reversible: if Google ever reinstates a cancelled event (the upsert
+-- path now clears `deletedAt` on update), the row comes back to life
+-- automatically.
+
+UPDATE "CalendarEvent"
+SET "deletedAt" = NOW(), "updatedAt" = NOW()
+WHERE "status" = 'cancelled'
+AND "deletedAt" IS NULL;

--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -473,6 +473,87 @@ describe("POST /sync/pull", () => {
     expect(deletedIds).toContain(tombstonedEventId);
   });
 
+  it("excludes cancelled calendar events from upserts and emits tombstones", async () => {
+    // The Google cancellation handler in calendar-sync.ts now both
+    // sets status="cancelled" AND soft-deletes the row, so /sync/pull
+    // emits a tombstone to iOS instead of leaking the cancelled event
+    // as a live row (which is what /calendar/events on desktop has
+    // always excluded). This test pins both behaviours: a cancelled-
+    // and-tombstoned row shows up only in `deleted[]`, never `upserted[]`.
+    clearAllRateLimits();
+
+    const cxlUser = await createTestUser("Cancelled Sync User");
+
+    const googleAccountId = generateId();
+    await prisma.googleAccount.create({
+      data: {
+        id: googleAccountId,
+        userId: cxlUser.userId,
+        googleEmail: "cxl-test@gmail.com",
+        googleUserId: `google-cxl-${googleAccountId}`,
+        accessToken: encryptToken("fake-access-token"),
+        refreshToken: encryptToken("fake-refresh-token"),
+        tokenExpiresAt: new Date(Date.now() + 3600 * 1000),
+      },
+    });
+
+    const calendarListId = generateId();
+    await prisma.calendarList.create({
+      data: {
+        id: calendarListId,
+        googleAccountId,
+        googleCalendarId: "cxl-cal",
+        name: "Mine",
+        color: "#4285f4",
+        isVisible: true,
+        isPrimary: true,
+      },
+    });
+
+    const liveEventId = generateId();
+    const cancelledEventId = generateId();
+    const now = new Date();
+    await prisma.calendarEvent.createMany({
+      data: [
+        {
+          id: liveEventId,
+          userId: cxlUser.userId,
+          googleAccountId,
+          calendarListId,
+          googleEventId: `live-evt-${liveEventId}`,
+          title: "Live event",
+          startTime: now,
+          endTime: new Date(now.getTime() + 3600 * 1000),
+        },
+        {
+          id: cancelledEventId,
+          userId: cxlUser.userId,
+          googleAccountId,
+          calendarListId,
+          googleEventId: `cxl-evt-${cancelledEventId}`,
+          title: "Cancelled event",
+          status: "cancelled",
+          startTime: now,
+          endTime: new Date(now.getTime() + 3600 * 1000),
+          deletedAt: now,
+        },
+      ],
+    });
+
+    const res = await authRequest("/sync/pull", cxlUser.token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    const upsertedIds = body.changes.calendar_events.upserted.map((e: any) => e.id);
+    const deletedIds: string[] = body.changes.calendar_events.deleted;
+    expect(upsertedIds).toContain(liveEventId);
+    expect(upsertedIds).not.toContain(cancelledEventId);
+    expect(deletedIds).toContain(cancelledEventId);
+  });
+
   // ── On-demand sync filters (perf-driven hot/cold split) ──
 
   it("items filter: archived items are excluded from sync", async () => {

--- a/apps/api/src/lib/calendar-visibility.ts
+++ b/apps/api/src/lib/calendar-visibility.ts
@@ -1,14 +1,39 @@
 import type { Prisma } from "@brett/api-core";
 
 /**
- * Where-clause fragment selecting only events on user-visible calendars.
+ * Where-clause fragment selecting events the user should see live —
+ * shared between the REST `/calendar/events` endpoint (used by desktop)
+ * and the `/sync/pull` calendar_events branch (used by iOS) so the
+ * two clients always agree on what counts as "visible".
  *
- * Shared between the REST `/calendar/events` endpoint (used by desktop)
- * and the `/sync/pull` calendar_events branch (used by iOS) so the two
- * clients agree on which events are user-visible. Without sharing the
- * filter, iOS sync-pulls everything the user owns and silently shows
- * events from calendars desktop has hidden via `CalendarList.isVisible`.
+ * The invariant we're enforcing: the set of LIVE events returned by
+ * `/sync/pull` equals the set of events returned by `/calendar/events`.
+ * Tombstones in `/sync/pull` are extra (they signal removals that
+ * `/calendar/events` represents implicitly by re-querying).
+ *
+ * Each rule must apply to BOTH endpoints — adding one here without
+ * threading it through both call sites silently re-creates the iOS↔
+ * desktop drift this helper exists to prevent.
+ *
+ * Current rules:
+ *  • `calendarList.isVisible: true` — respects the per-calendar
+ *    visibility toggle. Toggling off cascades a soft-delete
+ *    (PATCH /calendar/accounts/.../calendars/...) so existing iOS
+ *    replicas of those events get a tombstone via /sync/pull.
+ *  • `status: { not: "cancelled" }` — Google-cancelled events should
+ *    never render. The cancellation handler in calendar-sync.ts
+ *    soft-deletes them (deletedAt + status="cancelled") so iOS
+ *    receives a tombstone; the live filter here is defense-in-depth
+ *    in case a race ever leaves a cancelled-but-live row.
+ *
+ * IMPORTANT: in `/sync/pull`, this filter must be passed via
+ * `extraWhereLive`, NOT `extraWhere`. Constraining the tombstone
+ * query by these flags would block exactly the delete signal we
+ * need to send (a soft-deleted hidden-calendar event would be
+ * filtered out of the tombstone stream by its own now-false
+ * `isVisible` join). See `paginated-pull.ts`.
  */
-export const eventsOnVisibleCalendars: Prisma.CalendarEventWhereInput = {
+export const liveCalendarEventFilter: Prisma.CalendarEventWhereInput = {
   calendarList: { isVisible: true },
+  status: { not: "cancelled" },
 };

--- a/apps/api/src/routes/calendar.ts
+++ b/apps/api/src/routes/calendar.ts
@@ -4,7 +4,7 @@ import { rateLimiter } from "../middleware/rate-limit.js";
 import { prisma } from "../lib/prisma.js";
 import { getCalendarClient, updateRsvp } from "../lib/google-calendar.js";
 import { onDemandFetch } from "../services/calendar-sync.js";
-import { eventsOnVisibleCalendars } from "../lib/calendar-visibility.js";
+import { liveCalendarEventFilter } from "../lib/calendar-visibility.js";
 import {
   validateRsvpInput,
   validateCalendarNoteInput,
@@ -60,17 +60,17 @@ calendar.get("/events", authMiddleware, async (c) => {
     return c.json({ error: "Invalid date format" }, 400);
   }
 
-  // Visibility filter is shared with /sync/pull via `eventsOnVisibleCalendars`
-  // so iOS and desktop see the same set of events. The relation filter
-  // replaces the previous two-step (fetch IDs → IN clause) with a single
-  // query — Prisma compiles it to a JOIN on `CalendarList.isVisible`.
+  // `liveCalendarEventFilter` is shared with /sync/pull's extraWhereLive
+  // so iOS and desktop always agree on what counts as a user-visible event.
+  // It bundles `calendarList.isVisible: true` and `status != "cancelled"`.
+  // Adding rules in one place without the other re-introduces drift —
+  // see the helper docstring.
   const events = await prisma.calendarEvent.findMany({
     where: {
       userId: user.id,
-      ...eventsOnVisibleCalendars,
+      ...liveCalendarEventFilter,
       startTime: { lte: end },
       endTime: { gte: start },
-      status: { not: "cancelled" },
     },
     include: {
       calendarList: { select: { name: true, color: true } },

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -8,7 +8,7 @@ import { publishSSE } from "../lib/sse.js";
 import { detectContentType } from "@brett/utils";
 import { runExtraction } from "../lib/content-extractor.js";
 import { paginatedPull, parseCursor } from "../lib/sync/paginated-pull.js";
-import { eventsOnVisibleCalendars } from "../lib/calendar-visibility.js";
+import { liveCalendarEventFilter } from "../lib/calendar-visibility.js";
 import type {
   SyncPullRequest, SyncPullResponse, SyncTableChanges,
   SyncPushRequest, SyncPushResponse, SyncMutation, SyncMutationResult,
@@ -268,16 +268,13 @@ export const sync = new Hono<AuthEnv>()
       const extraWhereLive: Record<string, unknown> = {};
       if (table === "calendar_events") {
         extraWhere.startTime = { gte: fourteenDaysAgo, lte: fourteenDaysAhead };
-        // Visibility filter applies to LIVE rows only. The corresponding
-        // tombstones MUST escape this filter — when the user toggles a
-        // calendar to hidden, the cascade soft-deletes its events; iOS
-        // can only purge them locally if the tombstone reaches /sync/pull's
-        // `deleted[]` array. Constraining the tombstone query by the
-        // (now-false) calendarList.isVisible flag would block exactly the
-        // delete signal we need to send. Keep the filter on the live
-        // path so a race between the cascade and a concurrent insert
-        // never surfaces a hidden-calendar event to the client.
-        Object.assign(extraWhereLive, eventsOnVisibleCalendars);
+        // Live-only filter (visibility + non-cancelled). The matching
+        // tombstones MUST escape this filter — both rules cascade soft-
+        // delete (visibility toggle and Google cancellation), and iOS
+        // can only purge the row locally if the tombstone reaches
+        // /sync/pull's `deleted[]` array. Constraining the tombstone
+        // query would block exactly the delete signal we need to send.
+        Object.assign(extraWhereLive, liveCalendarEventFilter);
       } else if (table === "items") {
         // Active work + just-completed. Excludes archived entirely;
         // older done items are fetched on-demand via /things and via

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -481,7 +481,17 @@ export async function upsertEvents(
   for (const event of events) {
     if (!event.id) continue;
 
-    // Handle cancelled events — soft-delete by setting status, preserving user notes
+    // Handle cancelled events. Set BOTH `status: "cancelled"` and
+    // `deletedAt = now()` so:
+    //   • the live filter in /calendar/events and /sync/pull excludes
+    //     the row (status check),
+    //   • /sync/pull emits a tombstone to iOS via `deleted[]` so the
+    //     local SwiftData copy gets purged (deletedAt + bumped
+    //     updatedAt advances past the client's cursor).
+    // The CalendarEventNote is keyed separately and survives — user
+    // notes on cancelled events aren't lost. If Google ever reinstates
+    // a cancelled event (rare), the upsert path below clears
+    // `deletedAt` on the next sync (see updateData spread).
     if (event.status === "cancelled") {
       const existing = await prisma.calendarEvent.findUnique({
         where: {
@@ -492,9 +502,10 @@ export async function upsertEvents(
         },
       });
       if (existing) {
+        const now = new Date();
         await prisma.calendarEvent.update({
           where: { id: existing.id },
-          data: { status: "cancelled" },
+          data: { status: "cancelled", deletedAt: now, updatedAt: now },
         });
         deleted.push(existing.id);
       }


### PR DESCRIPTION
## Summary

Second divergence in the same shape as the visibility filter (#139, #142). Desktop's \`/calendar/events\` excluded cancelled events via \`status: { not: \"cancelled\" }\`. \`/sync/pull\` had no such filter, so iOS replicated cancelled events as live rows and rendered them on the timeline. The cancellation handler in [calendar-sync.ts](apps/api/src/services/calendar-sync.ts) only set \`status = \"cancelled\"\` without soft-deleting, so the tombstone mechanism never fired either — iOS clients with already-replicated rows had no way to learn about the cancellation.

## Architecture

Bundles visibility + non-cancelled into one helper, \`liveCalendarEventFilter\` (replaces \`eventsOnVisibleCalendars\`). Both \`/calendar/events\` (live findMany) and \`/sync/pull\` (\`extraWhereLive\`) consume it. The helper docstring spells out the invariant: *the set of LIVE events from \`/sync/pull\` equals the set of events from \`/calendar/events\`*; adding rules in one place without threading them through the other silently re-creates iOS↔desktop drift.

## Changes

- Rename \`eventsOnVisibleCalendars\` → \`liveCalendarEventFilter\`; add \`status: { not: \"cancelled\" }\`
- Both routes use the helper (drop the now-redundant inline status filter in \`/calendar/events\`)
- Cancellation handler in \`calendar-sync.ts\` sets \`deletedAt = now()\` alongside \`status = \"cancelled\"\` so /sync/pull emits a tombstone (reversible — upsert path clears \`deletedAt\` if Google ever reinstates the event)
- Backfill migration tombstones currently-cancelled events at deploy time so existing iOS replicas get the delete signal

## Test plan

- [x] New test: \`excludes cancelled calendar events from upserts and emits tombstones\`
- [x] Existing visibility tests still pass
- [x] Full API suite (770 tests, 1 new) passes
- [x] Typecheck clean
- [x] Migration applies cleanly locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)