### PR TITLE
fix(ios): nonisolated segment helper (unblock TestFlight build)

### DIFF
--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -801,7 +801,7 @@ final class BackgroundService {
         return nil
     }
 
-    private static func segment(forFolderName folder: String) -> Segment? {
+    nonisolated private static func segment(forFolderName folder: String) -> Segment? {
         switch folder {
         case "dawn": return .dawn
         case "morning": return .morning


### PR DESCRIPTION
Swift 6 / Xcode 26.4 strict concurrency caught a synchronous MainActor-isolated call from a nonisolated context in \`BackgroundService.swift\`. The helper is a pure switch with a single caller — making it \`nonisolated\` is safe.

Regression slipped through #161 because iOS has no CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)