### PR TITLE
fix: drop stale-segment cached wallpaper on cold launch (#161)

### DIFF
--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -365,6 +365,13 @@ final class BackgroundService {
     /// Idempotent.
     func resumeRotation() {
         guard rendererCount > 0, tickTask == nil else { return }
+        // Re-run recompute so a stale-segment cached URL (long
+        // background period crossing a time-of-day boundary, e.g.
+        // overnight) is refreshed on foreground. Same-segment caches
+        // are preserved by `recompute()`, so the original "no
+        // spurious crossfade on resume" intent is unchanged for the
+        // common short-background case. See #161.
+        recompute()
         startTick()
     }
 
@@ -463,13 +470,21 @@ final class BackgroundService {
             // the URL resolvable — usually the same URL the cache held,
             // so no crossfade fires.
             if currentRemoteURL != nil { return }
-        } else if let cached = currentRemoteURL {
-            // Auto mode + we already have a cached URL painted (either
-            // from UserDefaults at init or set by a prior `rotate()`
-            // tick this process). Keep it — refreshing the wash sample
-            // along the way — instead of picking a fresh random URL
-            // that would trigger a crossfade to a different photo
-            // from the same tier.
+        } else if let cached = currentRemoteURL,
+                  Self.segment(forURL: cached)
+                      == Self.segment(forHour: Calendar.current.component(.hour, from: Date())) {
+            // Auto mode + the cached URL's photo belongs to the
+            // current time-of-day segment. Keep it — refreshing the
+            // wash sample along the way — instead of picking a fresh
+            // random URL that would trigger a crossfade to a
+            // different photo from the same tier.
+            //
+            // The segment check guards #161: closing the app at night
+            // with a `photo/night/...` URL cached, then cold-launching
+            // at 7 AM, would otherwise paint the stale night photo
+            // until the 60s rotation timer fired. Falling through to
+            // the fresh-pick branch below resolves the right segment
+            // immediately.
             currentSolidColor = nil
             currentFallbackAsset = ""
             currentWashColor = WashColorSampler.cachedWash(forURL: cached)
@@ -762,6 +777,39 @@ final class BackgroundService {
         case 17...18: return .goldenHour
         case 19...20: return .evening
         default: return .night // 21-4
+        }
+    }
+
+    /// Extract a `Segment` from a manifest-shaped URL whose path encodes
+    /// the segment as a directory name — e.g. `photo/night/light-2.webp`
+    /// or `photo-portrait/golden-hour/light-1.webp`. Returns `nil` for
+    /// URLs that don't fit the shape so callers can fall back rather
+    /// than misclassify.
+    ///
+    /// Used by `recompute()` to detect when a cached URL from a prior
+    /// session belongs to a different time-of-day segment than "now"
+    /// — the cold-launch path that produced #161 (cached night photo
+    /// persisting into a morning launch).
+    nonisolated static func segment(forURL url: URL) -> Segment? {
+        let components = url.pathComponents
+        for (idx, comp) in components.enumerated() {
+            guard comp == "photo" || comp == "photo-portrait" else { continue }
+            let next = idx + 1
+            guard next < components.count else { return nil }
+            return segment(forFolderName: components[next])
+        }
+        return nil
+    }
+
+    private static func segment(forFolderName folder: String) -> Segment? {
+        switch folder {
+        case "dawn": return .dawn
+        case "morning": return .morning
+        case "afternoon": return .afternoon
+        case "golden-hour": return .goldenHour
+        case "evening": return .evening
+        case "night": return .night
+        default: return nil
         }
     }
 

--- a/apps/ios/BrettTests/Views/BackgroundServiceSegmentTests.swift
+++ b/apps/ios/BrettTests/Views/BackgroundServiceSegmentTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Coverage for `BackgroundService.segment(forURL:)` — the URL→segment
+/// classifier that gates the cached-URL preservation path in
+/// `recompute()`.
+///
+/// The bug class this guards: a cached URL from a previous session
+/// belonging to a different time-of-day segment than "now" being kept
+/// instead of refreshed, producing the symptom from #161 — opening the
+/// app at 7 AM and seeing last night's wallpaper until the 60s rotation
+/// timer fires. The classifier has to recognise both `photo/` and
+/// `photo-portrait/` shapes (iOS uses portrait, desktop uses landscape;
+/// either could land in the cache during migrations), and has to return
+/// `nil` for unrelated URL shapes so the caller falls back safely
+/// rather than misclassifying.
+@Suite("BackgroundServiceSegment", .tags(.views))
+struct BackgroundServiceSegmentTests {
+
+    @Test func portraitNightPathResolvesToNight() {
+        let url = URL(string: "https://api.example.com/public/backgrounds/photo-portrait/night/light-2.webp")!
+        #expect(BackgroundService.segment(forURL: url) == .night)
+    }
+
+    @Test func portraitMorningPathResolvesToMorning() {
+        let url = URL(string: "https://api.example.com/public/backgrounds/photo-portrait/morning/light-1.webp")!
+        #expect(BackgroundService.segment(forURL: url) == .morning)
+    }
+
+    @Test func landscapePhotoPathAlsoResolves() {
+        // The manifest stores landscape paths (`photo/...`); the
+        // service swaps to `photo-portrait/...` when building iOS URLs,
+        // but cached entries from older builds — or future
+        // landscape-aware code paths — should still classify correctly.
+        let url = URL(string: "https://api.example.com/public/backgrounds/photo/dawn/light-1.webp")!
+        #expect(BackgroundService.segment(forURL: url) == .dawn)
+    }
+
+    @Test func goldenHourFolderMapsToGoldenHourSegment() {
+        // The folder is kebab-case (`golden-hour`) but the enum is
+        // camelCase (`goldenHour`). The mapping has to bridge that.
+        let url = URL(string: "https://api.example.com/public/backgrounds/photo-portrait/golden-hour/light-1.webp")!
+        #expect(BackgroundService.segment(forURL: url) == .goldenHour)
+    }
+
+    @Test func afternoonAndEveningResolveCorrectly() {
+        let afternoon = URL(string: "https://api.example.com/public/backgrounds/photo-portrait/afternoon/moderate-2.webp")!
+        let evening = URL(string: "https://api.example.com/public/backgrounds/photo-portrait/evening/packed-1.webp")!
+        #expect(BackgroundService.segment(forURL: afternoon) == .afternoon)
+        #expect(BackgroundService.segment(forURL: evening) == .evening)
+    }
+
+    @Test func unrelatedURLReturnsNil() {
+        // A URL that doesn't pass through a `photo/` or `photo-portrait/`
+        // path component should not match anything — callers should
+        // treat this as "can't classify, refresh from manifest"
+        // rather than guessing.
+        let url = URL(string: "https://api.example.com/public/something-else/night/light.webp")!
+        #expect(BackgroundService.segment(forURL: url) == nil)
+    }
+
+    @Test func unknownFolderNameReturnsNil() {
+        // A URL with the right prefix shape but an unrecognised
+        // segment folder (e.g. a future manifest experiment that
+        // hasn't shipped to this client yet) must return nil so the
+        // caller refreshes rather than silently defaulting to one of
+        // the known segments.
+        let url = URL(string: "https://api.example.com/public/backgrounds/photo-portrait/twilight/light-1.webp")!
+        #expect(BackgroundService.segment(forURL: url) == nil)
+    }
+
+    @Test func trailingPathWithoutSegmentReturnsNil() {
+        // `photo/` with nothing after it can't be classified.
+        let url = URL(string: "https://api.example.com/public/backgrounds/photo/")!
+        #expect(BackgroundService.segment(forURL: url) == nil)
+    }
+}


### PR DESCRIPTION
Closes #161

## Root cause

`BackgroundService.recompute()` has a cached-URL preservation branch that keeps the previous session's photo URL (read from `UserDefaults` at init, written by `applyRemote()` on every fresh pick). It was designed to suppress the cold-launch "asset → remote" crossfade jank — i.e., the wallpaper appearing to animate in even when the user already had a perfectly good cached photo from the prior session.

But the preservation check didn't ask whether the cached URL actually belonged to the **current** time-of-day segment. Symptom path:

1. User opens the app at 11 PM. `currentImageURL` picks `photo-portrait/night/light-2.webp` from the `.night` tier. `applyRemote` writes it to `UserDefaults`.
2. User closes the app.
3. User opens the app at 7 AM. `BackgroundService.shared.currentRemoteURL` is seeded from the cache → still the `night` URL. `BackgroundView.onAppear` runs `updateProfile` → `recompute`.
4. Auto mode + cached URL exists → `recompute` keeps it. User sees nighttime stars at 7 AM.
5. 60 seconds later, the rotation `tickTask` fires `rotate()` and picks a fresh URL from `.morning`. Crossfade.

If the user only spent <60s in the app — fast-glance for a task — they'd never see the rotation correct the photo.

Same root cause hit `resumeRotation()` on long backgrounded sessions crossing a time-of-day boundary: the resume path restarts the 60s tick without re-evaluating the cached URL.

## Approach

**Picked:** add a `segment(forURL:)` helper that extracts the time-of-day segment from a manifest-shaped URL (`photo/<segment>/...` or `photo-portrait/<segment>/...`). Gate the cache-preservation branch on `cached.segment == currentSegment`. Stale-segment caches fall through to the fresh-pick branch already present.

`resumeRotation()` now re-runs `recompute()` so foreground-after-long-background also revalidates. Same-segment cached URLs are still preserved by `recompute()` itself, so the original "no spurious crossfade on resume" intent is unchanged for the common short-background case.

Other options considered:

1. **Drop the cache preservation entirely** — simplest, but re-introduces the cold-launch crossfade the preservation was specifically designed to suppress. Net UX worse.
2. **Move the segment-check into `cachedRemoteURL`'s getter** so a stale entry never even seeds `currentRemoteURL` at init. Cleaner separation of concerns, but the getter is `nonisolated` and the segment enum is main-actor-adjacent — workable, but more surface area for the same effective result.
3. **Inject `now` into `recompute()`** for testability. Heavier — `recompute()` is on a hot path (every `updateProfile`) and the existing call sites would all need to be updated. The pure-helper test approach (below) is enough.

## Tests

`apps/ios/BrettTests/Views/BackgroundServiceSegmentTests.swift` — 8 tests covering `segment(forURL:)`:

- `photo-portrait/night/...` → `.night`
- `photo-portrait/morning/...` → `.morning`
- `photo/dawn/...` → `.dawn` (landscape paths from older cached entries still classify)
- `photo-portrait/golden-hour/...` → `.goldenHour` (kebab → camelCase bridge)
- `photo-portrait/afternoon/...` and `photo-portrait/evening/...`
- Unrelated URL → nil (caller refreshes rather than misclassifying)
- Unknown folder (`twilight`) → nil (future manifest experiment can't silently map to a known segment on this client)
- Trailing path without segment → nil

**Bug class these guard:** any future change to the manifest URL shape (or to the segment enum's folder names) that would silently misclassify a cached URL, sending users back to stale-segment-wallpaper land.

The wiring in `recompute()` is a single `==` between two `Segment?` values — read-by-eye trivial once `segment(forURL:)` is verified. Adding a behavioral test would require parameterising `recompute()` to inject `now`, which is heavier than the bug warrants given the helper is unit-tested.

## Build / typecheck

iOS-only Swift change; no Xcode/Swift toolchain on this Linux runner. `pnpm typecheck` is broken on `main` (pre-existing `@brett/api-core/src/prisma.ts` `noImplicitAny` errors — unrelated and verified to exist at `5df4d3c`); my changes don't touch TS at all. Confidence is high — `segment(forURL:)` is pure, the wiring change is one branch.

## Self-review

Walked the case matrix for `recompute()`:

| Mode | cached URL? | cached segment | current segment | result |
|---|---|---|---|---|
| solid | — | — | — | solid path (unchanged) |
| pinned (non-solid) | — | — | — | pinned path (unchanged) |
| auto | no | — | — | fresh pick from manifest |
| auto | yes | match | match | **keep cached** (no crossfade) |
| auto | yes | night | morning | **fresh pick** (#161 fix) |
| auto | yes | nil (unrecognised) | any | **fresh pick** (safe default) |
| auto | yes (manifest not loaded) | mismatch | morning | bundled asset for current hour |

Edge cases checked:

- Pinned URL with stale-segment branding — pinned path doesn't go through the segment check; user's explicit choice is honoured.
- `pathComponents` allocates a `[String]` once per `recompute()` — not in a hot loop (app launch + scene `.active`).
- `URL.pathComponents` ignores query strings; classification works on CDN URLs with `?w=…`.
- Helper is `nonisolated static` — safe to call from any isolation context.
- No data-flow changes → no multi-user implications.

## Risks / follow-ups

- Visual verification pending — `gh pr checkout 161`. Repro:
  1. Set device clock to 11 PM. Cold-launch the app. Note night wallpaper.
  2. Kill the app. Advance device clock to 7 AM. Cold-launch.
  3. Expect: morning wallpaper on first paint (not nighttime stars).
- The `Calendar.current.component(.hour, from: Date())` call inside `recompute()` reads device-local time. If a user is mid-flight crossing time zones and the OS hasn't updated `TimeZone.current` yet, they may see one rotation cycle of "wrong" wallpaper before the manifest tick catches up. Edge case, low priority.
- A future manifest revision that adds new segment folder names (e.g. `late-night`) would need a matching case added to `segment(forFolderName:)`. Tests will catch unknown folder names as `nil` rather than misclassifications.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CawK3rypn16B2jih4y4BZZ)_