### PR TITLE
fix(ios): pin Bundler 2.5.4 (unblock iOS release)

### DIFF
--- a/apps/ios/Gemfile.lock
+++ b/apps/ios/Gemfile.lock
@@ -237,4 +237,4 @@ DEPENDENCIES
   xcodeproj (~> 1.25)
 
 BUNDLED WITH
-  4.0.10
+  2.5.4


### PR DESCRIPTION
Build-only fix. Bundler 4.0.10 in Gemfile.lock requires Ruby >= 3.4; this Mac runs Ruby 3.3.0, so \`bundle exec fastlane\` crashes. Pinning to 2.5.4 (already installed, compatible with fastlane 2.226).

No runtime / API / desktop impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)