### PR TITLE
fix: constrain X article / tweet card to detail-pane width (#150)

### DIFF
--- a/apps/ios/Brett/Views/Content/TweetPreview.swift
+++ b/apps/ios/Brett/Views/Content/TweetPreview.swift
@@ -89,6 +89,14 @@ struct TweetPreview: View {
 
             viewOnX
         }
+        // Pin the card to the parent's full proposed width. Without
+        // `maxWidth: .infinity`, a VStack(alignment: .leading) sizes to
+        // its widest child; tweet body text can contain expanded URLs
+        // hundreds of chars long with no word-break opportunities, which
+        // force the VStack wider than the offered width and bleed the
+        // card past the detail-pane horizontal padding on both sides.
+        // The explicit frame gives Text a finite width to wrap into.
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .background {
             RoundedRectangle(cornerRadius: 14, style: .continuous)


### PR DESCRIPTION
Closes #150

## Root cause

`TweetPreview`'s outer `VStack(alignment: .leading)` had no explicit `maxWidth` constraint. In SwiftUI, a leading-aligned VStack sizes to its widest child. The tweet body `Text` uses `.fixedSize(horizontal: false, vertical: true)` — flexible horizontally — but when the parent doesn't propose a finite width, Text can fall back to its **ideal** (unwrapped) width if it can't find a word-break opportunity.

After the recent long-tweet support (`feat(content): show full long tweets, expand t.co links, render quoted tweets`), tweet bodies can contain multi-hundred-character expanded URLs without word-break opportunities, so a single such URL forces the Text — and therefore the VStack, and therefore the card chrome — wider than the parent's offered width. The card then bleeds past the detail-pane's horizontal padding on both sides, matching the bug description.

## Approach

**Picked: add `.frame(maxWidth: .infinity, alignment: .leading)` to the outer VStack** (between the children and `.padding(16)`). This pins the card to the parent's proposed width and propagates a finite width down to the Text views, restoring the expected word-wrap behaviour.

Other options considered:

1. **`.lineLimit` + truncation on body text** — would hide the overflow but defeats the whole point of the long-tweet expansion. Rejected.
2. **Apply a hardcoded `.frame(maxWidth: 360)`** — brittle; depends on device size and sheet detent. Rejected.
3. **AttributedString with `.byCharWrapping` line break mode** — heavier diff, only helps body text and not the heading title or quoted card. The frame fix is upstream of all of them.

The fix is one line plus a comment. Same-category audit: `NewsletterPreview` uses `.lineLimit(3)` truncation on title/description, so it already caps text-driven overflow. `WebPagePreview`, `PodcastPreview`, `VideoPreview`, `PDFPreview` weren't touched — the long-URL exposure is specific to tweets where we deliberately removed truncation.

## Tests

UI-only layout-constraint change — no test added. Reason: the fix is a single SwiftUI frame modifier; a snapshot test would just mirror the modifier without proving overflow no longer happens, and "an expanded URL doesn't bleed off the card" is a layout property that isn't tractable to assert without rendering on a real screen. Verify visually via `gh pr checkout 150` (or fetch the branch in Xcode), open any tweet whose body contains a long expanded URL, and confirm the card respects the 16pt horizontal pane padding.

Test-prevention reflection: a category test would assert "any preview card cannot exceed parent width when given a child with arbitrarily wide intrinsic content". That's a SwiftUI layout invariant; testing it requires snapshot infrastructure we don't have for iOS yet. Worth tracking as a follow-up if cards-too-wide bugs recur.

## Build / typecheck

iOS-only Swift change. The agent runs on Linux without Xcode/Swift toolchain; the TS workspace doesn't depend on this code path. `pnpm typecheck`/`pnpm test` won't exercise it. Verification will land in CI / on Mac. Confidence is high — change is small, additive, and the SwiftUI behaviour it relies on is well-documented.

## Self-review

Walked the layout chain:

- `DetailViewContainer` → `ScrollView { content().padding(.horizontal, 16) }` → proposes (screen_width - 32) to its content.
- `TaskDetailView`'s body VStack proposes that to `ContentPreview` → `TweetPreview`.
- Pre-fix `TweetPreview` VStack would size to widest child; an ideal-width Text could exceed the proposal.
- Post-fix VStack is pinned to the proposal; Text receives a finite width and wraps.

Edge cases:

- Tweet with a single short word as body → still renders correctly (frame caps at offered width but VStack alignment is `.leading`, so content stays left).
- Tweet without a body but with a heading title → same VStack, same frame; heading wraps.
- Tweet with a quoted sub-card → the quoted card already had `.frame(maxWidth: .infinity, alignment: .leading)`, no change there.
- Tweet with an image → media frame is unchanged (`.frame(maxWidth: .infinity).frame(height: 200)`), same behaviour.

No multi-user concerns. No API/storage changes. Backwards-compatible — every iOS client picks up the layout fix on the next install.

## Risks / follow-ups

- Visual verification pending — `gh pr checkout 150`.
- The same defensive frame pattern would be cheap to apply to the other preview types (`NewsletterPreview`, `WebPagePreview`, etc.) if a future overflow surfaces. Holding off here to keep the diff scoped.
- Could add an automated layout snapshot test once we stand up SwiftUI snapshot infrastructure — out of scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MkKbGZyWbvd7NesGzZ9Yqq)_