### PR TITLE
fix: treat sync URL cancellations as no-ops, not errors (#148)

### DIFF
--- a/apps/ios/Brett/Sync/SyncManager.swift
+++ b/apps/ios/Brett/Sync/SyncManager.swift
@@ -125,7 +125,9 @@ final class SyncManager {
     /// 5 minutes). Debounced / user-initiated syncs are NOT throttled —
     /// they fire immediately because the user just expressed intent.
     /// Reset to 0 on any successful sync.
-    private var consecutiveFailures: Int = 0
+    /// Read-only outside the class so tests can pin the backoff side-effect
+    /// of cancellations vs. real failures. Mutated only by `sync()`.
+    private(set) var consecutiveFailures: Int = 0
 
     /// Upper bound on the backoff window. Five minutes — longer than the
     /// default 30s poll, but short enough that a user returning from a
@@ -209,14 +211,22 @@ final class SyncManager {
         defer { isSyncing = false }
 
         var firstError: String?
+        var anyPhaseSucceeded = false
 
         // Phase 1: push. Capture errors but still attempt the pull so a one-off
         // push hiccup doesn't block incoming server changes indefinitely.
+        // Cancellations (URLError.cancelled / CancellationError) aren't real
+        // failures — they just mean Task.cancel() reached an in-flight request
+        // (debounce overlap, sign-out, app backgrounding) — so they bypass
+        // both the error state and the backoff counter.
         state = .pushing
         do {
             _ = try await pushEngine.push()
+            anyPhaseSucceeded = true
         } catch {
-            firstError = describe(error)
+            if !Self.isCancellation(error) {
+                firstError = describe(error)
+            }
         }
 
         // Phase 2: pull. Always attempted so the server has the final say on
@@ -230,21 +240,29 @@ final class SyncManager {
                 _ = try await pullEngine.pull()
             }
             lastSyncedAt = Date()
+            anyPhaseSucceeded = true
         } catch {
-            // Preserve the push error if we had one — it's the more actionable
-            // signal (a push failure means local mutations haven't landed).
-            firstError = firstError ?? describe(error)
+            if !Self.isCancellation(error) {
+                // Preserve the push error if we had one — it's the more
+                // actionable signal (a push failure means local mutations
+                // haven't landed).
+                firstError = firstError ?? describe(error)
+            }
         }
 
         // Final state reflects whether either phase errored. The backoff
         // counter tracks consecutive failures so the poll loop can throttle
-        // repeated retries on a flaky network.
+        // repeated retries on a flaky network. A cancellation-only cycle
+        // (no real error, no successful phase) leaves the counter alone —
+        // we didn't fail and we didn't succeed.
         if let message = firstError {
             state = .error(message)
             consecutiveFailures += 1
         } else {
             state = .idle
-            consecutiveFailures = 0
+            if anyPhaseSucceeded {
+                consecutiveFailures = 0
+            }
         }
     }
 
@@ -265,7 +283,7 @@ final class SyncManager {
         do {
             _ = try await pushEngine.push()
         } catch {
-            state = .error(describe(error))
+            state = Self.isCancellation(error) ? .idle : .error(describe(error))
             throw error
         }
 
@@ -278,7 +296,7 @@ final class SyncManager {
             state = .idle
             lastSyncedAt = Date()
         } catch {
-            state = .error(describe(error))
+            state = Self.isCancellation(error) ? .idle : .error(describe(error))
             throw error
         }
     }
@@ -425,6 +443,35 @@ final class SyncManager {
         let base = pollInterval * pow(2.0, Double(min(consecutiveFailures, 10)))
         let capped = min(base, maxBackoff)
         return capped * jitter
+    }
+
+    // MARK: - Cancellation classification
+
+    /// True when an error originates from `Task.cancel()` propagating into a
+    /// URLSession request (or surfacing as `CancellationError` directly).
+    /// Kept `nonisolated static` so tests can exercise the matrix without a
+    /// SyncManager instance, and so it's safe to call from any actor.
+    ///
+    /// Three shapes show up in practice:
+    ///  - `URLError(.cancelled)` — `URLSession.data(for:)` after the parent
+    ///    Task is cancelled.
+    ///  - `CancellationError` — Swift concurrency primitives (e.g.
+    ///    `Task.checkCancellation()`).
+    ///  - `APIError.unknown(URLError(.cancelled))` — the same URLError after
+    ///    `APIClient.map(urlError:)` wraps it for callers downstream.
+    nonisolated static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled {
+            return true
+        }
+        if let apiError = error as? APIError,
+           case .unknown(let underlying) = apiError {
+            if underlying is CancellationError { return true }
+            if let urlError = underlying as? URLError, urlError.code == .cancelled {
+                return true
+            }
+        }
+        return false
     }
 
     // MARK: - Crash recovery

--- a/apps/ios/BrettTests/Sync/SyncManagerTests.swift
+++ b/apps/ios/BrettTests/Sync/SyncManagerTests.swift
@@ -215,6 +215,116 @@ struct SyncManagerTests {
 
         #expect(fixture.pull.callCount == 1)
     }
+
+    // MARK: - Cancellation handling
+    //
+    // `URLError(.cancelled)` propagates whenever Swift `Task.cancel()` reaches
+    // an in-flight URLSession data task — debounce overlap, sign-out, app
+    // backgrounding, etc. None of those are real sync failures, so the red-dot
+    // indicator and exponential backoff should ignore them entirely. See #148.
+
+    @MainActor
+    @Test func syncIgnoresPushCancellationFromURLError() async {
+        let fixture = await TestHarness.make()
+        fixture.push.errorToThrow = URLError(.cancelled)
+
+        await fixture.sut.sync()
+
+        if case .error = fixture.sut.state {
+            Issue.record("cancelled push must not surface as a sync error")
+        }
+        // Pull still ran and succeeded — `lastSyncedAt` should be stamped.
+        #expect(fixture.sut.lastSyncedAt != nil)
+    }
+
+    @MainActor
+    @Test func syncIgnoresPullCancellationFromAPIErrorWrapper() async {
+        let fixture = await TestHarness.make()
+        fixture.pull.errorToThrow = APIError.unknown(URLError(.cancelled))
+
+        await fixture.sut.sync()
+
+        if case .error = fixture.sut.state {
+            Issue.record("cancelled pull (wrapped in APIError.unknown) must not surface as error")
+        }
+    }
+
+    @MainActor
+    @Test func syncDoesNotBumpFailureCountForCancellationOnly() async {
+        // Two consecutive syncs that get cancelled in both phases shouldn't
+        // accumulate any backoff — there's no failure to back off from.
+        let fixture = await TestHarness.make()
+        fixture.push.errorToThrow = URLError(.cancelled)
+        fixture.pull.errorToThrow = CancellationError()
+
+        await fixture.sut.sync()
+        await fixture.sut.sync()
+
+        #expect(fixture.sut.consecutiveFailures == 0)
+        if case .error = fixture.sut.state {
+            Issue.record("cancellation-only syncs should leave state idle")
+        }
+    }
+
+    @MainActor
+    @Test func syncResetsFailuresWhenCancelledPushButPullSucceeds() async {
+        // Prime a non-zero failure count via a real failure, then run a
+        // cycle where push is cancelled but pull succeeds. Pull's success
+        // is a useful round trip with the server, so failures must reset.
+        let fixture = await TestHarness.make()
+        fixture.push.errorToThrow = TestError.boom
+
+        await fixture.sut.sync()
+        #expect(fixture.sut.consecutiveFailures == 1)
+
+        fixture.push.errorToThrow = URLError(.cancelled)
+        fixture.pull.errorToThrow = nil
+        await fixture.sut.sync()
+
+        #expect(fixture.sut.consecutiveFailures == 0)
+    }
+
+    @MainActor
+    @Test func pullToRefreshClearsStateOnCancellationButRethrows() async {
+        let fixture = await TestHarness.make()
+        fixture.pull.errorToThrow = URLError(.cancelled)
+
+        do {
+            try await fixture.sut.pullToRefresh()
+            Issue.record("expected pullToRefresh to rethrow the cancellation")
+        } catch {
+            // Rethrow is correct — caller (pull-to-refresh gesture) decides
+            // whether to surface anything. State must NOT be .error.
+            if case .error = fixture.sut.state {
+                Issue.record("cancellation must not paint the sync indicator red")
+            }
+        }
+    }
+
+    // MARK: - Cancellation detector (pure helper)
+
+    @Test func isCancellationDetectsURLErrorCancelled() {
+        #expect(SyncManager.isCancellation(URLError(.cancelled)))
+    }
+
+    @Test func isCancellationDetectsSwiftCancellationError() {
+        #expect(SyncManager.isCancellation(CancellationError()))
+    }
+
+    @Test func isCancellationDetectsAPIErrorWrappedURLCancelled() {
+        #expect(SyncManager.isCancellation(APIError.unknown(URLError(.cancelled))))
+    }
+
+    @Test func isCancellationIgnoresOtherURLErrors() {
+        #expect(!SyncManager.isCancellation(URLError(.timedOut)))
+        #expect(!SyncManager.isCancellation(URLError(.notConnectedToInternet)))
+    }
+
+    @Test func isCancellationIgnoresOtherAPIErrors() {
+        #expect(!SyncManager.isCancellation(APIError.serverError(500)))
+        #expect(!SyncManager.isCancellation(APIError.unauthorized))
+        #expect(!SyncManager.isCancellation(APIError.unknown(URLError(.timedOut))))
+    }
 }
 
 // MARK: - Test harness


### PR DESCRIPTION
Closes #148

## Root cause

`URLError(.cancelled)` propagates whenever Swift `Task.cancel()` reaches an in-flight `URLSession` request. The most common triggers in this app are:

- A second `schedulePushDebounced()` call cancelling the in-flight one (the cancellation propagates from the parent `Task` into `URLSession.data(for:)`, which throws `URLError(.cancelled)`).
- Sign-out tearing down `SyncManager.stop()` mid-cycle.
- App backgrounding interrupting an active sync.

`SyncManager.sync()` treated these identically to real failures: `state = .error("Request cancelled.")`, the red sync indicator lit up, and `consecutiveFailures` bumped to throttle the next retry. None of those are actionable for the user — there's nothing to fix or wait for, the next sync cycle will succeed naturally.

Symptom path (matches the bug report verbatim):

`URLSession.data(for:)` → `URLError(.cancelled)` → `APIClient.map(urlError:)` → `APIError.unknown(URLError(.cancelled))` → `SyncManager.describe(...)` → `APIError.diagnosticMessage` → `urlErrorMessage` → `"Request cancelled."` → `state = .error(...)` → red indicator + alert text.

## Approach

**Picked: filter cancellations at the `SyncManager` layer.** Add a `nonisolated static isCancellation(_:)` helper that recognises `CancellationError`, `URLError(.cancelled)`, and `APIError.unknown` wrappers around either. `sync()` skips both the error state and the failure-counter bump on cancellations; `pullToRefresh()` resets state to `.idle` on cancellation but still rethrows so the gesture caller can decide what to do.

Other options considered:

1. **Add `APIError.cancelled` case** — cleanest type modeling, but invasive (every exhaustive switch on `APIError` needs the new case) and not necessary to fix the visible UX bug.
2. **Filter at `APIClient` (rethrow `CancellationError` directly)** — would change the public networking contract for callers that may genuinely want to know a request was cancelled. Out of scope.

The chosen approach is surgical: localised to one file, no public API change, no behaviour change for non-cancellation errors. `consecutiveFailures` reset semantics also tightened — only reset when at least one phase actually succeeded, so a cancellation-only cycle leaves the counter alone (correct: we neither failed nor succeeded).

## Tests

Added in `BrettTests/Sync/SyncManagerTests.swift`:

- `syncIgnoresPushCancellationFromURLError` — push throws `URLError(.cancelled)`, state must not be `.error`, pull still runs.
- `syncIgnoresPullCancellationFromAPIErrorWrapper` — pull throws `APIError.unknown(URLError(.cancelled))`, state must not be `.error`.
- `syncDoesNotBumpFailureCountForCancellationOnly` — two all-cancelled cycles leave `consecutiveFailures == 0`.
- `syncResetsFailuresWhenCancelledPushButPullSucceeds` — primes `consecutiveFailures = 1`, then a cycle where push cancels but pull succeeds correctly resets failures (pull's success counts as a useful round trip).
- `pullToRefreshClearsStateOnCancellationButRethrows` — user-initiated path doesn't paint the indicator red on cancellation, but still rethrows.
- Pure-helper coverage for `SyncManager.isCancellation(_:)` — `URLError(.cancelled)`, `CancellationError`, `APIError.unknown` wrappers, plus negative cases (`URLError(.timedOut)`, `URLError(.notConnectedToInternet)`, `APIError.serverError`, `APIError.unauthorized`).

Bug class these guard: any future regression that surfaces transient cancellations as user-visible sync errors, or that backs off the poll loop after non-failures.

Minor observability widening: `consecutiveFailures` is now `private(set)` (was `private`) so the failure-count tests can pin the side-effect directly. The value already drives the observable backoff timing.

## Build / typecheck

This is an iOS-only Swift change; no Xcode/Swift toolchain on the agent's Linux environment. The TS workspace doesn't depend on this code path. Verification will land in CI / on your Mac. Confidence is high — change is small, the new helper is pure, and existing tests all still hold (they use `TestError.boom`, which is correctly classified as not-cancellation).

## Self-review

Walked the case matrix:

| push | pull | `firstError` | `anyPhaseSucceeded` | end state | failures |
|---|---|---|---|---|---|
| OK | OK | nil | true | idle | reset |
| err | OK | push msg | true | .error(push) | +1 |
| OK | err | pull msg | true | .error(pull) | +1 |
| err | err | push msg | false | .error(push) | +1 |
| cancel | OK | nil | true | idle | reset |
| OK | cancel | nil | true | idle | reset |
| cancel | cancel | nil | false | idle | unchanged |
| cancel | err | pull msg | false | .error(pull) | +1 |
| err | cancel | push msg | false | .error(push) | +1 |

All paths line up with intent.

## Risks / follow-ups

- iOS 26.4.2 wasn't reproduced directly; the fix is based on Swift concurrency semantics that don't change between iOS versions.
- If we later want even more diagnostic visibility, we could log cancellations to OSLog at `.debug` so they show in Console without surfacing to the user. Not adding that here to keep the diff minimal.

Visual verification not applicable — this is a behaviour fix with no UI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vJUPoMitgiLHPkwxZY4Jr)_