### PR TITLE
fix: tap-to-complete dismisses task detail sheet (#152)

### DIFF
--- a/apps/ios/Brett/Views/Detail/TaskDetailView.swift
+++ b/apps/ios/Brett/Views/Detail/TaskDetailView.swift
@@ -520,9 +520,24 @@ private struct TaskDetailBody: View {
 
     private func toggleComplete() async {
         guard let item else { return }
+        let wasCompleted = item.itemStatus == .done
         itemStore.toggleStatus(id: item.id, userId: userId)
         // No manual reload needed — `@Query` reactively republishes the
         // matched row through `matchedItems` after the save lands.
+
+        // On the incomplete → complete transition, dismiss the sheet
+        // so the user gets out of the way of the thing they just
+        // finished. Un-completing (complete → incomplete) leaves the
+        // sheet open — that's a "bring this back" gesture, not a
+        // "done with it" one.
+        //
+        // The brief sleep gives the gold-fill checkmark animation time
+        // to land before the dismiss animation starts; without it the
+        // dismiss eats the visual confirmation.
+        if !wasCompleted {
+            try? await Task.sleep(for: .milliseconds(250))
+            dismiss()
+        }
     }
 
     private func addLink(_ targetId: String) async {


### PR DESCRIPTION
Closes #152

## Root cause

Tapping the gold checkbox in `TaskDetailView` toggled the item's status but never dismissed the sheet. The user has to drag-down or tap the breadcrumb to leave — when they just said "I'm done with it", the sheet hanging around is friction.

## Approach

**Picked: dismiss the sheet only on the incomplete → complete transition, with a 250 ms delay so the checkmark animation lands first.**

```swift
let wasCompleted = item.itemStatus == .done
itemStore.toggleStatus(id: item.id, userId: userId)
if !wasCompleted {
    try? await Task.sleep(for: .milliseconds(250))
    dismiss()
}
```

Other options considered:

1. **Dismiss on every toggle** — wrong direction. Un-completing (complete → incomplete) is a "bring this back to attention" gesture; closing the sheet contradicts that intent.
2. **Dismiss immediately, no delay** — works, but the gold-fill checkmark animation gets eaten by the sheet teardown. The 250 ms gives the animation time to land while still feeling snappy.
3. **`withAnimation { ... } completion:`** — heavier; the sleep is the simplest expression of "show feedback, then leave".

The captured `wasCompleted` is taken **before** `toggleStatus`, so the decision is based on the user's intent ("I just toggled FROM incomplete") rather than the post-toggle state.

`dismiss()` from the `TaskDetailBody`'s environment honours the `NavigationStack` context: when invoked from a linked sub-detail page (link stack > 0), it pops the link and returns to the parent task, which is the correct UX for completing a sub-item; when invoked at the root, it dismisses the entire sheet. No special-casing needed.

## Tests

No test added. Reason: the only extractable pure logic is `!wasCompleted` — testing that asserts the code calls what the code calls, which is the change-mirroring pattern called out as low-value in the engineering principles. The behaviour worth locking in ("incomplete → complete dismisses; complete → incomplete doesn't") is interactive UI and would need a SwiftUI snapshot/UI-test harness we don't have for iOS yet.

Test-prevention reflection: a meaningful test here would assert the dismiss-vs-stay rule across a `NavigationStack` scenario (linked-item completion pops, doesn't dismiss the whole sheet). That's a UI-test concern; tracking as a follow-up if SwiftUI snapshot infra lands.

## Build / typecheck

iOS-only Swift change. No Xcode/Swift toolchain on this Linux runner; the TS workspace doesn't depend on this code path. Confidence is high — change is localised to `toggleComplete()`, no API surface change.

## Self-review

- Re-entry: spam-tapping the checkbox spawns multiple unstructured `Task`s. Each captures its own `wasCompleted`. After the first dismiss, subsequent `dismiss()` calls are no-ops in SwiftUI's bookkeeping, and the captured environment value tolerates being called against an already-dismissed view.
- Background-actor safety: `Task.sleep` is fine on any executor; `DismissAction` dispatches to main internally. Same threading shape as the existing `Task { await toggleComplete() }` pattern in the button action.
- Linked navigation: `NavigationStack(path: $linkStack)` is the parent. `dismiss()` from the child pops the link before falling through to the sheet dismiss. Verified by reading SwiftUI's `DismissAction` semantics — pops first, dismisses second.
- Multi-user: `toggleStatus(id:userId:)` already user-scopes the mutation; this PR doesn't touch that path.
- Backwards-compat: pure UI-behaviour change; no API or storage impact.

## Risks / follow-ups

- Visual verification pending — `gh pr checkout 152`. Verify: (a) tap to complete an incomplete task → sheet dismisses after the checkmark fills, (b) tap to un-complete a completed task → sheet stays open, (c) drill into a linked item, complete it → returns to parent (sheet stays).
- If the 250 ms ends up feeling slow, easy one-line bump.
- Same dismiss-on-complete rule could apply to InboxView's tap-to-complete on individual rows — out of scope here, but a candidate for follow-up consistency. (The list-behavior-consistency rule in CLAUDE.md applies to list views; the detail sheet is a separate surface.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MkKbGZyWbvd7NesGzZ9Yqq)_