### PR TITLE
fix(calendar): incrementalSync must skip hidden calendars

### DIFF
--- a/apps/api/prisma/migrations/20260507042727_re_tombstone_hidden_calendar_events/migration.sql
+++ b/apps/api/prisma/migrations/20260507042727_re_tombstone_hidden_calendar_events/migration.sql
@@ -1,0 +1,28 @@
+-- Re-tombstone events on currently-hidden calendars.
+--
+-- The cascade migration shipped earlier today (20260506222541) tombstoned
+-- existing events on isVisible: false calendars at deploy time. But the
+-- reconciliation cron (every 4h) calls `incrementalSync(accountId)`,
+-- which (until the code change in this same PR) iterated ALL calendars
+-- on the account regardless of visibility. For each calendar it called
+-- `upsertEvents`, whose UPDATE branch clears `deletedAt: null` (added
+-- in PR #139 to support the visibility-on cascade restoring events).
+-- The net effect: every 4 hours, the cron silently un-tombstoned the
+-- events on hidden calendars, re-leaking them to iOS via /sync/pull.
+--
+-- The code change in this PR plugs the leak — `incrementalSync` now
+-- filters `isVisible: true`. This migration cleans up the rows the
+-- pre-fix cron already un-tombstoned, so iOS gets the tombstone signal
+-- on its next pull and finally purges them locally.
+--
+-- Idempotent + reversible (toggling a hidden calendar back on still
+-- works: PATCH clears the syncToken and the next periodic
+-- incrementalSync — now correctly scoped — full-fetches and the upsert
+-- path clears deletedAt for the events Google still has).
+
+UPDATE "CalendarEvent"
+SET "deletedAt" = NOW(), "updatedAt" = NOW()
+WHERE "calendarListId" IN (
+  SELECT id FROM "CalendarList" WHERE "isVisible" = false
+)
+AND "deletedAt" IS NULL;

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -204,8 +204,19 @@ export async function incrementalSync(googleAccountId: string): Promise<void> {
       console.warn("[calendar-sync] Failed to refresh calendar list metadata:", err);
     }
 
+    // Filter to user-visible calendars. Without this, the reconciliation
+    // cron (every 4h) would refetch events on calendars the user has
+    // hidden via `isVisible: false`, and `upsertEvents`'s update-branch
+    // (which clears `deletedAt: null` to support the visibility-on
+    // cascade) would un-tombstone them — silently re-leaking events to
+    // iOS via /sync/pull every 4 hours. The visibility-off cascade in
+    // PATCH /calendar/accounts/.../calendars/... already removes the
+    // syncToken when toggled back on, so a calendar re-becoming visible
+    // does NOT need to roll forward through this filter to catch up:
+    // the next periodic incrementalSync after toggle picks the cleared
+    // syncToken up and full-fetches.
     const calendarLists = await prisma.calendarList.findMany({
-      where: { googleAccountId },
+      where: { googleAccountId, isVisible: true },
     });
 
     const changeset: SyncChangeset = { created: [], updated: [], deleted: [] };


### PR DESCRIPTION
## Root cause of the post-deploy "still showing" report

The reconciliation cron (every 4h) calls \`incrementalSync\` which iterated ALL calendars on the account, not just visible ones. For each it called \`upsertEvents\`, whose UPDATE branch clears \`deletedAt: null\` (added in #139 to support the visibility-on cascade restoring events). The cron was silently un-tombstoning hidden-calendar events every 4 hours, re-leaking them to iOS via /sync/pull.

Production confirmed the cycle:

\`\`\`
                        | tombstoned | live
isVisible=false events  |     19     |  65   ← cron un-tombstoned 65 of the original 84
isVisible=true events   |      0     |  95
\`\`\`

deletedAt timestamp on the 19 still-tombstoned: 02:00 UTC (initial cascade migration).
updatedAt on the 65 leaked-again: 04:00 UTC (= reconciliation cron tick).

## Fix

Filter \`isVisible: true\` in the calendar-list query at the top of \`incrementalSync\`, matching the filter \`onDemandFetch\` already uses. Toggling a hidden calendar back on still works — the PATCH cascade clears the syncToken, and the next periodic incrementalSync (now correctly scoped) full-fetches it through.

Backfill migration re-tombstones the events the pre-fix cron had already un-tombstoned, so iOS gets the delete signal on its next pull.

## Test plan

- [x] Existing visibility tests still pass (770 total)
- [x] Typecheck clean
- [x] Migration applies cleanly locally
- [ ] After deploy: production query shows zero live events on isVisible=false calendars

🤖 Generated with [Claude Code](https://claude.com/claude-code)