### PR TITLE
Release: split This Weekend bucket end-to-end

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -496,24 +496,39 @@ export function App() {
   const endOfWeekISO = useMemo(() => getEndOfWeekUTC(new Date(todayKey)).toISOString(), [todayKey]);
   const { data: activeThingsForCount = [], isSuccess: todayQuerySuccess } = useActiveThings(endOfWeekISO);
 
-  // Push the Today count (overdue + due today + this week) to the macOS
-  // dock via the main process. Gates on `todayQuerySuccess` so the dock
-  // doesn't flash 0 during the brief hydration window before the first
-  // Today query resolves. Clears to 0 when signed out so the dock doesn't
-  // keep a stale number for the previous user. No-op in browsers and on
+  // Push the Today count to the macOS dock via the main process.
+  //
+  // Inclusion rules:
+  //   - Always: overdue + today + this_week (the upcoming workweek)
+  //   - On Sat/Sun only: + this_weekend (the current weekend has arrived)
+  //
+  // Weekend items are intentionally excluded from the badge during the
+  // workweek — the user shouldn't see a Saturday item pestering them on
+  // Tuesday. Once Saturday rolls around, those items roll into the badge.
+  //
+  // Gates on `todayQuerySuccess` so the dock doesn't flash 0 during the
+  // hydration window. Clears to 0 when signed out. No-op in browsers /
   // Windows. iOS parity lives in apps/ios/Brett/Services/BadgeManager.
   const badgeUserId = user?.id ?? null;
+  const isWeekendNow = useMemo(() => {
+    const dow = new Date(todayKey).getUTCDay();
+    return dow === 0 || dow === 6;
+  }, [todayKey]);
+  const badgeCount = useMemo(() => {
+    if (!badgeUserId) return 0;
+    return activeThingsForCount.filter((t: { urgency?: string }) => {
+      if (t.urgency === "this_weekend") return isWeekendNow;
+      return true;
+    }).length;
+  }, [badgeUserId, activeThingsForCount, isWeekendNow]);
   useEffect(() => {
     const api = (window as { electronAPI?: { setBadgeCount?: (n: number) => Promise<void> } }).electronAPI;
     if (!api?.setBadgeCount) return;
-    // While signed in, wait for the first successful query before writing
-    // a number. While signed out, push 0 immediately to clear.
     if (badgeUserId && !todayQuerySuccess) return;
-    const count = badgeUserId ? activeThingsForCount.length : 0;
-    api.setBadgeCount(count).catch(() => {
+    api.setBadgeCount(badgeCount).catch(() => {
       // Ignore — losing a badge update is strictly cosmetic.
     });
-  }, [badgeUserId, todayQuerySuccess, activeThingsForCount.length]);
+  }, [badgeUserId, todayQuerySuccess, badgeCount]);
 
   // Upcoming badge count
   const { data: upcomingThings = [] } = useUpcomingThings();
@@ -1257,7 +1272,7 @@ export function App() {
             isCollapsed={isDetailOpen || (location.pathname === "/scouts" && selectedScoutId !== null)}
             lists={lists}
             user={user}
-            incompleteCount={activeThingsForCount.length}
+            incompleteCount={badgeCount}
             currentPath={location.pathname}
             navigate={navigate}
             upcomingCount={upcomingThings.length}

--- a/apps/desktop/src/views/TodayView.tsx
+++ b/apps/desktop/src/views/TodayView.tsx
@@ -135,15 +135,32 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
       overdue: uncompleted.filter((t) => t.urgency === "overdue"),
       today: uncompleted.filter((t) => t.urgency === "today"),
       thisWeek: uncompleted.filter((t) => t.urgency === "this_week"),
+      thisWeekend: uncompleted.filter((t) => t.urgency === "this_weekend"),
       done,
     };
   }, [filteredThings]);
 
   const sections = useMemo(() => {
+    const dow = new Date().getUTCDay();
+    const isWeekendNow = dow === 0 || dow === 6;
     const list: Array<{ key: string; title: string; count: number }> = [];
     if (grouped.overdue.length > 0) list.push({ key: "overdue", title: "Overdue", count: grouped.overdue.length });
     if (grouped.today.length > 0) list.push({ key: "today", title: "Today", count: grouped.today.length });
-    if (grouped.thisWeek.length > 0) list.push({ key: "this-week", title: "This Week", count: grouped.thisWeek.length });
+    const weekend = grouped.thisWeekend.length > 0
+      ? { key: "this-weekend", title: "This Weekend", count: grouped.thisWeekend.length }
+      : null;
+    const week = grouped.thisWeek.length > 0
+      ? { key: "this-week", title: "This Week", count: grouped.thisWeek.length }
+      : null;
+    // Chronological ordering — weekend first on Sat/Sun (it's imminent),
+    // week first on Mon-Fri (Fri comes before the weekend).
+    if (isWeekendNow) {
+      if (weekend) list.push(weekend);
+      if (week) list.push(week);
+    } else {
+      if (week) list.push(week);
+      if (weekend) list.push(weekend);
+    }
     if (grouped.done.length > 0) list.push({ key: "done-today", title: "Done Today", count: grouped.done.length });
     return list;
   }, [grouped]);

--- a/apps/ios/Brett/Models/Enums.swift
+++ b/apps/ios/Brett/Models/Enums.swift
@@ -18,6 +18,7 @@ enum Urgency: String, Codable, CaseIterable {
     case overdue
     case today
     case thisWeek = "this_week"
+    case thisWeekend = "this_weekend"
     case nextWeek = "next_week"
     case later
     case done

--- a/apps/ios/Brett/Utilities/DateHelpers.swift
+++ b/apps/ios/Brett/Utilities/DateHelpers.swift
@@ -12,6 +12,37 @@ enum DateHelpers {
         return cal
     }()
 
+    /// Day-offset ranges (relative to today) used to classify due dates
+    /// into the four forward-looking urgency buckets. Mirrors the TS
+    /// `urgencyBucketRanges` helper in `packages/business/src/index.ts`
+    /// exactly — change one, change the other.
+    private struct UrgencyRanges {
+        let thisWeekStart: Int
+        let thisWeekEnd: Int
+        let thisWeekendStart: Int
+        let thisWeekendEnd: Int
+        let nextWeekEnd: Int
+    }
+
+    private static func urgencyRanges(weekday: Int) -> UrgencyRanges {
+        // Apple's Calendar.weekday: Sun=1..Sat=7. Convert to JS-style
+        // 0=Sun..6=Sat so the math reads the same as desktop.
+        let dow = weekday - 1
+        if dow == 0 {
+            return UrgencyRanges(thisWeekStart: 1, thisWeekEnd: 5, thisWeekendStart: 6, thisWeekendEnd: 7, nextWeekEnd: 14)
+        }
+        if dow == 6 {
+            return UrgencyRanges(thisWeekStart: 2, thisWeekEnd: 6, thisWeekendStart: 1, thisWeekendEnd: 1, nextWeekEnd: 8)
+        }
+        return UrgencyRanges(
+            thisWeekStart: 1,
+            thisWeekEnd: 5 - dow,
+            thisWeekendStart: 6 - dow,
+            thisWeekendEnd: 7 - dow,
+            nextWeekEnd: 14 - dow
+        )
+    }
+
     static func computeUrgency(dueDate: Date?, isCompleted: Bool, now: Date = Date()) -> Urgency {
         if isCompleted { return .done }
         guard let dueDate else { return .later }
@@ -23,29 +54,25 @@ enum DateHelpers {
         if startOfDueDay < startOfToday {
             return .overdue
         }
-
         if startOfDueDay == startOfToday {
             return .today
         }
 
-        // Boundary mirrors desktop's `computeUrgency` exactly: "this week"
-        // is inclusive of the upcoming Sunday; on Sunday itself it
-        // extends a full 7 days. Same end-of-Sunday-UTC moment as
-        // `TodaySections.bucket()`, just compared with `<=` against
-        // `startOfDueDay` (also UTC-stripped) instead of `<` against
-        // start-of-Monday — equivalent semantics.
         let weekday = calendar.component(.weekday, from: now)
-        let daysUntilEndOfWeek = weekday == 1 ? 7 : (8 - weekday) // Sunday = 1
-        let endOfWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday)!
-        if startOfDueDay <= endOfWeek {
+        let r = urgencyRanges(weekday: weekday)
+        let diff = calendar.dateComponents([.day], from: startOfToday, to: startOfDueDay).day ?? 0
+        let dueWeekday = calendar.component(.weekday, from: startOfDueDay)
+        let isWeekendDay = dueWeekday == 1 || dueWeekday == 7 // Sun or Sat
+
+        if isWeekendDay && diff >= r.thisWeekendStart && diff <= r.thisWeekendEnd {
+            return .thisWeekend
+        }
+        if !isWeekendDay && diff >= r.thisWeekStart && diff <= r.thisWeekEnd {
             return .thisWeek
         }
-
-        let endOfNextWeek = calendar.date(byAdding: .day, value: 7, to: endOfWeek)!
-        if startOfDueDay <= endOfNextWeek {
+        if diff <= r.nextWeekEnd {
             return .nextWeek
         }
-
         return .later
     }
 

--- a/apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
+++ b/apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
@@ -56,18 +56,14 @@ enum QuickScheduleOption: String, CaseIterable, Identifiable {
         case .tomorrow:
             return calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: now) ?? now)
         case .thisWeekend:
-            // Next Saturday (weekday 7 in Gregorian). If today *is* Saturday,
-            // prefer the upcoming one — users interpret "this weekend" as
-            // "the weekend ahead of me."
+            // If today is already Saturday (7) or Sunday (1), we ARE in the weekend
+            // — pick today. Otherwise jump to the upcoming Saturday.
             let today = calendar.startOfDay(for: now)
             let weekday = calendar.component(.weekday, from: today) // Sun=1..Sat=7
-            let daysUntilSaturday: Int
-            if weekday == 7 {
-                daysUntilSaturday = 7 // today is Saturday — jump to next one
-            } else {
-                daysUntilSaturday = 7 - weekday
+            if weekday == 7 || weekday == 1 {
+                return today
             }
-            return calendar.date(byAdding: .day, value: daysUntilSaturday, to: today)
+            return calendar.date(byAdding: .day, value: 7 - weekday, to: today)
         case .nextWeek:
             return calendar.startOfDay(for: calendar.date(byAdding: .day, value: 7, to: now) ?? now)
         case .inAMonth:

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -383,7 +383,13 @@ private struct TodayPageBody: View {
             onDelete: delete
         )
 
-        TaskSection(
+        // Chronological ordering: weekend first on Sat/Sun, week first on
+        // Mon-Fri. Mirrors the same rule on desktop's ThingsList +
+        // TodayView. The two TaskSection calls are identical aside from
+        // their inputs — kept inline so the builder doesn't fight us.
+        let weekday = Calendar.current.component(.weekday, from: Date())
+        let isWeekendNow = weekday == 1 || weekday == 7
+        let weekSection = TaskSection(
             label: "This Week",
             icon: "calendar",
             items: s.thisWeek,
@@ -395,6 +401,26 @@ private struct TodayPageBody: View {
             onArchive: archive,
             onDelete: delete
         )
+        let weekendSection = TaskSection(
+            label: "This Weekend",
+            icon: "sparkles",
+            items: s.thisWeekend,
+            labelColor: .white,
+            listNameProvider: nameProvider,
+            onToggle: toggle,
+            onSelect: select,
+            onSchedule: schedule,
+            onArchive: archive,
+            onDelete: delete
+        )
+
+        if isWeekendNow {
+            weekendSection
+            weekSection
+        } else {
+            weekSection
+            weekendSection
+        }
 
         TaskSection(
             label: "Next Week",

--- a/apps/ios/Brett/Views/Today/TodaySections.swift
+++ b/apps/ios/Brett/Views/Today/TodaySections.swift
@@ -13,11 +13,12 @@ struct TodaySections {
     let overdue: [Item]
     let today: [Item]
     let thisWeek: [Item]
+    let thisWeekend: [Item]
     let nextWeek: [Item]
     let doneToday: [Item]
 
     var activeCount: Int {
-        overdue.count + today.count + thisWeek.count + nextWeek.count
+        overdue.count + today.count + thisWeek.count + thisWeekend.count + nextWeek.count
     }
 
     var hasDoneToday: Bool { !doneToday.isEmpty }
@@ -25,14 +26,25 @@ struct TodaySections {
     var isEveryActiveSectionEmpty: Bool { activeCount == 0 }
 
     /// Count shown on the iOS home-screen badge and the macOS dock badge.
-    /// Overdue + due today + due this week, excluding Next Week, completed,
-    /// archived, and items without a due date. Semantically identical to
-    /// desktop's `activeThingsForCount.length` in `apps/desktop/src/App.tsx`
-    /// — both bucket on the same UTC day/week boundaries, so a row that
-    /// counts on one client counts on the other.
+    ///
+    /// Inclusion rules (must stay in lockstep with desktop's `App.tsx`
+    /// `badgeCount`):
+    ///   - Always: overdue + today + thisWeek
+    ///   - On Sat/Sun: + thisWeekend (the weekend has arrived)
+    ///
+    /// Weekend items deliberately stay out of the badge on weekdays —
+    /// a Saturday task shouldn't nag the user on Tuesday — but roll in
+    /// once the weekend itself arrives.
     static func badgeCount(items: [Item], now: Date = Date()) -> Int {
         let s = bucket(items: items, reflowKey: 0, now: now)
-        return s.overdue.count + s.today.count + s.thisWeek.count
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let weekday = cal.component(.weekday, from: now) // Sun=1..Sat=7
+        let isWeekend = weekday == 1 || weekday == 7
+        return s.overdue.count
+            + s.today.count
+            + s.thisWeek.count
+            + (isWeekend ? s.thisWeekend.count : 0)
     }
 
     /// UTC calendar — matches desktop's `getTodayUTC` / `getEndOfWeekUTC`
@@ -73,26 +85,46 @@ struct TodaySections {
         let startOfToday = calendar.startOfDay(for: now)
         let endOfToday = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday.addingTimeInterval(86_400)
 
-        // Boundary mirrors desktop's `computeUrgency`
-        // (`packages/business/src/index.ts`) exactly: "this week" is
-        // inclusive of the upcoming Sunday; on Sunday itself it extends
-        // a full 7 days. Desktop achieves this with `dueMs <=
-        // endOfThisWeek` against start-of-Sunday UTC. We use `<` against
-        // start-of-Monday UTC (one day past Sunday) so the comparison
-        // stays symmetric with `endOfToday` and so a row stored anywhere
-        // on Sunday — including 00:00:00 UTC — buckets identically on
-        // both clients. The previous off-by-one (boundary at start-of-
-        // Sunday with `<`) was dropping every Sunday-due task into
-        // `nextWeek` and every following-Sunday task out of the bucket
-        // entirely.
-        let weekday = calendar.component(.weekday, from: now)
-        let daysUntilEndOfWeek = weekday == 1 ? 8 : (9 - weekday) // Sunday = 1; +1 day past upcoming Sunday
-        let endOfThisWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday) ?? endOfToday
-        let endOfNextWeek = calendar.date(byAdding: .day, value: 7, to: endOfThisWeek) ?? endOfThisWeek.addingTimeInterval(7 * 86_400)
+        // Boundary offsets mirror desktop's TS `urgencyBucketRanges` in
+        // `packages/business/src/index.ts` EXACTLY — change one, change
+        // the other. The four forward-looking buckets are partitioned by
+        // (day-of-week of today) × (day-of-week of the due date):
+        //
+        //   - thisWeek    = next upcoming Mon-Fri workweek
+        //   - thisWeekend = next upcoming Sat-Sun pair
+        //   - nextWeek    = the calendar week after thisWeekend
+        //   - everything beyond → dropped (this surface only renders
+        //     overdue..nextWeek; "later" doesn't render here)
+        //
+        // We compute END boundaries as "start of the day AFTER the last
+        // included day" so `<` against `startOfDueDay` (UTC-stripped)
+        // gives inclusive semantics on the named end day. The TS layer
+        // uses `<=` against the named end day directly; mathematically
+        // identical when both sides are start-of-day UTC.
+        let weekday = calendar.component(.weekday, from: now) // Sun=1..Sat=7
+        let dow = weekday - 1 // 0=Sun..6=Sat (matches TS getUTCDay())
+
+        struct Ranges { let thisWeekStart, thisWeekEnd, thisWeekendStart, thisWeekendEnd, nextWeekEnd: Int }
+        let r: Ranges = {
+            if dow == 0 {
+                return Ranges(thisWeekStart: 1, thisWeekEnd: 5, thisWeekendStart: 6, thisWeekendEnd: 7, nextWeekEnd: 14)
+            }
+            if dow == 6 {
+                return Ranges(thisWeekStart: 2, thisWeekEnd: 6, thisWeekendStart: 1, thisWeekendEnd: 1, nextWeekEnd: 8)
+            }
+            return Ranges(
+                thisWeekStart: 1,
+                thisWeekEnd: 5 - dow,
+                thisWeekendStart: 6 - dow,
+                thisWeekendEnd: 7 - dow,
+                nextWeekEnd: 14 - dow
+            )
+        }()
 
         var overdue: [Item] = []
         var today: [Item] = []
         var thisWeek: [Item] = []
+        var thisWeekend: [Item] = []
         var nextWeek: [Item] = []
         var doneToday: [Item] = []
 
@@ -113,17 +145,28 @@ struct TodaySections {
                 continue
             }
 
-            // Active tasks only from here on out.
             if effectiveStatus != .active { continue }
             guard let due = item.dueDate else { continue }
 
             if due < startOfToday {
                 overdue.append(item)
-            } else if due < endOfToday {
+                continue
+            }
+            if due < endOfToday {
                 today.append(item)
-            } else if due < endOfThisWeek {
+                continue
+            }
+
+            let startOfDueDay = calendar.startOfDay(for: due)
+            let diff = calendar.dateComponents([.day], from: startOfToday, to: startOfDueDay).day ?? 0
+            let dueWeekday = calendar.component(.weekday, from: startOfDueDay)
+            let isWeekendDay = dueWeekday == 1 || dueWeekday == 7
+
+            if isWeekendDay && diff >= r.thisWeekendStart && diff <= r.thisWeekendEnd {
+                thisWeekend.append(item)
+            } else if !isWeekendDay && diff >= r.thisWeekStart && diff <= r.thisWeekEnd {
                 thisWeek.append(item)
-            } else if due < endOfNextWeek {
+            } else if diff <= r.nextWeekEnd {
                 nextWeek.append(item)
             }
         }
@@ -144,6 +187,7 @@ struct TodaySections {
             overdue: overdue.sorted(by: activeSort),
             today: today.sorted(by: activeSort),
             thisWeek: thisWeek.sorted(by: activeSort),
+            thisWeekend: thisWeekend.sorted(by: activeSort),
             nextWeek: nextWeek.sorted(by: activeSort),
             doneToday: doneToday.sorted {
                 if let a = $0.completedAt, let b = $1.completedAt, a != b {

--- a/apps/ios/BrettTests/Views/QuickScheduleTests.swift
+++ b/apps/ios/BrettTests/Views/QuickScheduleTests.swift
@@ -27,11 +27,23 @@ struct QuickScheduleTests {
 
     private func saturdayAnchor() -> Date {
         // Saturday, April 18, 2026 at 09:00 local — used to verify the
-        // "today is Saturday → roll over to next Saturday" case.
+        // "today is Saturday → resolve to today" case.
         var comps = DateComponents()
         comps.year = 2026
         comps.month = 4
         comps.day = 18
+        comps.hour = 9
+        comps.minute = 0
+        return Calendar(identifier: .gregorian).date(from: comps)!
+    }
+
+    private func sundayAnchor() -> Date {
+        // Sunday, April 19, 2026 at 09:00 local — used to verify the
+        // "today is Sunday → resolve to today" case.
+        var comps = DateComponents()
+        comps.year = 2026
+        comps.month = 4
+        comps.day = 19
         comps.hour = 9
         comps.minute = 0
         return Calendar(identifier: .gregorian).date(from: comps)!
@@ -73,12 +85,22 @@ struct QuickScheduleTests {
         #expect(diff == 4, "Tue → Sat is 4 days away")
     }
 
-    @Test("This Weekend rolls to NEXT Saturday when today is already Saturday")
-    func weekendRollsWhenTodayIsSaturday() {
+    @Test("This Weekend resolves to today when today is already Saturday")
+    func weekendIsTodayWhenSaturday() {
         let now = saturdayAnchor()
         let resolved = QuickScheduleOption.thisWeekend.resolvedDate(now: now, calendar: calendar)!
+        #expect(calendar.isDate(resolved, inSameDayAs: now), "Saturday should resolve to today — we ARE in the weekend")
         let diff = calendar.dateComponents([.day], from: calendar.startOfDay(for: now), to: resolved).day
-        #expect(diff == 7, "Saturday should resolve to *next* Saturday, not today")
+        #expect(diff == 0)
+    }
+
+    @Test("This Weekend resolves to today when today is Sunday")
+    func weekendIsTodayWhenSunday() {
+        let now = sundayAnchor()
+        let resolved = QuickScheduleOption.thisWeekend.resolvedDate(now: now, calendar: calendar)!
+        #expect(calendar.isDate(resolved, inSameDayAs: now), "Sunday should resolve to today — we ARE in the weekend")
+        let diff = calendar.dateComponents([.day], from: calendar.startOfDay(for: now), to: resolved).day
+        #expect(diff == 0)
     }
 
     // MARK: - Next Week

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -2,123 +2,162 @@ import Foundation
 import Testing
 @testable import Brett
 
-/// Tests for `TodaySections.badgeCount(items:)` — the number that drives
-/// the iOS home-screen badge. Count = overdue + due today + this week,
-/// excluding Next Week, completed, and archived items.
+/// Tests for `TodaySections.badgeCount(items:now:)` — the number that
+/// drives the iOS home-screen badge.
+///
+/// Rules under test:
+///   - Always: overdue + today + thisWeek
+///   - On Sat/Sun only: + thisWeekend (weekend items roll in once it IS
+///     the weekend)
+///
+/// Anchored on fixed dates (Wednesday + Saturday) to make assertions
+/// time-independent. Calendar is forced to UTC so date arithmetic agrees
+/// with `TodaySections.bucket()` regardless of the host timezone.
 @Suite("TodaySections.badgeCount", .tags(.views))
 struct TodaySectionsBadgeTests {
 
-    /// Fixtures align to the same UTC calendar `TodaySections.bucket()`
-    /// uses internally — without this, a "noon today (local)" date can
-    /// land in a different UTC bucket on machines whose timezone shifts
-    /// it across midnight UTC. Matches desktop's bucketing semantics.
     private let calendar: Calendar = {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone(identifier: "UTC")!
         return cal
     }()
 
-    // MARK: - Dates
+    // MARK: - Fixed reference dates
 
-    private var startOfToday: Date { calendar.startOfDay(for: Date()) }
-    private var yesterday: Date { calendar.date(byAdding: .day, value: -1, to: startOfToday)! }
-    private var noonToday: Date { calendar.date(byAdding: .hour, value: 12, to: startOfToday)! }
-    /// A date strictly inside "this week" but after today. Mirrors the
-    /// `bucket()` formula: end-of-this-week is start-of-Monday UTC (one
-    /// day past the upcoming Sunday, matching desktop's inclusive
-    /// `<= endOfThisWeek` boundary). Returning one hour before that lands
-    /// inside `thisWeek` on every weekday including Saturday and Sunday.
-    private var laterThisWeek: Date {
-        let weekday = calendar.component(.weekday, from: Date())
-        let daysUntilEndOfWeek = weekday == 1 ? 8 : (9 - weekday)
-        let endOfWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday)!
-        return calendar.date(byAdding: .hour, value: -1, to: endOfWeek)!
-    }
-    private var nextWeek: Date {
-        let weekday = calendar.component(.weekday, from: Date())
-        let daysUntilEndOfWeek = weekday == 1 ? 8 : (9 - weekday)
-        let endOfWeek = calendar.date(byAdding: .day, value: daysUntilEndOfWeek, to: startOfToday)!
-        return calendar.date(byAdding: .day, value: 2, to: endOfWeek)!
+    /// Wednesday April 15, 2026 at 12:00 UTC — mid-week anchor.
+    private static let wednesdayNow: Date = {
+        var c = DateComponents()
+        c.year = 2026; c.month = 4; c.day = 15; c.hour = 12
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }()
+
+    /// Saturday April 18, 2026 at 12:00 UTC — weekend anchor.
+    private static let saturdayNow: Date = {
+        var c = DateComponents()
+        c.year = 2026; c.month = 4; c.day = 18; c.hour = 12
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }()
+
+    private func days(_ n: Int, from base: Date) -> Date {
+        calendar.date(byAdding: .day, value: n, to: base)!
     }
 
     // MARK: - Cases
 
     @Test func emptyInputReturnsZero() {
-        #expect(TodaySections.badgeCount(items: []) == 0)
+        #expect(TodaySections.badgeCount(items: [], now: Self.wednesdayNow) == 0)
     }
 
-    @Test func countsOverdue() {
+    @Test func countsOverdueOnWeekday() {
+        let yesterday = days(-1, from: Self.wednesdayNow)
         let items = [
             TestFixtures.makeItem(status: .active, dueDate: yesterday),
             TestFixtures.makeItem(status: .active, dueDate: yesterday),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 2)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 2)
     }
 
-    @Test func countsToday() {
+    @Test func countsTodayOnWeekday() {
         let items = [
-            TestFixtures.makeItem(status: .active, dueDate: noonToday),
+            TestFixtures.makeItem(status: .active, dueDate: Self.wednesdayNow),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 1)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 1)
     }
 
-    @Test func countsThisWeek() {
+    @Test func countsThisWeekOnWeekday() {
+        // Thu/Fri from Wed → thisWeek bucket → counted.
+        let thursday = days(1, from: Self.wednesdayNow)
+        let friday = days(2, from: Self.wednesdayNow)
         let items = [
-            TestFixtures.makeItem(status: .active, dueDate: laterThisWeek),
+            TestFixtures.makeItem(status: .active, dueDate: thursday),
+            TestFixtures.makeItem(status: .active, dueDate: friday),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 1)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 2)
+    }
+
+    @Test func excludesThisWeekendOnWeekday() {
+        // The key new rule: Saturday and Sunday do NOT count toward the
+        // badge while today is a weekday. Sat/Sun from Wed land in
+        // `thisWeekend`, which is excluded until the weekend arrives.
+        let saturday = days(3, from: Self.wednesdayNow)
+        let sunday = days(4, from: Self.wednesdayNow)
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: saturday),
+            TestFixtures.makeItem(status: .active, dueDate: sunday),
+        ]
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 0)
+    }
+
+    @Test func includesThisWeekendOnSaturday() {
+        // Same Sat/Sun items, now evaluated on Saturday — they should
+        // count toward the badge ("until it IS the weekend").
+        let sunday = days(1, from: Self.saturdayNow)
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: Self.saturdayNow), // today urgency
+            TestFixtures.makeItem(status: .active, dueDate: sunday),            // thisWeekend
+        ]
+        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow) == 2)
     }
 
     @Test func excludesNextWeek() {
+        // Eight days past Wed = Thu of next week — well into nextWeek.
+        let eightDaysOut = days(8, from: Self.wednesdayNow)
         let items = [
-            TestFixtures.makeItem(status: .active, dueDate: nextWeek),
+            TestFixtures.makeItem(status: .active, dueDate: eightDaysOut),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 0)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 0)
     }
 
     @Test func excludesCompletedItems() {
+        let yesterday = days(-1, from: Self.wednesdayNow)
         let items = [
             TestFixtures.makeItem(status: .done, dueDate: yesterday),
-            TestFixtures.makeItem(status: .done, dueDate: noonToday),
+            TestFixtures.makeItem(status: .done, dueDate: Self.wednesdayNow),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 0)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 0)
     }
 
     @Test func excludesArchivedItems() {
+        let yesterday = days(-1, from: Self.wednesdayNow)
         let items = [
             TestFixtures.makeItem(status: .archived, dueDate: yesterday),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 0)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 0)
     }
 
     @Test func excludesSnoozedItems() {
-        // Snoozed items are hidden from the Today view until their snooze
-        // expires, so the badge should match what the user sees on-screen
-        // — zero contribution regardless of the due date.
+        let yesterday = days(-1, from: Self.wednesdayNow)
         let items = [
             TestFixtures.makeItem(status: .snoozed, dueDate: yesterday),
-            TestFixtures.makeItem(status: .snoozed, dueDate: noonToday),
+            TestFixtures.makeItem(status: .snoozed, dueDate: Self.wednesdayNow),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 0)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 0)
     }
 
     @Test func excludesItemsWithoutDueDate() {
         let items = [
             TestFixtures.makeItem(status: .active, dueDate: nil),
         ]
-        #expect(TodaySections.badgeCount(items: items) == 0)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 0)
     }
 
-    @Test func sumsBucketsTogether() {
+    @Test func sumsBucketsTogetherOnWeekday() {
+        let yesterday = days(-1, from: Self.wednesdayNow)
+        let thursday = days(1, from: Self.wednesdayNow)
+        let saturday = days(3, from: Self.wednesdayNow)
+        let nextThursday = days(8, from: Self.wednesdayNow)
         let items = [
-            TestFixtures.makeItem(status: .active,  dueDate: yesterday),
-            TestFixtures.makeItem(status: .active,  dueDate: noonToday),
-            TestFixtures.makeItem(status: .active,  dueDate: laterThisWeek),
-            TestFixtures.makeItem(status: .active,  dueDate: nextWeek),       // excluded
-            TestFixtures.makeItem(status: .done,    dueDate: noonToday),       // excluded
-            TestFixtures.makeItem(status: .snoozed, dueDate: yesterday),       // excluded
-            TestFixtures.makeItem(status: .active,  dueDate: nil),             // excluded
+            TestFixtures.makeItem(status: .active,  dueDate: yesterday),         // overdue ✓
+            TestFixtures.makeItem(status: .active,  dueDate: Self.wednesdayNow), // today ✓
+            TestFixtures.makeItem(status: .active,  dueDate: thursday),          // thisWeek ✓
+            TestFixtures.makeItem(status: .active,  dueDate: saturday),          // thisWeekend ✗ (weekday)
+            TestFixtures.makeItem(status: .active,  dueDate: nextThursday),      // nextWeek ✗
+            TestFixtures.makeItem(status: .done,    dueDate: Self.wednesdayNow), // ✗
+            TestFixtures.makeItem(status: .snoozed, dueDate: yesterday),         // ✗
+            TestFixtures.makeItem(status: .active,  dueDate: nil),               // ✗
         ]
-        #expect(TodaySections.badgeCount(items: items) == 3)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow) == 3)
     }
 }

--- a/apps/ios/BrettTests/Views/TodaySectionsTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsTests.swift
@@ -139,11 +139,10 @@ struct TodaySectionsTests {
         return Calendar(identifier: .gregorian).date(from: c)!
     }
 
-    @Test func sundayDueOnSaturdayBucketsAsThisWeek() throws {
-        // The exact bug we shipped against: on Saturday, a task due the
-        // upcoming Sunday must land in `thisWeek` to match desktop's
-        // `computeUrgency` (`packages/business/src/index.ts`), which treats
-        // `dueMs <= endOfThisWeek` (Sunday midnight UTC) as inclusive.
+    @Test func sundayDueOnSaturdayBucketsAsThisWeekend() throws {
+        // On Saturday, the upcoming Sunday is the second day of the
+        // current weekend — must land in `thisWeekend`, not `thisWeek`.
+        // Mirrors desktop's `computeUrgency` returning "this_weekend".
         let ctx = try makeContext()
         let saturday = Self.utcDate(2026, 4, 25, 12)         // Sat noon UTC
         let sundayDue = Self.utcDate(2026, 4, 26, 0)         // Sun 00:00 UTC — boundary
@@ -152,14 +151,15 @@ struct TodaySectionsTests {
 
         let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
 
-        #expect(sections.thisWeek.map(\.id) == [item.id])
+        #expect(sections.thisWeekend.map(\.id) == [item.id])
+        #expect(sections.thisWeek.isEmpty)
         #expect(sections.nextWeek.isEmpty)
     }
 
-    @Test func sundayDueLaterInDayOnSaturdayBucketsAsThisWeek() throws {
-        // Same day-of-week boundary, but with a non-midnight time on the
-        // due date. Desktop strips to `utcDay(dueDate)` so any moment on
-        // Sunday counts as "this week" today (Saturday).
+    @Test func sundayDueLaterInDayOnSaturdayBucketsAsThisWeekend() throws {
+        // Same day-of-week boundary, non-midnight time. `bucket()` strips
+        // to start-of-day before comparing day-of-week, so any moment on
+        // Sunday classifies as `thisWeekend` when today is Saturday.
         let ctx = try makeContext()
         let saturday = Self.utcDate(2026, 4, 25, 12)
         let sundayLate = Self.utcDate(2026, 4, 26, 23)       // Sun 23:00 UTC
@@ -168,14 +168,13 @@ struct TodaySectionsTests {
 
         let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
 
-        #expect(sections.thisWeek.map(\.id) == [item.id])
-        #expect(sections.nextWeek.isEmpty)
+        #expect(sections.thisWeekend.map(\.id) == [item.id])
+        #expect(sections.thisWeek.isEmpty)
     }
 
-    @Test func mondayDueOnSaturdayBucketsAsNextWeek() throws {
-        // Sanity check the upper edge — Monday must still fall to
-        // `nextWeek`. Catches an over-correction (e.g. +2 days instead of
-        // +1) that would also pull Monday in.
+    @Test func mondayDueOnSaturdayBucketsAsThisWeek() throws {
+        // On Saturday, the upcoming Mon-Fri is treated as "this week" —
+        // the next workweek begins after the current weekend ends.
         let ctx = try makeContext()
         let saturday = Self.utcDate(2026, 4, 25, 12)
         let mondayDue = Self.utcDate(2026, 4, 27, 0)
@@ -184,14 +183,14 @@ struct TodaySectionsTests {
 
         let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
 
-        #expect(sections.nextWeek.map(\.id) == [item.id])
-        #expect(sections.thisWeek.isEmpty)
+        #expect(sections.thisWeek.map(\.id) == [item.id])
+        #expect(sections.thisWeekend.isEmpty)
+        #expect(sections.nextWeek.isEmpty)
     }
 
     @Test func nextSundayDueOnSaturdayBucketsAsNextWeek() throws {
-        // Desktop puts a task on the *following* Sunday into `nextWeek`
-        // (`dueMs <= endOfNextWeek`, where `endOfNextWeek = endOfThisWeek
-        // + 7 days`). Before parity work iOS dropped this row entirely.
+        // The Sunday a week from this Saturday — falls past `thisWeekend`
+        // (which is today + tomorrow only on Saturday) and into `nextWeek`.
         let ctx = try makeContext()
         let saturday = Self.utcDate(2026, 4, 25, 12)
         let nextSunday = Self.utcDate(2026, 5, 3, 0)
@@ -201,12 +200,13 @@ struct TodaySectionsTests {
         let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: saturday)
 
         #expect(sections.nextWeek.map(\.id) == [item.id])
+        #expect(sections.thisWeekend.isEmpty)
     }
 
-    @Test func sundayTodayPutsTodayItemInTodayNotThisWeek() throws {
+    @Test func sundayTodayPutsTodayItemInTodayNotElsewhere() throws {
         // When today *is* Sunday, an item dated today must still land in
-        // `today`, not `thisWeek` — verifies the `weekday == 1` branch
-        // doesn't pull today's row forward.
+        // `today`, not in `thisWeekend` or `thisWeek` — `today` urgency
+        // takes precedence in the bucket switch.
         let ctx = try makeContext()
         let sunday = Self.utcDate(2026, 4, 26, 12)
         let sundayDue = Self.utcDate(2026, 4, 26, 18)
@@ -217,6 +217,38 @@ struct TodaySectionsTests {
 
         #expect(sections.today.map(\.id) == [item.id])
         #expect(sections.thisWeek.isEmpty)
+        #expect(sections.thisWeekend.isEmpty)
+    }
+
+    @Test func saturdayDueOnWednesdayBucketsAsThisWeekend() throws {
+        // Mid-week reference. Sat & Sun of this week are the `thisWeekend`
+        // bucket — splitting them out from `thisWeek` (which is Mon-Fri).
+        let ctx = try makeContext()
+        let wednesday = Self.utcDate(2026, 4, 22, 12)
+        let saturdayDue = Self.utcDate(2026, 4, 25, 0)
+        let sundayDue = Self.utcDate(2026, 4, 26, 0)
+        let sat = itemDue(saturdayDue)
+        let sun = itemDue(sundayDue)
+        ctx.insert(sat); ctx.insert(sun)
+
+        let sections = TodaySections.bucket(items: [sat, sun], reflowKey: 0, now: wednesday)
+
+        #expect(Set(sections.thisWeekend.map(\.id)) == Set([sat.id, sun.id]))
+        #expect(sections.thisWeek.isEmpty)
+    }
+
+    @Test func fridayDueOnWednesdayBucketsAsThisWeek() throws {
+        // Mid-week weekday → still in `thisWeek` under the new split.
+        let ctx = try makeContext()
+        let wednesday = Self.utcDate(2026, 4, 22, 12)
+        let fridayDue = Self.utcDate(2026, 4, 24, 0)
+        let item = itemDue(fridayDue)
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, now: wednesday)
+
+        #expect(sections.thisWeek.map(\.id) == [item.id])
+        #expect(sections.thisWeekend.isEmpty)
     }
 
     @Test func sortingPutsNewestCreatedFirst() throws {

--- a/packages/business/src/__tests__/business.test.ts
+++ b/packages/business/src/__tests__/business.test.ts
@@ -68,9 +68,10 @@ describe("computeUrgency", () => {
       expect(computeUrgency(new Date("2026-03-13"), "day", null, NOW)).toBe("today");
     });
 
-    it("this_week when dueDate is later this week", () => {
-      expect(computeUrgency(new Date("2026-03-14"), "day", null, NOW)).toBe("this_week");
-      expect(computeUrgency(new Date("2026-03-15"), "day", null, NOW)).toBe("this_week");
+    it("this_weekend when dueDate is Sat/Sun of the upcoming weekend", () => {
+      // From Friday, Sat (Mar 14) and Sun (Mar 15) are the upcoming weekend.
+      expect(computeUrgency(new Date("2026-03-14"), "day", null, NOW)).toBe("this_weekend");
+      expect(computeUrgency(new Date("2026-03-15"), "day", null, NOW)).toBe("this_weekend");
     });
 
     it("next_week when dueDate is next week", () => {
@@ -89,8 +90,10 @@ describe("computeUrgency", () => {
       expect(computeUrgency(new Date("2026-03-13T23:59:59Z"), "day", null, NOW)).toBe("today");
     });
 
-    it("tomorrow is this_week (not today)", () => {
-      expect(computeUrgency(new Date("2026-03-14"), "day", null, NOW)).toBe("this_week");
+    it("tomorrow (Saturday) is this_weekend when today is Friday", () => {
+      // Confirmed semantic — Friday's "tomorrow" is the start of the weekend
+      // bucket, never the workweek bucket.
+      expect(computeUrgency(new Date("2026-03-14"), "day", null, NOW)).toBe("this_weekend");
     });
   });
 
@@ -150,24 +153,32 @@ describe("computeUrgency", () => {
       expect(computeUrgency(new Date("2026-03-16"), "day", null, SUNDAY)).toBe("this_week");
     });
 
-    it("on Sunday, next Sunday is 'this_week'", () => {
-      expect(computeUrgency(new Date("2026-03-22"), "day", null, SUNDAY)).toBe("this_week");
+    it("on Sunday, next Sunday is 'this_weekend'", () => {
+      // Sun day-precision in the upcoming Sat-Sun pair → this_weekend.
+      expect(computeUrgency(new Date("2026-03-22"), "day", null, SUNDAY)).toBe("this_weekend");
     });
 
     it("on Sunday, Monday after next is 'next_week'", () => {
       expect(computeUrgency(new Date("2026-03-23"), "day", null, SUNDAY)).toBe("next_week");
     });
 
-    it("on Saturday, Sunday (tomorrow) is 'this_week'", () => {
-      expect(computeUrgency(new Date("2026-03-15"), "day", null, SATURDAY)).toBe("this_week");
+    it("on Saturday, Sunday (tomorrow) is 'this_weekend'", () => {
+      // Sat's tomorrow is still in the current weekend.
+      expect(computeUrgency(new Date("2026-03-15"), "day", null, SATURDAY)).toBe("this_weekend");
     });
 
-    it("on Saturday, next Monday is 'next_week'", () => {
-      expect(computeUrgency(new Date("2026-03-16"), "day", null, SATURDAY)).toBe("next_week");
+    it("on Saturday, next Monday is 'this_week' (upcoming workweek)", () => {
+      // On Sat/Sun, the next Mon-Fri is treated as "this week".
+      expect(computeUrgency(new Date("2026-03-16"), "day", null, SATURDAY)).toBe("this_week");
     });
 
-    it("on Monday, this Sunday is 'this_week'", () => {
-      expect(computeUrgency(new Date("2026-03-22"), "day", null, MONDAY)).toBe("this_week");
+    it("on Monday, this Sunday is 'this_weekend'", () => {
+      expect(computeUrgency(new Date("2026-03-22"), "day", null, MONDAY)).toBe("this_weekend");
+    });
+
+    it("on Monday, this Friday is 'this_week'", () => {
+      // Friday is the tail of the upcoming workweek bucket.
+      expect(computeUrgency(new Date("2026-03-20"), "day", null, MONDAY)).toBe("this_week");
     });
 
     it("on Monday, next Monday is 'next_week'", () => {
@@ -176,6 +187,38 @@ describe("computeUrgency", () => {
 
     it("on Monday, two Mondays out is 'later'", () => {
       expect(computeUrgency(new Date("2026-03-30"), "day", null, MONDAY)).toBe("later");
+    });
+  });
+
+  describe("this_week vs this_weekend split", () => {
+    // Mid-week reference: Wednesday March 11, 2026.
+    const WEDNESDAY = new Date("2026-03-11T12:00:00Z");
+
+    it("Thu and Fri from Wed are this_week", () => {
+      expect(computeUrgency(new Date("2026-03-12"), "day", null, WEDNESDAY)).toBe("this_week");
+      expect(computeUrgency(new Date("2026-03-13"), "day", null, WEDNESDAY)).toBe("this_week");
+    });
+
+    it("Sat and Sun from Wed are this_weekend", () => {
+      expect(computeUrgency(new Date("2026-03-14"), "day", null, WEDNESDAY)).toBe("this_weekend");
+      expect(computeUrgency(new Date("2026-03-15"), "day", null, WEDNESDAY)).toBe("this_weekend");
+    });
+
+    it("Mon (next week) from Wed is next_week", () => {
+      expect(computeUrgency(new Date("2026-03-16"), "day", null, WEDNESDAY)).toBe("next_week");
+    });
+
+    it("on Saturday, next-week's weekend lands in next_week (not this_weekend)", () => {
+      const SATURDAY = new Date("2026-03-14T12:00:00Z");
+      // Sat Mar 21 = 7 days after Sat Mar 14 → next_week, not this_weekend.
+      expect(computeUrgency(new Date("2026-03-21"), "day", null, SATURDAY)).toBe("next_week");
+    });
+
+    it("week-precision items stay in this_week regardless of weekday split", () => {
+      // Even though Sun (Mar 15) day-precision would be this_weekend,
+      // a week-precision item stored as that Sunday is the "this week"
+      // tag and must round-trip to this_week.
+      expect(computeUrgency(new Date("2026-03-15"), "week", null, WEDNESDAY)).toBe("this_week");
     });
   });
 
@@ -261,6 +304,10 @@ describe("computeTriageResult", () => {
     it("next_month → day precision", () => {
       expect(computeTriageResult("next_month", NOW).dueDatePrecision).toBe("day");
     });
+
+    it("this_weekend → day precision", () => {
+      expect(computeTriageResult("this_weekend", NOW).dueDatePrecision).toBe("day");
+    });
   });
 
   describe("dates from Friday (March 13)", () => {
@@ -283,6 +330,10 @@ describe("computeTriageResult", () => {
     it("next_month → April 1", () => {
       expect(computeTriageResult("next_month", NOW).dueDate).toBe("2026-04-01T00:00:00.000Z");
     });
+
+    it("this_weekend → Saturday March 14", () => {
+      expect(computeTriageResult("this_weekend", NOW).dueDate).toBe("2026-03-14T00:00:00.000Z");
+    });
   });
 
   describe("Sunday edge cases (March 15)", () => {
@@ -295,11 +346,16 @@ describe("computeTriageResult", () => {
     it("next_week → Sunday March 29", () => {
       expect(computeTriageResult("next_week", SUNDAY).dueDate).toBe("2026-03-29T00:00:00.000Z");
     });
+
+    it("this_weekend on Sunday → today (already in the weekend)", () => {
+      expect(computeTriageResult("this_weekend", SUNDAY).dueDate).toBe("2026-03-15T00:00:00.000Z");
+    });
   });
 
   describe("other days", () => {
     const MONDAY = new Date("2026-03-16T12:00:00Z");
     const SATURDAY = new Date("2026-03-14T12:00:00Z");
+    const WEDNESDAY = new Date("2026-03-11T12:00:00Z");
 
     it("this_week on Monday → Sunday March 22", () => {
       expect(computeTriageResult("this_week", MONDAY).dueDate).toBe("2026-03-22T00:00:00.000Z");
@@ -308,6 +364,18 @@ describe("computeTriageResult", () => {
     it("this_week on Saturday → Sunday March 15", () => {
       expect(computeTriageResult("this_week", SATURDAY).dueDate).toBe("2026-03-15T00:00:00.000Z");
     });
+
+    it("this_weekend on Saturday → today (already in the weekend)", () => {
+      expect(computeTriageResult("this_weekend", SATURDAY).dueDate).toBe("2026-03-14T00:00:00.000Z");
+    });
+
+    it("this_weekend on Monday → upcoming Saturday March 21", () => {
+      expect(computeTriageResult("this_weekend", MONDAY).dueDate).toBe("2026-03-21T00:00:00.000Z");
+    });
+
+    it("this_weekend on Wednesday → upcoming Saturday March 14", () => {
+      expect(computeTriageResult("this_weekend", WEDNESDAY).dueDate).toBe("2026-03-14T00:00:00.000Z");
+    });
   });
 });
 
@@ -315,7 +383,7 @@ describe("computeTriageResult", () => {
 
 describe("triage → urgency round-trip", () => {
   function triageAndClassify(
-    preset: "today" | "tomorrow" | "this_week" | "next_week" | "next_month",
+    preset: "today" | "tomorrow" | "this_weekend" | "this_week" | "next_week" | "next_month",
     now: Date
   ): Urgency {
     const result = computeTriageResult(preset, now);
@@ -324,7 +392,10 @@ describe("triage → urgency round-trip", () => {
 
   describe("from Friday (March 13)", () => {
     it("today → 'today'", () => expect(triageAndClassify("today", NOW)).toBe("today"));
-    it("tomorrow → 'this_week'", () => expect(triageAndClassify("tomorrow", NOW)).toBe("this_week"));
+    it("tomorrow → 'this_weekend'", () =>
+      // Tomorrow on Friday is Saturday — falls into the weekend bucket.
+      expect(triageAndClassify("tomorrow", NOW)).toBe("this_weekend"));
+    it("this_weekend → 'this_weekend'", () => expect(triageAndClassify("this_weekend", NOW)).toBe("this_weekend"));
     it("this_week → 'this_week'", () => expect(triageAndClassify("this_week", NOW)).toBe("this_week"));
     it("next_week → 'next_week'", () => expect(triageAndClassify("next_week", NOW)).toBe("next_week"));
     it("next_month → 'later'", () => expect(triageAndClassify("next_month", NOW)).toBe("later"));
@@ -334,6 +405,10 @@ describe("triage → urgency round-trip", () => {
     const SUNDAY = new Date("2026-03-15T12:00:00Z");
 
     it("today → 'today'", () => expect(triageAndClassify("today", SUNDAY)).toBe("today"));
+    it("this_weekend → 'today'", () =>
+      // On Sun, the "this_weekend" preset stores today → urgency is "today",
+      // not "this_weekend" (today takes precedence in the urgency switch).
+      expect(triageAndClassify("this_weekend", SUNDAY)).toBe("today"));
     it("this_week → 'this_week'", () => expect(triageAndClassify("this_week", SUNDAY)).toBe("this_week"));
     it("next_week → 'next_week'", () => expect(triageAndClassify("next_week", SUNDAY)).toBe("next_week"));
   });
@@ -342,6 +417,7 @@ describe("triage → urgency round-trip", () => {
     const MONDAY = new Date("2026-03-16T12:00:00Z");
 
     it("today → 'today'", () => expect(triageAndClassify("today", MONDAY)).toBe("today"));
+    it("this_weekend → 'this_weekend'", () => expect(triageAndClassify("this_weekend", MONDAY)).toBe("this_weekend"));
     it("this_week → 'this_week'", () => expect(triageAndClassify("this_week", MONDAY)).toBe("this_week"));
     it("next_week → 'next_week'", () => expect(triageAndClassify("next_week", MONDAY)).toBe("next_week"));
   });
@@ -349,6 +425,9 @@ describe("triage → urgency round-trip", () => {
   describe("from Saturday (March 14)", () => {
     const SATURDAY = new Date("2026-03-14T12:00:00Z");
 
+    it("this_weekend → 'today'", () =>
+      // On Sat, the "this_weekend" preset stores today → "today" urgency.
+      expect(triageAndClassify("this_weekend", SATURDAY)).toBe("today"));
     it("this_week → 'this_week'", () => expect(triageAndClassify("this_week", SATURDAY)).toBe("this_week"));
     it("next_week → 'next_week'", () => expect(triageAndClassify("next_week", SATURDAY)).toBe("next_week"));
   });
@@ -375,7 +454,7 @@ describe("triage → label round-trip", () => {
 // ── today view filtering ──
 
 describe("today view filtering", () => {
-  const TODAY_VIEW_URGENCIES = new Set(["overdue", "today", "this_week"]);
+  const TODAY_VIEW_URGENCIES = new Set(["overdue", "today", "this_week", "this_weekend"]);
 
   function isVisibleInTodayView(urgency: Urgency): boolean {
     return TODAY_VIEW_URGENCIES.has(urgency);
@@ -384,6 +463,7 @@ describe("today view filtering", () => {
   it("shows overdue", () => expect(isVisibleInTodayView("overdue")).toBe(true));
   it("shows today", () => expect(isVisibleInTodayView("today")).toBe(true));
   it("shows this_week", () => expect(isVisibleInTodayView("this_week")).toBe(true));
+  it("shows this_weekend", () => expect(isVisibleInTodayView("this_weekend")).toBe(true));
   it("hides next_week", () => expect(isVisibleInTodayView("next_week")).toBe(false));
   it("hides later", () => expect(isVisibleInTodayView("later")).toBe(false));
   it("hides done", () => expect(isVisibleInTodayView("done")).toBe(false));

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -120,6 +120,49 @@ function getDateParts(date: Date, timezone: string): {
   };
 }
 
+/**
+ * Day-offset ranges (relative to today, in UTC days) for the four
+ * forward-looking urgency buckets. Reflects the user-facing rule:
+ *   - `this_week`     = the next upcoming Mon-Fri workweek
+ *   - `this_weekend`  = the next upcoming Sat-Sun pair
+ *   - `next_week`     = the calendar week following `this_weekend`
+ *   - everything else = `later`
+ *
+ * On Mon-Fri, "this week" is the remainder of the current calendar week.
+ * On Fri specifically, `thisWeek` is empty (Fri = today; Sat-Sun is the
+ * upcoming weekend; the workweek itself has no future days left).
+ * On Sat-Sun, "this week" rolls forward to the NEXT workweek and
+ * "this weekend" is what remains of the current weekend.
+ */
+function urgencyBucketRanges(dayOfWeek: number): {
+  thisWeekStart: number;
+  thisWeekEnd: number;
+  thisWeekendStart: number;
+  thisWeekendEnd: number;
+  nextWeekEnd: number;
+} {
+  if (dayOfWeek === 0) {
+    // Sun: this_week = next Mon-Fri (today+1..today+5).
+    //      this_weekend = next Sat-Sun (today+6..today+7).
+    //      next_week extends to today+14 (a full subsequent calendar week).
+    return { thisWeekStart: 1, thisWeekEnd: 5, thisWeekendStart: 6, thisWeekendEnd: 7, nextWeekEnd: 14 };
+  }
+  if (dayOfWeek === 6) {
+    // Sat: this_week = next Mon-Fri (today+2..today+6).
+    //      this_weekend = tomorrow's Sun only (today+1).
+    //      next_week extends through the Sun after that (today+8).
+    return { thisWeekStart: 2, thisWeekEnd: 6, thisWeekendStart: 1, thisWeekendEnd: 1, nextWeekEnd: 8 };
+  }
+  // Mon-Fri (1..5). On Fri, thisWeekEnd === 0, leaving the bucket empty.
+  return {
+    thisWeekStart: 1,
+    thisWeekEnd: 5 - dayOfWeek,
+    thisWeekendStart: 6 - dayOfWeek,
+    thisWeekendEnd: 7 - dayOfWeek,
+    nextWeekEnd: 14 - dayOfWeek,
+  };
+}
+
 export function computeUrgency(
   dueDate: Date | null,
   dueDatePrecision: DueDatePrecision | null,
@@ -128,39 +171,35 @@ export function computeUrgency(
 ): Urgency {
   if (!dueDate) return completedAt ? "done" : "later";
 
-  // Week-precision dates: urgency comes from the range, not the specific date
+  const todayMs = utcDay(now);
+  const dueMs = utcDay(dueDate);
+  const DAY_MS = 86400000;
+  const dayOfWeek = now.getUTCDay(); // 0=Sun..6=Sat
+  const r = urgencyBucketRanges(dayOfWeek);
+  const weekendEndMs = todayMs + r.thisWeekendEnd * DAY_MS;
+  const nextWeekEndMs = todayMs + r.nextWeekEnd * DAY_MS;
+
+  if (dueMs < todayMs) return "overdue";
+
+  // Week-precision items (the "this week" preset, stored as Sunday) — they're
+  // a soft "sometime this week" tag, NOT a Saturday-specific commitment. Keep
+  // them in `this_week` regardless of their stored day-of-week so the picker's
+  // intent (loose targeting) is preserved.
   if (dueDatePrecision === "week") {
-    const todayMs = utcDay(now);
-    const dueMs = utcDay(dueDate);
-
-    // End of this week (next Sunday); on Sunday, "this week" means the upcoming week
-    const dayOfWeek = now.getUTCDay();
-    const daysUntilSunday = dayOfWeek === 0 ? 7 : 7 - dayOfWeek;
-    const endOfThisWeekMs = todayMs + daysUntilSunday * 86400000;
-    const endOfNextWeekMs = endOfThisWeekMs + 7 * 86400000;
-
-    // If the stored Sunday has passed, it's overdue
-    if (dueMs < todayMs) return "overdue";
-    if (dueMs <= endOfThisWeekMs) return "this_week";
-    if (dueMs <= endOfNextWeekMs) return "next_week";
+    if (dueMs <= weekendEndMs) return "this_week";
+    if (dueMs <= nextWeekEndMs) return "next_week";
     return "later";
   }
 
-  // Day-precision dates: compare exact days
-  const todayMs = utcDay(now);
-  const dueMs = utcDay(dueDate);
-
-  if (dueMs < todayMs) return "overdue";
+  // Day-precision items: split Sat/Sun into `this_weekend`.
   if (dueMs === todayMs) return "today";
+  const diff = (dueMs - todayMs) / DAY_MS;
+  const dueDayOfWeek = new Date(dueMs).getUTCDay();
+  const isWeekendDay = dueDayOfWeek === 0 || dueDayOfWeek === 6;
 
-  // End of this week (next Sunday); on Sunday, "this week" means the upcoming week
-  const dayOfWeek = now.getUTCDay();
-  const daysUntilSunday = dayOfWeek === 0 ? 7 : 7 - dayOfWeek;
-  const endOfThisWeekMs = todayMs + daysUntilSunday * 86400000;
-  const endOfNextWeekMs = endOfThisWeekMs + 7 * 86400000;
-
-  if (dueMs <= endOfThisWeekMs) return "this_week";
-  if (dueMs <= endOfNextWeekMs) return "next_week";
+  if (isWeekendDay && diff >= r.thisWeekendStart && diff <= r.thisWeekendEnd) return "this_weekend";
+  if (!isWeekendDay && diff >= r.thisWeekStart && diff <= r.thisWeekEnd) return "this_week";
+  if (diff <= r.nextWeekEnd) return "next_week";
   return "later";
 }
 
@@ -618,7 +657,7 @@ export function validateBulkUpdate(
   };
 }
 
-export type TriageDatePreset = "today" | "tomorrow" | "this_week" | "next_week" | "next_month";
+export type TriageDatePreset = "today" | "tomorrow" | "this_weekend" | "this_week" | "next_week" | "next_month";
 
 export interface TriageResult {
   dueDate: string; // ISO string
@@ -637,6 +676,15 @@ export function computeTriageResult(
     case "tomorrow":
       d.setUTCDate(d.getUTCDate() + 1);
       return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+    case "this_weekend": {
+      // If today is Saturday (6) or Sunday (0), we ARE in the weekend — use today.
+      // Otherwise jump to the next upcoming Saturday.
+      const dayOfWeek = d.getUTCDay();
+      if (dayOfWeek !== 6 && dayOfWeek !== 0) {
+        d.setUTCDate(d.getUTCDate() + (6 - dayOfWeek));
+      }
+      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+    }
     case "this_week": {
       // Next Sunday (end of current week); if already Sunday, use next Sunday
       const dayOfWeek = d.getUTCDay(); // 0=Sun

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,7 +29,7 @@ export interface Notification {
 
 export type ItemType = "task" | "content";
 export type ItemStatus = "active" | "snoozed" | "done" | "archived";
-export type Urgency = "overdue" | "today" | "this_week" | "next_week" | "later" | "done";
+export type Urgency = "overdue" | "today" | "this_week" | "this_weekend" | "next_week" | "later" | "done";
 
 /** DB record — mirrors the Prisma Item model */
 export type DueDatePrecision = "day" | "week";

--- a/packages/ui/src/ThingsList.tsx
+++ b/packages/ui/src/ThingsList.tsx
@@ -40,6 +40,14 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
   // list-consistency rule.
   const handleToggleWithFreeze = useDeferredToggle(onToggle);
 
+  // On Sat/Sun, "This Weekend" is what's imminent — render it before
+  // "This Week" (the upcoming workweek). On Mon-Fri, the workweek comes
+  // first chronologically.
+  const isWeekendNow = (() => {
+    const dow = new Date().getUTCDay();
+    return dow === 0 || dow === 6;
+  })();
+
   const { uncompleted, done, grouped, allItems } = (() => {
     const uncompleted = things.filter((t) => !t.isCompleted);
     const done = things.filter((t) => t.isCompleted);
@@ -47,8 +55,12 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
       overdue: uncompleted.filter((t) => t.urgency === "overdue"),
       today: uncompleted.filter((t) => t.urgency === "today"),
       this_week: uncompleted.filter((t) => t.urgency === "this_week"),
+      this_weekend: uncompleted.filter((t) => t.urgency === "this_weekend"),
     };
-    const allItems = [...grouped.overdue, ...grouped.today, ...grouped.this_week, ...done];
+    const weekChunks = isWeekendNow
+      ? [...grouped.this_weekend, ...grouped.this_week]
+      : [...grouped.this_week, ...grouped.this_weekend];
+    const allItems = [...grouped.overdue, ...grouped.today, ...weekChunks, ...done];
     return { uncompleted, done, grouped, allItems };
   })();
   const quickAddRef = useRef<QuickAddInputHandle>(null);
@@ -86,15 +98,22 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
 
   const hasUncompleted = uncompleted.length > 0;
 
-  // Compute running offset so Section knows which indices are "focused"
+  // Compute running offset so Section knows which indices are "focused".
+  // The order here MUST match the `allItems` concat above — weekend comes
+  // before week on Sat/Sun, otherwise after.
   let offset = 0;
   const overdueOffset = offset;
   offset += grouped.overdue.length;
   const todayOffset = offset;
   offset += grouped.today.length;
-  const thisWeekOffset = offset;
-  offset += grouped.this_week.length;
+  const firstWeekChunkOffset = offset;
+  const firstWeekChunkLength = isWeekendNow ? grouped.this_weekend.length : grouped.this_week.length;
+  offset += firstWeekChunkLength;
+  const secondWeekChunkOffset = offset;
+  offset += isWeekendNow ? grouped.this_week.length : grouped.this_weekend.length;
   const doneOffset = offset;
+  const thisWeekOffset = isWeekendNow ? secondWeekChunkOffset : firstWeekChunkOffset;
+  const thisWeekendOffset = isWeekendNow ? firstWeekChunkOffset : secondWeekChunkOffset;
 
   const cardClass = bare ? "" : "bg-black/40 backdrop-blur-xl rounded-xl border border-white/10 p-4";
 
@@ -110,8 +129,24 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
           {grouped.today.length > 0 && (
             <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} />
           )}
-          {grouped.this_week.length > 0 && (
-            <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+          {isWeekendNow ? (
+            <>
+              {grouped.this_weekend.length > 0 && (
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} />
+              )}
+              {grouped.this_week.length > 0 && (
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+              )}
+            </>
+          ) : (
+            <>
+              {grouped.this_week.length > 0 && (
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+              )}
+              {grouped.this_weekend.length > 0 && (
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} />
+              )}
+            </>
           )}
 
           {hasUncompleted && (

--- a/packages/ui/src/__tests__/quickPicker/QuickDatePicker.test.tsx
+++ b/packages/ui/src/__tests__/quickPicker/QuickDatePicker.test.tsx
@@ -41,17 +41,20 @@ function renderPicker(
 }
 
 describe("QuickDatePicker", () => {
-  it("renders the five preset chips with letters and resolved dates", () => {
+  it("renders the six preset chips with letters and resolved dates", () => {
     renderPicker();
     expect(screen.getByTestId("chip-today")).toHaveTextContent("Today");
     expect(screen.getByTestId("chip-today")).toHaveTextContent("Thu · May 7");
     expect(screen.getByTestId("chip-tomorrow")).toHaveTextContent("Tomorrow");
+    expect(screen.getByTestId("chip-this_weekend")).toHaveTextContent("This Weekend");
+    expect(screen.getByTestId("chip-this_weekend")).toHaveTextContent("Sat · May 9");
     expect(screen.getByTestId("chip-this_week")).toHaveTextContent("This Week");
     expect(screen.getByTestId("chip-next_week")).toHaveTextContent("Next Week");
     expect(screen.getByTestId("chip-next_month")).toHaveTextContent("Next Month");
 
     expect(screen.getByTestId("chip-today")).toHaveTextContent("T");
     expect(screen.getByTestId("chip-tomorrow")).toHaveTextContent("M");
+    expect(screen.getByTestId("chip-this_weekend")).toHaveTextContent("S");
     expect(screen.getByTestId("chip-this_week")).toHaveTextContent("W");
     expect(screen.getByTestId("chip-next_week")).toHaveTextContent("N");
     expect(screen.getByTestId("chip-next_month")).toHaveTextContent("X");
@@ -71,6 +74,14 @@ describe("QuickDatePicker", () => {
     expect(onCommit).toHaveBeenCalledTimes(1);
     const date = onCommit.mock.calls[0][0] as Date;
     expect(date.toISOString()).toBe("2026-05-08T00:00:00.000Z");
+  });
+
+  it("commits the upcoming Saturday when 's' is pressed", () => {
+    const { onCommit } = renderPicker();
+    fireEvent.keyDown(window, { key: "s" });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const date = onCommit.mock.calls[0][0] as Date;
+    expect(date.toISOString()).toBe("2026-05-09T00:00:00.000Z");
   });
 
   it("clears the date on Backspace and Delete", () => {

--- a/packages/ui/src/__tests__/quickPicker/letters.test.ts
+++ b/packages/ui/src/__tests__/quickPicker/letters.test.ts
@@ -10,6 +10,7 @@ describe("date picker letter map", () => {
     expect(DATE_LETTER_TO_PRESET).toEqual({
       t: "today",
       m: "tomorrow",
+      s: "this_weekend",
       w: "this_week",
       n: "next_week",
       x: "next_month",
@@ -20,6 +21,7 @@ describe("date picker letter map", () => {
     expect(DATE_PRESET_ORDER).toEqual([
       "today",
       "tomorrow",
+      "this_weekend",
       "this_week",
       "next_week",
       "next_month",
@@ -29,6 +31,7 @@ describe("date picker letter map", () => {
   it("provides display labels for every preset", () => {
     expect(DATE_PRESET_LABELS.today).toBe("Today");
     expect(DATE_PRESET_LABELS.tomorrow).toBe("Tomorrow");
+    expect(DATE_PRESET_LABELS.this_weekend).toBe("This Weekend");
     expect(DATE_PRESET_LABELS.this_week).toBe("This Week");
     expect(DATE_PRESET_LABELS.next_week).toBe("Next Week");
     expect(DATE_PRESET_LABELS.next_month).toBe("Next Month");

--- a/packages/ui/src/quickPicker/letters.ts
+++ b/packages/ui/src/quickPicker/letters.ts
@@ -3,6 +3,7 @@ import type { TriageDatePreset } from "@brett/business";
 export const DATE_LETTER_TO_PRESET: Record<string, TriageDatePreset> = {
   t: "today",
   m: "tomorrow",
+  s: "this_weekend",
   w: "this_week",
   n: "next_week",
   x: "next_month",
@@ -11,6 +12,7 @@ export const DATE_LETTER_TO_PRESET: Record<string, TriageDatePreset> = {
 export const DATE_PRESET_ORDER: TriageDatePreset[] = [
   "today",
   "tomorrow",
+  "this_weekend",
   "this_week",
   "next_week",
   "next_month",
@@ -19,6 +21,7 @@ export const DATE_PRESET_ORDER: TriageDatePreset[] = [
 export const DATE_PRESET_LABELS: Record<TriageDatePreset, string> = {
   today: "Today",
   tomorrow: "Tomorrow",
+  this_weekend: "This Weekend",
   this_week: "This Week",
   next_week: "Next Week",
   next_month: "Next Month",


### PR DESCRIPTION
## Summary
- Adds `this_weekend` urgency that splits day-precision Sat/Sun items out of `this_week` across desktop, iOS, and the API enrichment.
- New "This Weekend" Today section on both clients (chronological order: weekend-first on Sat/Sun, week-first on Mon-Fri).
- New "this weekend" date-picker preset (letter \`s\`) — picks the upcoming Saturday, or today if today is Sat/Sun.
- Badge rule: weekend items excluded from the dock/home-screen badge on weekdays; included once it IS the weekend.

## Test plan
- [x] \`pnpm typecheck\` — all 17 packages green
- [x] \`packages/business\` — 229 tests pass (covers urgency split, badge filter, triage round-trip, week-precision preservation)
- [x] \`packages/ui\` — 127 tests pass (chip rendering, keyboard shortcut, picker letter map)
- [x] \`apps/desktop\` renderer — 183 tests pass
- [ ] iOS Swift tests — run locally via Xcode (no Mac CI)
- [ ] Smoke-test on packaged desktop build after \`scripts/release.sh desktop\`

## Known regression window
Old desktop clients pre-auto-update will not render Sat/Sun items in Today/list sections after this API deploy (they filter on \`urgency === "this_week"\`). Auto-update fires on launch, so most users self-heal within hours. iOS computes urgency locally and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)