### PR TITLE
Release: incrementalSync respects calendar visibility

### DIFF
--- a/apps/api/prisma/migrations/20260507042727_re_tombstone_hidden_calendar_events/migration.sql
+++ b/apps/api/prisma/migrations/20260507042727_re_tombstone_hidden_calendar_events/migration.sql
@@ -1,0 +1,28 @@
+-- Re-tombstone events on currently-hidden calendars.
+--
+-- The cascade migration shipped earlier today (20260506222541) tombstoned
+-- existing events on isVisible: false calendars at deploy time. But the
+-- reconciliation cron (every 4h) calls `incrementalSync(accountId)`,
+-- which (until the code change in this same PR) iterated ALL calendars
+-- on the account regardless of visibility. For each calendar it called
+-- `upsertEvents`, whose UPDATE branch clears `deletedAt: null` (added
+-- in PR #139 to support the visibility-on cascade restoring events).
+-- The net effect: every 4 hours, the cron silently un-tombstoned the
+-- events on hidden calendars, re-leaking them to iOS via /sync/pull.
+--
+-- The code change in this PR plugs the leak — `incrementalSync` now
+-- filters `isVisible: true`. This migration cleans up the rows the
+-- pre-fix cron already un-tombstoned, so iOS gets the tombstone signal
+-- on its next pull and finally purges them locally.
+--
+-- Idempotent + reversible (toggling a hidden calendar back on still
+-- works: PATCH clears the syncToken and the next periodic
+-- incrementalSync — now correctly scoped — full-fetches and the upsert
+-- path clears deletedAt for the events Google still has).
+
+UPDATE "CalendarEvent"
+SET "deletedAt" = NOW(), "updatedAt" = NOW()
+WHERE "calendarListId" IN (
+  SELECT id FROM "CalendarList" WHERE "isVisible" = false
+)
+AND "deletedAt" IS NULL;

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -204,8 +204,19 @@ export async function incrementalSync(googleAccountId: string): Promise<void> {
       console.warn("[calendar-sync] Failed to refresh calendar list metadata:", err);
     }
 
+    // Filter to user-visible calendars. Without this, the reconciliation
+    // cron (every 4h) would refetch events on calendars the user has
+    // hidden via `isVisible: false`, and `upsertEvents`'s update-branch
+    // (which clears `deletedAt: null` to support the visibility-on
+    // cascade) would un-tombstone them — silently re-leaking events to
+    // iOS via /sync/pull every 4 hours. The visibility-off cascade in
+    // PATCH /calendar/accounts/.../calendars/... already removes the
+    // syncToken when toggled back on, so a calendar re-becoming visible
+    // does NOT need to roll forward through this filter to catch up:
+    // the next periodic incrementalSync after toggle picks the cleared
+    // syncToken up and full-fetches.
     const calendarLists = await prisma.calendarList.findMany({
-      where: { googleAccountId },
+      where: { googleAccountId, isVisible: true },
     });
 
     const changeset: SyncChangeset = { created: [], updated: [], deleted: [] };

--- a/apps/ios/Brett/Views/Today/TodayHero.swift
+++ b/apps/ios/Brett/Views/Today/TodayHero.swift
@@ -130,38 +130,59 @@ struct TodayHero: View {
     // MARK: - Markdown → plain summary
 
     /// Collapse a markdown briefing into a single-paragraph plain
-    /// summary suitable for the hero. Strips headings, list bullets
-    /// (unordered + ordered), blockquote markers, code fences, inline
-    /// emphasis, and link syntax; truncates at ~280 chars on the
+    /// summary suitable for the hero. Headings, blockquotes, code
+    /// fences, and horizontal rules are dropped (they don't read as
+    /// prose). List bullet markers (`-`, `*`, `+`, `N.`) are stripped
+    /// and the bullet TEXT is folded into the paragraph — the API's
+    /// briefing prompt produces a bullet list, so without this step
+    /// the hero renders nothing. Inline emphasis and link syntax are
+    /// stripped, then the result is truncated at ~280 chars on the
     /// nearest sentence boundary.
     ///
     /// Public for testability — `TodayHeroTests` exercises the
     /// markdown-stripping cases directly without rendering SwiftUI.
-    /// Lines we don't want concatenated into the hero prose: list
-    /// bullets, ordered list items, blockquotes, code fences, headings,
-    /// and horizontal rules. Anything else is treated as prose.
+    /// Lines we drop entirely (no readable prose equivalent): headings,
+    /// blockquotes, code fences, horizontal rules.
     private static func isStructuralLine(_ trimmed: String) -> Bool {
         if trimmed.hasPrefix("#") { return true }                    // heading
-        if trimmed.hasPrefix("-") { return true }                    // unordered list
-        if trimmed.hasPrefix("*") { return true }                    // unordered list / emphasis-only
-        if trimmed.hasPrefix("+") { return true }                    // unordered list (alt)
         if trimmed.hasPrefix(">") { return true }                    // blockquote
         if trimmed.hasPrefix("```") { return true }                  // code fence
         if trimmed == "---" || trimmed == "***" { return true }      // horizontal rule
-        // Ordered list — `1. text`, `12. text`. Match a leading run of
-        // digits followed by `. ` (the markdown ordered-list marker).
-        if let firstSpace = trimmed.firstIndex(of: " "),
-           let dot = trimmed.firstIndex(of: "."),
-           dot < firstSpace,
-           trimmed[..<dot].allSatisfy({ $0.isNumber }) {
-            return true
-        }
         return false
     }
 
+    /// If `trimmed` starts with a list bullet marker (`- `, `* `, `+ `,
+    /// or `N. `), return the text after the marker. Otherwise return
+    /// `trimmed` unchanged. The trailing-space requirement is what
+    /// keeps `*italic*` and `--hyphen` from being misread as bullets.
+    static func stripBulletMarker(_ trimmed: String) -> String {
+        // Unordered: `- text`, `* text`, `+ text`. Need at least
+        // marker + space + one content character.
+        if trimmed.count >= 3,
+           let first = trimmed.first,
+           first == "-" || first == "*" || first == "+" {
+            let afterMarker = trimmed.index(after: trimmed.startIndex)
+            if trimmed[afterMarker] == " " {
+                return String(trimmed[trimmed.index(after: afterMarker)...])
+            }
+        }
+        // Ordered: `1. text`, `12. text`. Leading digits, then `. `.
+        if let dot = trimmed.firstIndex(of: "."),
+           dot > trimmed.startIndex,
+           trimmed[..<dot].allSatisfy({ $0.isNumber }) {
+            let afterDot = trimmed.index(after: dot)
+            if afterDot < trimmed.endIndex, trimmed[afterDot] == " " {
+                return String(trimmed[trimmed.index(after: afterDot)...])
+            }
+        }
+        return trimmed
+    }
+
     static func stripMarkdownToPlain(_ md: String) -> String {
-        // Walk the lines and pick the first prose paragraph (skip
-        // headings + list bullets — we want the conversational opener).
+        // Walk the lines and pick the first content paragraph. Bullet
+        // lines have their marker stripped so the text joins the
+        // surrounding prose; consecutive non-empty lines fold together
+        // with a single space (matches markdown soft-break semantics).
         let lines = md.components(separatedBy: .newlines)
         var paragraphs: [String] = []
         var current = ""
@@ -177,8 +198,10 @@ struct TodayHero: View {
             if Self.isStructuralLine(trimmed) {
                 continue
             }
+            let content = Self.stripBulletMarker(trimmed)
+            if content.isEmpty { continue }
             if !current.isEmpty { current += " " }
-            current += trimmed
+            current += content
         }
         if !current.isEmpty { paragraphs.append(current) }
         guard let first = paragraphs.first(where: { !$0.isEmpty }) else { return "" }

--- a/apps/ios/BrettTests/Views/TodayHeroTests.swift
+++ b/apps/ios/BrettTests/Views/TodayHeroTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Tests for `TodayHero.stripMarkdownToPlain` — the function that
+/// turns the briefing markdown into the single-paragraph editorial
+/// prose shown in the calm-hero. The contract here is what keeps the
+/// hero from going silently blank when the API briefing format
+/// changes; see `TodayHero.swift` for the design intent.
+///
+/// Production briefings come out of `getBriefingPrompt` as a 3-5
+/// bullet list (every line begins with `- `). The earlier version of
+/// this stripper treated bullet-prefixed lines as structural and
+/// skipped them, which left the hero with an empty string and a
+/// hidden briefing card. These cases pin the bullet-folding behavior
+/// so that regression can't recur.
+///
+/// `@MainActor` because `TodayHero` conforms to `View` and inherits
+/// MainActor isolation under Swift 6 strict concurrency — calling its
+/// static funcs from a non-isolated test context traps at runtime.
+@MainActor
+@Suite("TodayHero markdown stripping", .tags(.views))
+struct TodayHeroTests {
+
+    // MARK: - Prose-only
+
+    @Test func plainProseReturnsAsIs() {
+        let md = "Two things slipped past Friday — clear those first."
+        #expect(TodayHero.stripMarkdownToPlain(md) == md)
+    }
+
+    @Test func multiLineProseFoldsWithSpace() {
+        let md = """
+        First line.
+        Second line.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "First line. Second line.")
+    }
+
+    @Test func blankLineSplitsParagraphsAndFirstWins() {
+        let md = """
+        First paragraph wins.
+
+        Second paragraph is dropped.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "First paragraph wins.")
+    }
+
+    // MARK: - Bullet-only (production format)
+
+    @Test func bulletOnlyBriefingFoldsIntoOneParagraph() {
+        // Mirrors the `getBriefingPrompt` example output. The earlier
+        // behavior returned "" here, which hid the hero card entirely
+        // — that's the regression these tests guard against.
+        let md = """
+        - 2 overdue: Q3 budget review (3 days late) and Reply to Sarah's proposal (1 day).
+        - Due today: Ship v2.1 release notes — been sitting since Monday.
+        - 10:00 AM: Product sync with Design (Lena, Marcus). 2:30 PM: 1:1 with Jordan.
+        - Start with Sarah's proposal — it's quick, then block time for the budget review.
+        """
+        let result = TodayHero.stripMarkdownToPlain(md)
+        #expect(!result.isEmpty)
+        #expect(result.hasPrefix("2 overdue: Q3 budget review"))
+        // The 280-char sentence-boundary cap should bite before the
+        // last bullet, so the actionable suggestion gets dropped from
+        // the hero — that's expected and acceptable; the full briefing
+        // lives elsewhere.
+        #expect(result.count <= 280)
+    }
+
+    @Test func singleBulletStripsMarker() {
+        let md = "- The only line."
+        #expect(TodayHero.stripMarkdownToPlain(md) == "The only line.")
+    }
+
+    @Test func asteriskBulletsStripMarker() {
+        let md = """
+        * First item.
+        * Second item.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "First item. Second item.")
+    }
+
+    @Test func plusBulletsStripMarker() {
+        let md = "+ Plus-marker bullet."
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Plus-marker bullet.")
+    }
+
+    @Test func orderedListStripsMarker() {
+        let md = """
+        1. First task.
+        2. Second task.
+        12. Twelfth task.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "First task. Second task. Twelfth task.")
+    }
+
+    // MARK: - Mixed content
+
+    @Test func headingPlusBulletsKeepsBullets() {
+        let md = """
+        # Today's briefing
+
+        - Bullet content.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Bullet content.")
+    }
+
+    @Test func proseLeadInJoinsWithBullets() {
+        let md = """
+        Here's what matters today.
+        - First priority.
+        - Second priority.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) ==
+                "Here's what matters today. First priority. Second priority.")
+    }
+
+    @Test func blockquotesAreSkipped() {
+        let md = """
+        > Skipped quote.
+        Kept prose.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Kept prose.")
+    }
+
+    @Test func codeFenceMarkersAreSkipped() {
+        // The stripper drops the ``` fence-marker lines but not the
+        // content between them — it doesn't track multi-line fence
+        // state. Acceptable: the briefing prompt never produces code
+        // blocks. This test pins the actual behavior so a future
+        // improvement to track fence state shows up as a deliberate
+        // change rather than a silent regression.
+        let md = """
+        ```
+        code body
+        ```
+        Kept prose.
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "code body Kept prose.")
+    }
+
+    @Test func horizontalRulesAreSkipped() {
+        let md = """
+        ---
+        Kept prose.
+        ***
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Kept prose.")
+    }
+
+    // MARK: - Inline markdown stripping (preserved from original behavior)
+
+    @Test func boldMarkersAreStripped() {
+        let md = "- Wrap **Q3 review** in bold."
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Wrap Q3 review in bold.")
+    }
+
+    @Test func italicMarkersAreStripped() {
+        let md = "This is *italic* text and _also italic_."
+        #expect(TodayHero.stripMarkdownToPlain(md) == "This is italic text and also italic.")
+    }
+
+    @Test func linkSyntaxKeepsTextOnly() {
+        let md = "Check [the doc](https://example.com) when ready."
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Check the doc when ready.")
+    }
+
+    @Test func inlineCodeBackticksAreStripped() {
+        let md = "Run `pnpm test` after."
+        #expect(TodayHero.stripMarkdownToPlain(md) == "Run pnpm test after.")
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyStringReturnsEmpty() {
+        #expect(TodayHero.stripMarkdownToPlain("") == "")
+    }
+
+    @Test func onlyStructuralLinesReturnsEmpty() {
+        let md = """
+        # Heading
+        ---
+        > quote
+        """
+        #expect(TodayHero.stripMarkdownToPlain(md) == "")
+    }
+
+    @Test func bareDashIsNotTreatedAsBullet() {
+        // `-` without trailing space + content isn't a bullet marker;
+        // it's effectively garbage but should not crash and should not
+        // be folded into the paragraph as content.
+        let md = """
+        -
+        Real prose.
+        """
+        // The bare "-" survives as content (it's not structural and
+        // not a stripped bullet); it joins with the following line.
+        // Acceptable — bare dashes aren't expected in real briefings.
+        let result = TodayHero.stripMarkdownToPlain(md)
+        #expect(result.contains("Real prose"))
+    }
+
+    @Test func longContentTruncatesAtSentenceBoundary() {
+        // 300+ chars of prose-like sentences. Cap is 280 with backtrack
+        // to nearest period; result should end with "." not "…".
+        let md = String(repeating: "This is a sentence. ", count: 25)
+        let result = TodayHero.stripMarkdownToPlain(md)
+        #expect(result.count <= 280)
+        #expect(result.hasSuffix("."))
+    }
+
+    @Test func longContentWithoutPeriodFallsBackToEllipsis() {
+        // No sentence boundaries → cap with "…".
+        let md = String(repeating: "word ", count: 80)
+        let result = TodayHero.stripMarkdownToPlain(md)
+        #expect(result.count <= 281) // 280 + "…"
+        #expect(result.hasSuffix("…"))
+    }
+
+    // MARK: - stripBulletMarker direct tests
+
+    @Test func stripBulletMarkerHandlesAllPrefixes() {
+        #expect(TodayHero.stripBulletMarker("- text") == "text")
+        #expect(TodayHero.stripBulletMarker("* text") == "text")
+        #expect(TodayHero.stripBulletMarker("+ text") == "text")
+        #expect(TodayHero.stripBulletMarker("1. text") == "text")
+        #expect(TodayHero.stripBulletMarker("42. text") == "text")
+    }
+
+    @Test func stripBulletMarkerLeavesProseAlone() {
+        #expect(TodayHero.stripBulletMarker("Plain prose.") == "Plain prose.")
+        #expect(TodayHero.stripBulletMarker("*italic*") == "*italic*")
+        #expect(TodayHero.stripBulletMarker("Mr. Smith said hi.") == "Mr. Smith said hi.")
+    }
+}


### PR DESCRIPTION
PR #146: fixes the reconciliation cron silently un-tombstoning hidden-calendar events every 4 hours. Includes backfill migration to re-tombstone the rows already leaked by the cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)