### PR TITLE
release: detail-pane list picker + briefing typography polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,17 +111,27 @@ Brett is in production with real users. All code changes flow through a gated re
 
 ```
 commit to main → push → CI tests run
-main → PR to release → CI tests + deploy → live
+main → PR to release → CI tests + API deploy
+                       ↓
+                       (then: desktop + iOS built locally on macOS)
 ```
 
 - **`main`** — development branch. Brent commits and pushes directly. CI (`.github/workflows/ci.yml`) runs typecheck + tests on every push.
-- **`release`** — production branch. Merging `main → release` via PR triggers the full deploy pipeline (`.github/workflows/release.yml`): tests → Railway API deploy → health check → desktop build → artifact upload.
+- **`release`** — production branch. Merging `main → release` via PR triggers `.github/workflows/release.yml`: tests → Railway API deploy → health check. **That's all CI does.** No desktop build, no iOS build, no artifact upload (GitHub's Mac runners are paid on private repos, and the signing certs / notarytool profile / App Store Connect API key live in the local login keychain).
 - **Never push directly to `release`.** Always go through a PR from `main`.
 - **Never force-push to `main` or `release`.**
 
 ### Deploying
 
-To cut a release: open a PR from `main` to `release` on GitHub, review the diff, merge. The deploy pipeline runs automatically.
+A full release is **three things**, not one. Don't stop after the merge — the API ships automatically but the clients don't:
+
+1. **API** — open a PR from `main` to `release`, merge it. The Railway deploy runs automatically. Watch [the run](https://github.com/brentbarkman/brett/actions) until the health check passes.
+2. **Desktop** — locally: `git checkout release && git pull && scripts/release.sh desktop`. Builds a signed + notarized DMG/ZIP, uploads to `brett-releases`, overwrites `latest-mac.yml`. **Without this step, every existing desktop user sees "you're up to date" against the previous version's manifest** — the autoupdater has no idea anything changed.
+3. **iOS** — locally: `scripts/release.sh ios` (from the release branch). Builds the IPA via Fastlane and uploads to TestFlight.
+
+Verify what's actually live: `curl -s https://api.brett.brentbarkman.com/releases/latest-mac.yml | head -3` shows the version the desktop autoupdater will offer. If that doesn't match the merge commit's `git rev-list --count HEAD`, the desktop step hasn't been run yet.
+
+When the user asks for "a release" / "ship it" / "merge to release," assume they want **all three** unless they specify otherwise. The merge alone is not a release.
 
 ### Rolling Back
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -90,6 +90,7 @@
     "@brett/utils": "workspace:*",
     "@carrot-kpi/switzer-font": "^0.1.0",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
+    "@fontsource-variable/source-serif-4": "^5.2.9",
     "@tanstack/react-query": "^5.60.0",
     "better-auth": "^1.6.6",
     "electron-store": "^8.2.0",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1079,10 +1079,10 @@ export function App() {
     createThing.mutate({ type: "task", title: `${item.title} (copy)`, listId: item.listId ?? undefined });
   };
 
-  const handleMoveToList = (id: string) => {
+  const handleSetList = (id: string, anchorEl: HTMLElement) => {
     if (!selectedItem || "googleEventId" in selectedItem) return;
     const item = selectedItem as Thing;
-    handleTriageOpen("list-first", [id], { listId: item.listId, dueDate: item.dueDate ?? undefined, dueDatePrecision: item.dueDatePrecision });
+    handleTriageOpen("list-only", [id], { listId: item.listId, dueDate: item.dueDate ?? undefined, dueDatePrecision: item.dueDatePrecision }, anchorEl);
   };
 
   const handleTriageOpen = (
@@ -1417,7 +1417,8 @@ export function App() {
           onUpdate={handleUpdateThing}
           onDelete={handleDeleteThing}
           onDuplicate={handleDuplicateThing}
-          onMoveToList={handleMoveToList}
+          lists={lists}
+          onSetList={handleSetList}
           onUpdateDueDate={(dueDate, precision) => {
             if (selectedId) updateThing.mutate({ id: selectedId, dueDate, dueDatePrecision: precision });
           }}

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -11,6 +11,9 @@
 /* Plus Jakarta Sans — wordmark only */
 @import "@fontsource-variable/plus-jakarta-sans";
 
+/* Source Serif 4 — editorial briefing prose */
+@import "@fontsource-variable/source-serif-4";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/desktop/tailwind.config.js
+++ b/apps/desktop/tailwind.config.js
@@ -60,6 +60,8 @@ module.exports = {
       },
       fontFamily: {
         sans: ['"Switzer"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', 'sans-serif'],
+        display: ['"New York"', 'ui-serif', 'Georgia', '"Times New Roman"', 'serif'],
+        prose: ['"Source Serif 4 Variable"', '"Source Serif 4"', 'Georgia', 'serif'],
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/packages/ui/src/ContentDetailPanel.tsx
+++ b/packages/ui/src/ContentDetailPanel.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useEffect } from "react";
-import { CheckCircle, Radar, RotateCw, ThumbsUp, ThumbsDown, X } from "lucide-react";
+import { CheckCircle, FolderPlus, Inbox, Radar, RotateCw, ThumbsUp, ThumbsDown, X } from "lucide-react";
 import { BrettMark } from "./BrettMark";
 import type {
   ThingDetail,
   DueDatePrecision,
   ReminderType,
   RecurrenceType,
+  NavList,
   Thing,
 } from "@brett/types";
 import { OverflowMenu } from "./OverflowMenu";
@@ -27,7 +28,9 @@ interface ContentDetailPanelProps {
   onToggle: (id: string) => void;
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
-  onMoveToList: (id: string) => void;
+  // List picker — opens a popover anchored to the in-panel list pill
+  lists?: NavList[];
+  onSetList?: (id: string, anchorEl: HTMLElement) => void;
   // Schedule callbacks
   onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision) => void;
   onUpdateReminder?: (reminder: ReminderType | null) => void;
@@ -74,7 +77,8 @@ export function ContentDetailPanel({
   onToggle,
   onDelete,
   onDuplicate,
-  onMoveToList,
+  lists,
+  onSetList,
   onUpdateDueDate,
   onUpdateReminder,
   onUpdateRecurrence,
@@ -111,6 +115,10 @@ export function ContentDetailPanel({
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState(detail.title);
   const titleRef = useRef<HTMLInputElement>(null);
+  const listButtonRef = useRef<HTMLButtonElement>(null);
+  const currentListColor = detail.listId
+    ? lists?.find((l) => l.id === detail.listId)?.colorClass
+    : undefined;
 
   useEffect(() => {
     setTitleValue(detail.title);
@@ -156,7 +164,6 @@ export function ContentDetailPanel({
               <OverflowMenu
                 onDelete={() => onDelete(detail.id)}
                 onDuplicate={() => onDuplicate(detail.id)}
-                onMoveToList={() => onMoveToList(detail.id)}
                 onCopyLink={() =>
                   navigator.clipboard.writeText(`brett://things/${detail.id}`)
                 }
@@ -195,6 +202,37 @@ export function ContentDetailPanel({
             >
               {shownTitle}
             </h2>
+          )}
+
+          {/* List pill — click to open list picker */}
+          {onSetList && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                ref={listButtonRef}
+                onClick={() => listButtonRef.current && onSetList(detail.id, listButtonRef.current)}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-white/5 border border-white/10 text-white/70 hover:bg-white/10 hover:text-white transition-colors"
+              >
+                {detail.listId ? (
+                  <>
+                    <span className={`w-1.5 h-1.5 rounded-full ${currentListColor ?? "bg-white/40"}`} />
+                    <span>{detail.list}</span>
+                  </>
+                ) : detail.list && detail.list !== "Inbox" ? (
+                  <>
+                    <span className="w-1.5 h-1.5 rounded-full bg-white/40" />
+                    <span>{detail.list}</span>
+                  </>
+                ) : (
+                  <>
+                    <Inbox size={11} className="text-white/50" />
+                    <span>Inbox</span>
+                    <span className="text-white/30">·</span>
+                    <FolderPlus size={11} className="text-white/50" />
+                    <span className="text-white/50">Add to list</span>
+                  </>
+                )}
+              </button>
+            </div>
           )}
 
           {/* Scout provenance + feedback */}

--- a/packages/ui/src/DailyBriefing.tsx
+++ b/packages/ui/src/DailyBriefing.tsx
@@ -88,17 +88,16 @@ function renderEditorial(
 
   const parts = text.split(/(\*\*[^*]+\*\*|"[^"]+")/g);
 
+  const linkChip =
+    "font-medium text-white hover:text-brett-gold underline decoration-brett-gold decoration-2 underline-offset-4 transition-colors cursor-pointer";
+
   return parts.map((part, i) => {
     if (part.startsWith("**") && part.endsWith("**")) {
       const inner = part.slice(2, -2);
       const matched = matchItem(inner);
       if (matched && onItemClick) {
         return (
-          <button
-            key={i}
-            onClick={() => onItemClick(matched.id)}
-            className="font-medium text-brett-gold hover:text-brett-gold/80 transition-colors cursor-pointer"
-          >
+          <button key={i} onClick={() => onItemClick(matched.id)} className={linkChip}>
             {inner}
           </button>
         );
@@ -111,11 +110,7 @@ function renderEditorial(
       const matched = matchItem(inner);
       if (matched && onItemClick) {
         return (
-          <button
-            key={i}
-            onClick={() => onItemClick(matched.id)}
-            className="text-brett-gold hover:text-brett-gold/80 transition-colors cursor-pointer"
-          >
+          <button key={i} onClick={() => onItemClick(matched.id)} className={linkChip}>
             {inner}
           </button>
         );
@@ -127,10 +122,7 @@ function renderEditorial(
   });
 }
 
-// Single hero-zone shadow — tight outline + medium halo. Reads at every type size
-// so the greeting, date, and brief all carry the same legibility treatment over
-// any wallpaper.
-const HERO_SHADOW = "[text-shadow:0_1px_2px_rgba(0,0,0,0.7),0_0_8px_rgba(0,0,0,0.55)]";
+const HERO_SHADOW = "";
 
 function BriefingProseSkeleton() {
   return (
@@ -187,9 +179,9 @@ export function DailyBriefing({
         </div>
       )}
 
-      {/* Greeting — editorial 38px serif */}
+      {/* Greeting — editorial 38px display serif (system New York on Apple) */}
       <h1
-        className={`font-serif text-[38px] leading-[1.05] font-medium tracking-[-0.02em] text-white ${HERO_SHADOW}`}
+        className={`font-display text-[38px] leading-[1.05] font-medium tracking-[-0.02em] text-white ${HERO_SHADOW}`}
       >
         {greeting}
       </h1>
@@ -214,7 +206,7 @@ export function DailyBriefing({
             </p>
           ) : prose.length > 0 ? (
             <p
-              className={`text-[18px] leading-relaxed text-white font-normal ${HERO_SHADOW}`}
+              className={`font-prose text-[19px] leading-[1.65] text-white/[0.92] font-normal ${HERO_SHADOW}`}
             >
               {renderEditorial(prose, titleMap, knownItems, onItemClick)}
               {isGenerating && (
@@ -227,11 +219,11 @@ export function DailyBriefing({
         ) : !summary ? (
           <BriefingProseSkeleton />
         ) : isDayEmpty ? (
-          <p className={`text-[18px] leading-relaxed text-white font-normal ${HERO_SHADOW}`}>
+          <p className={`font-prose text-[19px] leading-[1.65] text-white/[0.92] font-normal ${HERO_SHADOW}`}>
             Nothing on the books today. A rare opening — use it well.
           </p>
         ) : (
-          <p className={`text-[18px] leading-relaxed text-white font-normal ${HERO_SHADOW}`}>
+          <p className={`font-prose text-[19px] leading-[1.65] text-white/[0.92] font-normal ${HERO_SHADOW}`}>
             {[
               summary.dueTodayTasks > 0 &&
                 `${summary.dueTodayTasks} task${summary.dueTodayTasks !== 1 ? "s" : ""} due today`,

--- a/packages/ui/src/DetailPanel.tsx
+++ b/packages/ui/src/DetailPanel.tsx
@@ -9,6 +9,7 @@ import type {
   DueDatePrecision,
   ReminderType,
   RecurrenceType,
+  NavList,
 } from "@brett/types";
 import { TaskDetailPanel } from "./TaskDetailPanel";
 import { ContentDetailPanel } from "./ContentDetailPanel";
@@ -26,7 +27,9 @@ interface DetailPanelProps {
   onUpdate?: (updates: Record<string, unknown>) => void;
   onDelete?: (id: string) => void;
   onDuplicate?: (id: string) => void;
-  onMoveToList?: (id: string) => void;
+  // List picker — opens a popover anchored to the in-panel list pill
+  lists?: NavList[];
+  onSetList?: (id: string, anchorEl: HTMLElement) => void;
   // Schedule
   onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision) => void;
   onUpdateReminder?: (reminder: ReminderType | null) => void;
@@ -111,7 +114,8 @@ export function DetailPanel({
   onUpdate,
   onDelete,
   onDuplicate,
-  onMoveToList,
+  lists,
+  onSetList,
   onUpdateDueDate,
   onUpdateReminder,
   onUpdateRecurrence,
@@ -216,7 +220,8 @@ export function DetailPanel({
             onToggle={onToggle ?? (() => {})}
             onDelete={onDelete ?? (() => {})}
             onDuplicate={onDuplicate ?? (() => {})}
-            onMoveToList={onMoveToList ?? (() => {})}
+            lists={lists}
+            onSetList={onSetList}
             onUpdateDueDate={onUpdateDueDate}
             onUpdateReminder={onUpdateReminder}
             onUpdateRecurrence={onUpdateRecurrence}
@@ -269,7 +274,8 @@ export function DetailPanel({
             onToggle={onToggle ?? (() => {})}
             onDelete={onDelete ?? (() => {})}
             onDuplicate={onDuplicate ?? (() => {})}
-            onMoveToList={onMoveToList ?? (() => {})}
+            lists={lists}
+            onSetList={onSetList}
             onUpdateDueDate={onUpdateDueDate}
             onUpdateReminder={onUpdateReminder}
             onUpdateRecurrence={onUpdateRecurrence}

--- a/packages/ui/src/OverflowMenu.tsx
+++ b/packages/ui/src/OverflowMenu.tsx
@@ -1,18 +1,16 @@
 import React, { useState, useRef } from "react";
-import { MoreHorizontal, Trash2, Copy, ArrowRight, Link2 } from "lucide-react";
+import { MoreHorizontal, Trash2, Copy, Link2 } from "lucide-react";
 import { useClickOutside } from "./useClickOutside";
 
 interface OverflowMenuProps {
   onDelete: () => void;
   onDuplicate: () => void;
-  onMoveToList: () => void;
   onCopyLink: () => void;
 }
 
 export function OverflowMenu({
   onDelete,
   onDuplicate,
-  onMoveToList,
   onCopyLink,
 }: OverflowMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -26,7 +24,6 @@ export function OverflowMenu({
     action: () => void;
   }[] = [
     { icon: Copy, label: "Duplicate", action: onDuplicate },
-    { icon: ArrowRight, label: "Move to List\u2026", action: onMoveToList },
     { icon: Link2, label: "Copy Link", action: onCopyLink },
   ];
 

--- a/packages/ui/src/TaskDetailPanel.tsx
+++ b/packages/ui/src/TaskDetailPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { Calendar, CheckCircle, Radar, RotateCw, ThumbsUp, ThumbsDown, X } from "lucide-react";
+import { Calendar, CheckCircle, FolderPlus, Inbox, Radar, RotateCw, ThumbsUp, ThumbsDown, X } from "lucide-react";
 import type {
   ThingDetail,
   DueDatePrecision,
@@ -7,6 +7,7 @@ import type {
   RecurrenceType,
   Attachment,
   ItemLink,
+  NavList,
   Thing,
 } from "@brett/types";
 import { OverflowMenu } from "./OverflowMenu";
@@ -27,7 +28,9 @@ interface TaskDetailPanelProps {
   onToggle: (id: string) => void;
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
-  onMoveToList: (id: string) => void;
+  // List picker — opens a popover anchored to the in-panel list pill
+  lists?: NavList[];
+  onSetList?: (id: string, anchorEl: HTMLElement) => void;
   // Schedule callbacks
   onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision) => void;
   onUpdateReminder?: (reminder: ReminderType | null) => void;
@@ -80,7 +83,8 @@ export function TaskDetailPanel({
   onToggle,
   onDelete,
   onDuplicate,
-  onMoveToList,
+  lists,
+  onSetList,
   onUpdateDueDate,
   onUpdateReminder,
   onUpdateRecurrence,
@@ -123,6 +127,10 @@ export function TaskDetailPanel({
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState(detail.title);
   const titleRef = useRef<HTMLInputElement>(null);
+  const listButtonRef = useRef<HTMLButtonElement>(null);
+  const currentListColor = detail.listId
+    ? lists?.find((l) => l.id === detail.listId)?.colorClass
+    : undefined;
 
   useEffect(() => {
     setTitleValue(detail.title);
@@ -174,7 +182,6 @@ export function TaskDetailPanel({
               <OverflowMenu
                 onDelete={() => onDelete(detail.id)}
                 onDuplicate={() => onDuplicate(detail.id)}
-                onMoveToList={() => onMoveToList(detail.id)}
                 onCopyLink={() =>
                   navigator.clipboard.writeText(`brett://things/${detail.id}`)
                 }
@@ -213,6 +220,37 @@ export function TaskDetailPanel({
             >
               {shownTitle}
             </h2>
+          )}
+
+          {/* List pill — click to open list picker */}
+          {onSetList && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                ref={listButtonRef}
+                onClick={() => listButtonRef.current && onSetList(detail.id, listButtonRef.current)}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-white/5 border border-white/10 text-white/70 hover:bg-white/10 hover:text-white transition-colors"
+              >
+                {detail.listId ? (
+                  <>
+                    <span className={`w-1.5 h-1.5 rounded-full ${currentListColor ?? "bg-white/40"}`} />
+                    <span>{detail.list}</span>
+                  </>
+                ) : detail.list && detail.list !== "Inbox" ? (
+                  <>
+                    <span className="w-1.5 h-1.5 rounded-full bg-white/40" />
+                    <span>{detail.list}</span>
+                  </>
+                ) : (
+                  <>
+                    <Inbox size={11} className="text-white/50" />
+                    <span>Inbox</span>
+                    <span className="text-white/30">·</span>
+                    <FolderPlus size={11} className="text-white/50" />
+                    <span className="text-white/50">Add to list</span>
+                  </>
+                )}
+              </button>
+            </div>
           )}
 
           {/* Meeting provenance */}

--- a/packages/ui/src/ThingCard.tsx
+++ b/packages/ui/src/ThingCard.tsx
@@ -84,7 +84,7 @@ export function ThingCard({ thing, onClick, onToggle, onFocus, isFocused, onReco
       case "overdue":
         return "bg-transparent text-brett-red border-transparent";
       case "today":
-        return "bg-amber-500/20 text-amber-400 border border-amber-500/20";
+        return "bg-transparent text-brett-gold border-transparent";
       default:
         return "bg-white/5 text-white/50 border border-white/5";
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@fontsource-variable/plus-jakarta-sans':
         specifier: ^5.2.8
         version: 5.2.8
+      '@fontsource-variable/source-serif-4':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@tanstack/react-query':
         specifier: ^5.60.0
         version: 5.90.21(react@19.2.5)
@@ -2313,6 +2316,10 @@ packages:
 
   /@fontsource-variable/plus-jakarta-sans@5.2.8:
     resolution: {integrity: sha512-iQecBizIdZxezODNHzOn4SvvRMrZL/S8k4MEXGDynCmUrImVW0VmX+tIAMqnADwH4haXlHSXqMgU6+kcfBQJdw==}
+    dev: false
+
+  /@fontsource-variable/source-serif-4@5.2.9:
+    resolution: {integrity: sha512-PPcxjLFk/fS0WHg79pDM2YNvz61kC+oYZ5cWZZyCS0DHpJncmuYOuiZAsvj4tDxlWPBEvxxcRLQQNmSaRbPkqw==}
     dev: false
 
   /@google/generative-ai@0.24.1:


### PR DESCRIPTION
## Summary

Promotes three commits from main:

- **feat(desktop): inline list picker on detail pane, gold \"Today\" label** — clickable list pill on TaskDetailPanel + ContentDetailPanel; \"Today\" renders as plain gold text matching overdue, no pill collision with the list name slot; removes the broken \"Move to List…\" overflow entry.
- **style(briefing): refine type stack** — system NY header, Source Serif prose, underline links.
- **docs(claude.md): clarify release pipeline — three steps, not one** (no runtime impact).

## Test plan

- [ ] CI: typecheck + tests pass
- [ ] Railway API deploy succeeds + health check
- [ ] Cut desktop release locally with \`scripts/release.sh desktop\` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)