### PR TITLE
fix: more breathing room above task detail sheet title (#151)

### DIFF
--- a/apps/ios/Brett/Views/Detail/TaskDetailView.swift
+++ b/apps/ios/Brett/Views/Detail/TaskDetailView.swift
@@ -286,7 +286,11 @@ private struct TaskDetailBody: View {
                     .accessibilityIdentifier("detail.titleField")
             }
         }
-        .padding(.top, 4)
+        // Pads below the sheet's drag indicator so the breadcrumb/title
+        // doesn't sit right under it. DetailViewContainer's own top
+        // padding of 8 leaves only ~12pt of breathing room which reads
+        // tight against the indicator and the sheet's rounded edge.
+        .padding(.top, 16)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Closes #151

## Root cause

The task detail sheet's first content row (breadcrumb + checkbox + title) sits only **12pt** below the sheet's drag indicator: `DetailViewContainer` adds `.padding(.top, 8)` to its content, and `TaskDetailView`'s `headerSection` adds another `.padding(.top, 4)`. With the visible drag indicator's own ~5pt height and ~8pt natural cushion, the title row reads pinned right against the sheet's rounded top edge — that's the "title too close looks jank".

## Approach

**Picked: bump `headerSection`'s `.padding(.top, 4)` to `.padding(.top, 16)`** — task-detail-specific, doesn't touch the shared `DetailViewContainer` or affect the pushed `EventDetailView` (which gets its top buffer from a navigation bar instead of a sheet drag indicator).

Other options considered:

1. **Bump `DetailViewContainer.padding(.top, 8)` to a higher value** — would also push down the pushed `EventDetailView`, which already has its navigation bar handling top spacing. Out of scope.
2. **Insert a fixed-height `Spacer` above the headerSection** — equivalent visually, but `.padding` is the established idiom in this file and stays consistent with the other `padding(.top, X)` calls in the section views.
3. **Move the spacing onto the outer VStack's `spacing` arg** — affects spacing between sections too; not what's wanted.

The chosen value (16pt) gives ~24pt total above the breadcrumb when combined with the container's 8pt — comfortable but not gratuitous, and matches the calmer rhythm called out in `apps/ios/DESIGN.md`. If Brent wants even more breathing room, the change is a one-line bump.

## Tests

UI-only padding change — no test added. Reason: padding is a SwiftUI layout property; a test would just assert that we wrote `.padding(.top, 16)` instead of `.padding(.top, 4)`, which is the change-mirroring pattern the engineering principles call out as low-value. Verify visually via `gh pr checkout 151`.

## Build / typecheck

iOS-only Swift change. No Xcode/Swift toolchain on this Linux runner; the TS workspace doesn't depend on this code path. Confidence is high — change is one line + a comment.

## Self-review

- Other detail surfaces unaffected: `EventDetailView` is push-presented inside a `NavigationStack` with `.navigationTitle("Calendar")`, so the navigation bar already provides top chrome. Its `header(_:)` doesn't add a `.padding(.top, X)`, so this PR doesn't change its layout.
- iOS ↔ desktop parity: the desktop equivalent (`apps/desktop`) renders task details inline without a sheet drag indicator, so this is a sheet-presentation-specific tweak that doesn't apply there.
- Multi-user / scoping: no data flow changes.
- Backwards-compat: pure presentational change, no API or storage impact.

## Risks / follow-ups

- Visual verification pending — `gh pr checkout 151`.
- If the sheet's drag-indicator behaviour changes in a future iOS version (Apple has been adjusting sheet chrome between releases), revisit the value.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MkKbGZyWbvd7NesGzZ9Yqq)_