### PR TITLE
release: iOS wallpaper fixes (cross-user leak, cold-launch swap, side-scroll snap)

### DIFF
--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -9,10 +9,19 @@ import SwiftUI
 ///      "busyness" tier.
 ///   2. `/config` (network) — gives us the `storageBaseUrl` where images
 ///      actually live. Cached in-memory for the session; re-fetched on
-///      each fresh app launch.
+///      each fresh app launch and after `clearForSignOut()`.
 ///   3. `UserProfile.backgroundStyle` + `UserProfile.pinnedBackground` —
 ///      what the user picked. Either a relative path (e.g.
 ///      "photo/evening/light-2.webp") or a "solid:#RRGGBB" sentinel.
+///
+/// **No on-disk URL cache.** The service deliberately does not persist
+/// the last-resolved URL to UserDefaults. Cold launch starts from the
+/// wash bed (`defaultWashColor`) and the resolved photo fades in over
+/// it via `BackgroundView.paintAnimation` once `load()` + `recompute()`
+/// complete. The previous design persisted the URL to skip a blank
+/// frame, but that produced a cross-user leak (the cached URL survived
+/// sign-out) and a visible cached → resolved swap on every cold
+/// launch. See `BackgroundView` for the rendering pipeline.
 ///
 /// The service is a singleton on the main actor because `BackgroundView`
 /// reads it from SwiftUI, and because the manifest + base URL are
@@ -20,14 +29,15 @@ import SwiftUI
 /// can construct an instance with `init(client:)` directly.
 @MainActor
 @Observable
-final class BackgroundService {
+final class BackgroundService: Clearable {
     static let shared = BackgroundService()
 
     // MARK: - Public state
 
     /// Parsed manifest once loaded from the bundle. `nil` until `load()`
-    /// runs — callers should fall back to the asset-catalog images in
-    /// that window.
+    /// runs — `currentImageURL(...)` returns `nil` until then, which
+    /// pushes `recompute()` into the wash-only fallback branch and
+    /// `BackgroundView` renders just the wash bed.
     private(set) var manifest: BackgroundManifest?
 
     /// Base URL of the storage server (e.g.
@@ -51,19 +61,29 @@ final class BackgroundService {
 
     /// Current remote image URL (nil for solid backgrounds or before
     /// `/config` resolves).
-    private(set) var currentRemoteURL: URL? = BackgroundService.cachedRemoteURL
+    ///
+    /// **No UserDefaults seeding on cold launch.** An earlier version of
+    /// this service persisted the last-resolved URL to `UserDefaults` and
+    /// re-read it at init so the wallpaper could paint synchronously
+    /// before `/config` returned. That produced two regressions: (1) the
+    /// previous user's URL leaked into the next sign-in (the
+    /// UserDefaults key survived sign-out and `wipeAllData()`), and (2)
+    /// every cold launch painted a stale photo that visibly swapped to
+    /// the freshly-resolved one when the manifest landed. Now the
+    /// wallpaper starts as `BackgroundService.defaultWashColor` (the
+    /// burnt-umber wash bed) and the resolved photo fades in on top
+    /// once `load()` + `recompute()` complete — see
+    /// `BackgroundView.paintAnimation`.
+    private(set) var currentRemoteURL: URL?
 
     /// Current solid color when style is "solid".
     private(set) var currentSolidColor: Color?
 
-    /// Fallback asset-catalog name when neither remote nor solid applies.
-    /// Empty string means "not yet resolved" — callers fall back to
-    /// `assetNameForHour(...)` directly.
-    private(set) var currentFallbackAsset: String = ""
-
     /// Stable identity that drives the crossfade animation. Changes
-    /// whenever the rendered image changes.
-    private(set) var displayedKey: String = BackgroundService.cachedRemoteURL?.absoluteString ?? ""
+    /// whenever the rendered image changes. Empty string means "no
+    /// image resolved yet" — `BackgroundView` renders only the wash bed
+    /// in that state.
+    private(set) var displayedKey: String = ""
 
     /// Solid "wash" color used as the bed for non-Today pages and below
     /// the hero on Today. Calm-hero design (2026-05-04) uses the same
@@ -142,18 +162,26 @@ final class BackgroundService {
     var debug_rendererCount: Int { rendererCount }
     var debug_hasTickTask: Bool { tickTask != nil }
 
-    /// Reset the cached remote URL state so a test starts from a known
-    /// "first launch ever" baseline. Necessary because the singleton
-    /// caches `currentRemoteURL` from `UserDefaults` at init, and tests
-    /// asserting on the no-cache fallback path would otherwise be
-    /// non-deterministic across simulator runs that have ever opened
-    /// the app.
+    /// Reset the in-memory renderer state — and the bootstrap
+    /// (`manifest`, `storageBaseUrl`) — so a test starts from a known
+    /// "first launch ever" baseline. The singleton survives between
+    /// tests, so without this a test that resolved a URL leaves the
+    /// next test asserting on stale state. Bootstrap state is included
+    /// because the wash-only fallback only triggers when
+    /// `storageBaseUrl` is `nil` — a test that asserts on the
+    /// fallback path needs the bootstrap cleared, not just the
+    /// renderer state.
     func debug_resetRemoteCache() {
+        manifest = nil
+        storageBaseUrl = nil
         currentRemoteURL = nil
-        currentFallbackAsset = ""
         currentSolidColor = nil
         displayedKey = ""
-        Self.cachedRemoteURL = nil
+        currentWashColor = Self.defaultWashColor
+        currentWashLuminance = 0.0
+        currentWashIsLight = false
+        lastProfileStyle = nil
+        lastProfilePinned = nil
     }
     #endif
 
@@ -169,6 +197,50 @@ final class BackgroundService {
 
     init(client: APIClient = .shared) {
         self.client = client
+        // Register so `Session.tearDown()` (called from `AuthManager.signOut`
+        // and `clearInvalidSession`) wipes the resolved wallpaper before the
+        // next sign-in. Without this, user A's pinned photo paints behind
+        // user B's first frame post-login, and user B's first cold launch
+        // sees user A's photo swap to their own — exactly the leak this
+        // service was rebuilt to prevent.
+        ClearableStoreRegistry.register(self)
+    }
+
+    // MARK: - Clearable
+
+    /// Wipe in-memory wallpaper state on sign-out. Called from
+    /// `ClearableStoreRegistry.clearAll()` immediately before
+    /// `PersistenceController.wipeAllData()` removes the SwiftData
+    /// `UserProfile` row that drove the resolution. Resetting here
+    /// ensures the next render — whether it's the sign-in screen, an
+    /// in-process user switch, or the first frame of a fresh sign-in
+    /// — starts from the wash bed, not the prior session's photo.
+    ///
+    /// **Why we also wipe `manifest` + `storageBaseUrl`:** there's a
+    /// brief render-batching window between this method running and
+    /// `wipeAllData()` finishing, in which SignInView's BackgroundView
+    /// can mount, observe the still-present prior-user UserProfile row
+    /// via `@Query`, and call `updateProfile(...)` with stale values.
+    /// If `storageBaseUrl` is still cached, `currentImageURL(...)`
+    /// happily resolves the prior user's pinned URL → leaked photo.
+    /// Clearing the bootstrap forces `currentImageURL(...)` to return
+    /// `nil` for that intervening call, so the worst case stays at
+    /// "wash bed for an extra ~100ms on the next sign-in" instead of
+    /// "prior user's photo flashes on the sign-in screen." SwiftUI's
+    /// render batching usually hides the race in practice, but
+    /// `Clearable` is expected to be defensive about exactly this
+    /// kind of cross-session leak.
+    func clearForSignOut() {
+        manifest = nil
+        storageBaseUrl = nil
+        currentRemoteURL = nil
+        currentSolidColor = nil
+        displayedKey = ""
+        currentWashColor = Self.defaultWashColor
+        currentWashLuminance = 0.0
+        currentWashIsLight = false
+        lastProfileStyle = nil
+        lastProfilePinned = nil
     }
 
     // MARK: - Manifest
@@ -406,22 +478,19 @@ final class BackgroundService {
         }
     }
 
-    /// Resolve `currentSolidColor` / `currentRemoteURL` / `currentFallbackAsset`
-    /// from the last-known profile values.
+    /// Resolve `currentSolidColor` / `currentRemoteURL` from the
+    /// last-known profile values.
     ///
-    /// **Auto mode preserves the cached URL.** Cold launch jank used to
-    /// look like: cached photo paints → BackgroundView.onAppear runs
-    /// updateProfile → recompute downgrades to a bundled asset (manifest
-    /// not loaded yet) → BackgroundView.task awaits load() → updateProfile
-    /// runs again → currentImageURL picks a *different* random photo
-    /// from the same tier → crossfade. Two visible swaps every launch.
-    ///
-    /// Now: in auto mode (no pinned image), if `currentRemoteURL`
-    /// already has a value (either from the UserDefaults cache at init
-    /// or from a prior tick this process), recompute keeps it.
-    /// Explicit settings changes (pinned image, solid style, style
-    /// switch) still reroute through the appropriate branches below;
-    /// the 60s ticker calls `rotate()` for fresh picks.
+    /// **Auto mode preserves the in-memory URL across reruns within a
+    /// session.** Once `applyRemote(url:)` has populated
+    /// `currentRemoteURL`, subsequent recomputes (foreground resume,
+    /// re-pushed profile, manifest reload) keep it as long as the
+    /// segment still matches the current hour — otherwise they pick a
+    /// fresh URL from the right segment. Cold launch starts with
+    /// `currentRemoteURL == nil` (no UserDefaults seeding by design)
+    /// and falls into the wash-only branch at the bottom until the
+    /// first successful resolve. The 60s ticker calls `rotate()` for
+    /// the deliberate in-session photo rotation.
     private func recompute() {
         let style = lastProfileStyle ?? Style.photography.rawValue
         let pinned = lastProfilePinned
@@ -434,7 +503,6 @@ final class BackgroundService {
             if let color = Self.color(forHex: hex) {
                 currentRemoteURL = nil
                 currentSolidColor = color
-                currentFallbackAsset = ""
                 // Wash matches the user's solid pick. Without this,
                 // non-Today pages would render in the default warm-dark
                 // while Today shows the user's solid — the two surfaces
@@ -479,14 +547,16 @@ final class BackgroundService {
             // random URL that would trigger a crossfade to a
             // different photo from the same tier.
             //
-            // The segment check guards #161: closing the app at night
-            // with a `photo/night/...` URL cached, then cold-launching
-            // at 7 AM, would otherwise paint the stale night photo
-            // until the 60s rotation timer fired. Falling through to
-            // the fresh-pick branch below resolves the right segment
-            // immediately.
+            // The segment check guards #161: a long-background period
+            // crossing a time-of-day boundary (foregrounding the app at
+            // 7 AM after closing it the night before) would otherwise
+            // keep the stale night photo until the 60s rotation timer
+            // fired. Falling through to the fresh-pick branch below
+            // resolves the right segment immediately on resume. (No
+            // cold-launch implication anymore — we never seed
+            // `currentRemoteURL` from disk; this only matters once
+            // `applyRemote` has populated it during a live session.)
             currentSolidColor = nil
-            currentFallbackAsset = ""
             currentWashColor = WashColorSampler.cachedWash(forURL: cached)
                 ?? Self.defaultWashColor
             applyLuminance(forURL: cached)
@@ -500,21 +570,22 @@ final class BackgroundService {
             return
         }
 
-        // Service hasn't loaded yet (cold launch, offline) AND no
-        // cached URL to fall back to — paint the bundled asset for
-        // the current hour so the user never sees a blank screen.
-        // Renderer paints this without a crossfade.
-        let asset = Self.assetNameForHour(Calendar.current.component(.hour, from: Date()))
+        // Cold launch, offline, or signed-out — nothing to resolve. Hold
+        // the wash bed and clear any prior image state. `BackgroundView`
+        // renders the wash alone in this state, and the photo (or solid)
+        // fades in on top once `recompute()` is called again with a
+        // resolvable profile + loaded `/config`.
+        //
+        // We deliberately do NOT paint the bundled hour-keyed asset
+        // here. That used to be the cold-launch fallback, but it created
+        // the exact jank this rewrite removes: paint bundled asset →
+        // load completes → swap to remote photo, a visible crossfade
+        // the user reads as "old image, then real image."
         currentSolidColor = nil
         currentRemoteURL = nil
-        currentFallbackAsset = asset
-        // Bundled assets sample synchronously — UIImage(named:) hits
-        // the asset catalog with no I/O wait, and the average is
-        // CoreGraphics-fast. Cache result on first sight.
-        currentWashColor = WashColorSampler.sampledWash(forAssetNamed: asset)
-            ?? Self.defaultWashColor
-        applyLuminance(forAssetNamed: asset)
-        if displayedKey != asset { displayedKey = asset }
+        currentWashColor = Self.defaultWashColor
+        updateIsLight(luminance: Self.defaultPhotoLuminance)
+        if !displayedKey.isEmpty { displayedKey = "" }
     }
 
     /// Force a fresh random pick from the manifest in auto mode. Called
@@ -555,19 +626,17 @@ final class BackgroundService {
     private func applyRemote(url: URL) {
         currentSolidColor = nil
         currentRemoteURL = url
-        currentFallbackAsset = ""
-        // Set wash from the disk cache synchronously when we have
-        // it (avoids a default-color flash on cold launch). When we
-        // don't, ride the default until `kickWashSample(...)` resolves
-        // the download + sample on a background task and writes the
-        // real value back. SwiftUI re-paints any subscribed view
+        // Set wash from the in-memory cache synchronously when we have
+        // it (avoids a default-color flash on rotation). When we don't,
+        // ride the default until `kickWashSample(...)` resolves the
+        // download + sample on a background task and writes the real
+        // value back. SwiftUI re-paints any subscribed view
         // automatically because `currentWashColor` is a stored
         // `@Observable` property.
         currentWashColor = WashColorSampler.cachedWash(forURL: url)
             ?? Self.defaultWashColor
         applyLuminance(forURL: url)
         kickWashSample(url: url)
-        Self.cachedRemoteURL = url
         let key = url.absoluteString
         if displayedKey != key { displayedKey = key }
     }
@@ -677,21 +746,6 @@ final class BackgroundService {
             g: Double((value >> 8) & 0xFF) / 255.0,
             b: Double(value & 0xFF) / 255.0
         )
-    }
-
-    /// Bundled asset for the current hour. Mirrors the prior
-    /// `BackgroundView.assetNameForHour` so the fallback path picks
-    /// the same image the view used to compute itself. Public for
-    /// `BackgroundView` to use when the caller pinned an `imageName`
-    /// override (previews, auth screens with a specific look).
-    static func assetNameForHour(_ hour: Int) -> String {
-        switch hour {
-        case 5..<8: return "bg-morning"
-        case 8..<12: return "bg-morning"
-        case 12..<17: return "bg-golden"
-        case 17..<20: return "bg-evening"
-        default: return "bg-night"
-        }
     }
 
     // MARK: - Resolution
@@ -828,32 +882,6 @@ final class BackgroundService {
         case .goldenHour: return segments.goldenHour
         case .evening: return segments.evening
         case .night: return segments.night
-        }
-    }
-
-    // MARK: - Last URL cache
-    //
-    // Persisted in UserDefaults so a cold launch can paint the user's last
-    // wallpaper immediately from URLCache, while `/config` + manifest
-    // resolve in the background. This is what kills the "asset → remote"
-    // crossfade jank at startup: when the cache is seeded, BackgroundView
-    // starts directly in the remote branch and the first service resolution
-    // is usually a no-op (same URL) or at worst a deliberate segment
-    // crossfade. `nonisolated` so View property initializers can read it.
-
-    nonisolated private static let lastRemoteURLKey = "brett.background.lastRemoteURL"
-
-    nonisolated static var cachedRemoteURL: URL? {
-        get {
-            guard let raw = UserDefaults.standard.string(forKey: lastRemoteURLKey) else { return nil }
-            return URL(string: raw)
-        }
-        set {
-            if let newValue {
-                UserDefaults.standard.set(newValue.absoluteString, forKey: lastRemoteURLKey)
-            } else {
-                UserDefaults.standard.removeObject(forKey: lastRemoteURLKey)
-            }
         }
     }
 

--- a/apps/ios/Brett/Views/Shared/BackgroundView.swift
+++ b/apps/ios/Brett/Views/Shared/BackgroundView.swift
@@ -3,23 +3,36 @@ import SwiftData
 
 /// Full-screen wallpaper that drives the app's glass aesthetic.
 ///
-/// Three rendering paths:
-///   1. **Solid** — when `backgroundStyle == "solid"` and the pinned
-///      value is a `"solid:#RRGGBB"` sentinel, render the parsed color.
-///   2. **Remote photo** — when the `BackgroundService` has a manifest
-///      and storage URL, render via `AsyncImage`. The URL is either the
-///      user's pinned selection or a random pick from the manifest for
-///      the current time-of-day segment.
-///   3. **Fallback** — before the service loads (cold launch, offline),
-///      render the bundled asset-catalog image keyed on hour-of-day so
-///      the app never boots to a blank screen.
+/// Three rendering paths, layered bottom-to-top in the ZStack:
+///   1. **Wash bed** — always painted. `BackgroundService.currentWashColor`
+///      (the burnt-umber default, or a sampled color from the resolved
+///      photo). This is what the user sees on cold launch / offline /
+///      signed-out states. Photo and solid layers fade in over it.
+///   2. **Solid** — when `backgroundStyle == "solid"` and the pinned
+///      value is a `"solid:#RRGGBB"` sentinel, render the parsed color
+///      over the wash.
+///   3. **Remote photo** — when the `BackgroundService` has a manifest
+///      and storage URL, render via `AsyncImage` over the wash. The
+///      URL is either the user's pinned selection or a random pick
+///      from the manifest for the current time-of-day segment.
+///
+/// **Cold-launch behavior (2026-05-17 rewrite).** The previous design
+/// painted a UserDefaults-cached URL synchronously to skip a blank
+/// frame, then crossfaded to the resolved URL when `load()` finished.
+/// That produced two problems: (1) cross-user leak — the cached URL
+/// survived sign-out, so user B's first frame was user A's photo, and
+/// (2) a visible "old image then new image" swap on every cold launch
+/// when the resolved URL differed from the cached one. Both were fixed
+/// by deleting the UserDefaults cache entirely and starting from the
+/// wash bed; the resolved photo now fades in over the wash on first
+/// paint, and there's no stale URL to leak.
 ///
 /// View architecture: BackgroundView is a *pure observer* of
 /// `BackgroundService.shared`. The 60s segment ticker, the resolution
-/// pipeline, and the cached `displayedKey` all live in the service. Any
-/// number of mounted BackgroundView instances share that single state —
-/// before the hoist each instance ran its own ticker, image-decision
-/// pipeline, and `@State` slots, which compounded with every pushed nav
+/// pipeline, and `displayedKey` all live in the service. Any number of
+/// mounted BackgroundView instances share that single state — before
+/// the hoist each instance ran its own ticker, image-decision pipeline,
+/// and `@State` slots, which compounded with every pushed nav
 /// destination on top of MainContainer.
 ///
 /// Each instance still owns one tiny `@Query<UserProfile>` so it can
@@ -33,14 +46,29 @@ struct BackgroundView: View {
 
     @State private var service = BackgroundService.shared
 
-    /// Tracks whether the first non-empty image key has landed. The
-    /// crossfade animation is suppressed until then so cold launch shows
-    /// the wallpaper as "just there" — without this, the empty initial
-    /// `displayedKey` swapping to its first resolved value triggers the
-    /// 1.5s opacity transition, which reads as the photo animating in
-    /// even though there's no Ken Burns scale anymore. Initialised from
-    /// the service's current key so a warm process (cached URL already
-    /// pinned) skips the gate entirely.
+    /// Tracks whether this view instance has rendered its first
+    /// successful image. Drives two distinct animation choices:
+    ///
+    /// 1. **`paintAnimation`** — the outer `.animation(value: displayedKey)`
+    ///    uses the fast 800ms easeOut bloom on cold launch
+    ///    (`hasInitialPaint == false`) and the slower 1.5s easeInOut
+    ///    rotation crossfade once a photo has been seen.
+    /// 2. **`asyncImageTransaction`** — when `hasInitialPaint == false`,
+    ///    the `.empty → .success` phase change is animated so the photo
+    ///    blooms in over the wash. Once `hasInitialPaint` is true the
+    ///    transaction is empty, so a pushed nav destination's new
+    ///    BackgroundView (whose URL is already in URLCache and reaches
+    ///    `.success` in milliseconds) doesn't get a separate
+    ///    wash-bleed-through fade every time the user pushes into a
+    ///    list. The outer crossfade still handles in-session rotations.
+    ///
+    /// Initialised from the service's current key so a view created
+    /// during a warm session (`displayedKey` already non-empty) starts
+    /// in the post-first-paint state. Latched true → false the first
+    /// time `.success` actually renders, NOT when `displayedKey`
+    /// becomes non-empty — the distinction matters because bytes can
+    /// arrive after the key has changed and we want the bloom
+    /// animation to be in effect when they do.
     @State private var hasInitialPaint: Bool = !BackgroundService.shared.displayedKey.isEmpty
 
     /// Live read of the user's profile. SwiftData is canonical;
@@ -52,7 +80,7 @@ struct BackgroundView: View {
     /// races the wipe. `BackgroundView` has no `@Environment(AuthManager)`
     /// (it's used at the auth boundary too), so a userId predicate
     /// isn't available. Defensive: only consume the row when exactly
-    /// one is present; multi-row → fall through to the asset fallback
+    /// one is present; multi-row → fall through to the wash bed
     /// rather than picking up a stale user's preference.
     @Query(sort: \UserProfile.id) private var profiles: [UserProfile]
     private var currentProfile: UserProfile? {
@@ -61,10 +89,16 @@ struct BackgroundView: View {
 
     var body: some View {
         ZStack {
-            // Photo / asset / solid layer. Service-owned `displayedKey`
-            // drives the crossfade — switching it triggers the 1.5s
-            // opacity transition regardless of which rendering path is
-            // active.
+            // Wash bed — always present as the deepest layer. Cold
+            // launch and offline states render this alone; resolved
+            // images fade in on top via the .transition(.opacity) +
+            // AsyncImage transaction below.
+            service.currentWashColor
+                .ignoresSafeArea()
+
+            // Image / solid layer over the wash. `displayedKey` drives
+            // the .id() so SwiftUI swaps the inserted view (and fires
+            // the opacity transition) when the resolved photo changes.
             GeometryReader { geo in
                 ZStack {
                     if let imageName {
@@ -80,7 +114,21 @@ struct BackgroundView: View {
                             .id("solid:\(service.displayedKey)")
                             .transition(.opacity)
                     } else if let remoteURL = service.currentRemoteURL {
-                        AsyncImage(url: remoteURL) { phase in
+                        // On cold launch (hasInitialPaint=false) the
+                        // transaction animates the `.empty → .success`
+                        // phase change, so the photo blooms over the
+                        // wash when bytes arrive. After first paint
+                        // (and on pushed-view remounts whose URL is
+                        // already in URLCache) the transaction is
+                        // empty — the outer `.animation(value:)` and
+                        // `.transition(.opacity)` handle in-session
+                        // rotations, and a pushed view's near-instant
+                        // `.empty → .success` snap is invisible at one
+                        // frame rather than a 1.5s wash-bleed fade.
+                        AsyncImage(
+                            url: remoteURL,
+                            transaction: asyncImageTransaction
+                        ) { phase in
                             switch phase {
                             case .success(let image):
                                 image
@@ -88,30 +136,42 @@ struct BackgroundView: View {
                                     .aspectRatio(contentMode: .fill)
                                     .frame(width: geo.size.width, height: geo.size.height)
                                     .clipped()
+                                    // Latch out of the cold-launch
+                                    // animation mode now that we've
+                                    // actually rendered a photo. We
+                                    // wait for `.success` rather than
+                                    // the key change because bytes can
+                                    // arrive long after the key — and
+                                    // the bloom animation needs to
+                                    // still be live when they do.
+                                    .onAppear {
+                                        if !hasInitialPaint { hasInitialPaint = true }
+                                    }
                             default:
-                                fallbackImage(size: geo.size)
+                                // Loading or failure: render nothing,
+                                // wash bed shows through. Never flash
+                                // a bundled fallback — that was the
+                                // jarring swap this rewrite removes.
+                                Color.clear
                             }
                         }
                         .id("remote:\(service.displayedKey)")
                         .transition(.opacity)
-                    } else {
-                        fallbackImage(size: geo.size)
-                            .id("asset:\(service.displayedKey)")
-                            .transition(.opacity)
                     }
+                    // else: no image layer — wash bed alone. No
+                    // .id-bearing view inserted, so no transition
+                    // fires; the wash is just visible.
                 }
             }
             .ignoresSafeArea()
-            // Crossfade ONLY after the initial key has landed. Cold
-            // launch's first key swap (empty → resolved) would
-            // otherwise look like the photo "animating in" — calm-hero
-            // wants the wallpaper to just BE there.
-            .animation(hasInitialPaint ? crossfadeAnimation : nil, value: service.displayedKey)
-            .onChange(of: service.displayedKey, initial: false) { _, newKey in
-                if !hasInitialPaint && !newKey.isEmpty {
-                    hasInitialPaint = true
-                }
-            }
+            // `paintAnimation` chooses between the fast first-paint
+            // bloom (800ms ease-out, hasInitialPaint=false) and the
+            // slower in-session rotation crossfade (1.5s ease-in-out,
+            // hasInitialPaint=true). Both honour Reduce Motion. The
+            // `hasInitialPaint` latch flips inside the AsyncImage's
+            // .success closure, NOT here on the key change — see the
+            // doc comment on `hasInitialPaint` for why.
+            .animation(paintAnimation, value: service.displayedKey)
 
             // Top vignette for status bar readability
             VStack {
@@ -193,15 +253,6 @@ struct BackgroundView: View {
     }
 
     @ViewBuilder
-    private func fallbackImage(size: CGSize) -> some View {
-        Image(assetName)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: size.width, height: size.height)
-            .clipped()
-    }
-
-    @ViewBuilder
     private func assetImage(name: String, size: CGSize) -> some View {
         Image(name)
             .resizable()
@@ -210,22 +261,31 @@ struct BackgroundView: View {
             .clipped()
     }
 
-    /// Asset name for the fallback path. Prefers the service's
-    /// `currentFallbackAsset` (set during a successful recompute), falls
-    /// back to the hour-keyed default for the cold-launch window where
-    /// the service hasn't run yet.
-    private var assetName: String {
-        if let imageName { return imageName }
-        let serviceFallback = service.currentFallbackAsset
-        if !serviceFallback.isEmpty { return serviceFallback }
-        return BackgroundService.assetNameForHour(Calendar.current.component(.hour, from: Date()))
+    /// Per-instance paint animation. First paint of a freshly-mounted
+    /// view (cold launch, or any mount before the service resolved a
+    /// URL) blooms over the wash with a fast `easeOut` — the photo is
+    /// appearing, not transitioning between two photos. Once a key has
+    /// landed, subsequent swaps (60s rotation tick, settings change)
+    /// use the slower `easeInOut` so the crossfade reads as a smooth
+    /// dissolve between two equally-resolved photos. `nil` under
+    /// Reduce Motion so the swap is instant.
+    private var paintAnimation: Animation? {
+        if BrettAnimation.isReduceMotionEnabled { return nil }
+        return hasInitialPaint
+            ? .easeInOut(duration: 1.5)
+            : .easeOut(duration: 0.8)
     }
 
-    /// 1.5s ease-in-out crossfade, or `nil` when Reduce Motion is on so
-    /// the image swap is instant.
-    private var crossfadeAnimation: Animation? {
-        BrettAnimation.isReduceMotionEnabled
-            ? nil
-            : .easeInOut(duration: 1.5)
+    /// Transaction passed to `AsyncImage` for its internal
+    /// `.empty → .success` phase change. See `hasInitialPaint`'s doc
+    /// for the design rationale: animate the phase change ONLY on
+    /// this view's first paint, never on subsequent re-mounts or
+    /// rotations (where it would compound into a 1.5s
+    /// wash-bleed-fade on every push into a list view).
+    private var asyncImageTransaction: Transaction {
+        if hasInitialPaint {
+            return Transaction()
+        }
+        return Transaction(animation: paintAnimation)
     }
 }

--- a/apps/ios/Brett/Views/Shared/PagedSwipeView.swift
+++ b/apps/ios/Brett/Views/Shared/PagedSwipeView.swift
@@ -4,20 +4,25 @@ import UIKit
 /// Horizontal pager built on `UIPageViewController` so we can read
 /// real-time swipe progress (something SwiftUI's `TabView(.page)`
 /// doesn't expose). Drives the calm-hero photo crossfade: as the user
-/// drags Today off-screen toward Inbox, `dragProgress` ramps from 0
-/// toward 1, and the photo's opacity fades in lockstep — no snap at
-/// midpoint, no top/bottom safe-area lag.
+/// drags Today off-screen toward Inbox, `signedDragProgress` ramps
+/// from 0 toward ±1, and the photo's opacity fades in lockstep — no
+/// snap at midpoint, no snap at commit, no top/bottom safe-area lag.
 ///
 /// Three bindings:
 /// - `selection` — current page index (0…pageCount-1). Settles after
-///   the swipe completes; updated programmatically also flips the page
-///   (for tap-to-switch on the view-pills row).
+///   the swipe completes; updating it programmatically also flips the
+///   page (for tap-to-switch on the view-pills row). The coordinator
+///   bumps `selection` proactively at the moment UIPageViewController
+///   resets its inner scroll offset (see `prevOffsetX`) so consumers
+///   see the post-commit values one frame earlier — without that
+///   bump, opacity snaps from its release-moment value to the
+///   committed value when `didFinishAnimating` fires.
 /// - `dragProgress` — magnitude 0…1 of how far the user has dragged
 ///   from the current page toward an adjacent one. Always non-negative.
-/// - `dragSource` — which page the user is dragging FROM. Stays at the
-///   most recent settled page until the next swipe completes; lets
-///   callers compute "is the user dragging away from Today?" without
-///   lookups.
+/// - `signedDragProgress` — same magnitude, signed -1…+1. Positive
+///   when the user drags toward a HIGHER index (next page); negative
+///   toward a LOWER index. Lets callers compute "where is the user
+///   effectively pointing" for crossfades that need direction.
 ///
 /// Implementation is deliberately small. `UIPageViewController` exposes
 /// its inner scroll view via `view.subviews` (the only `UIScrollView`
@@ -106,6 +111,33 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
         /// causing swipes to bounce back even past the midpoint.
         private var hostCache: [Int: PageHost] = [:]
 
+        /// Previous scroll-view contentOffset.x, sampled on every
+        /// `scrollViewDidScroll`. Used to detect the page-commit
+        /// discontinuity: UIPageViewController resets its inner scroll
+        /// offset by one pageWidth in a single frame when a page change
+        /// commits (offset jumps from ~0 or ~2·pageWidth back to
+        /// pageWidth in the new 3-page window). At that frame we bump
+        /// `selection` ourselves so the next live-progress publish
+        /// computes against the correct `currentPage` — instead of
+        /// freezing progress during settle, which produced the visible
+        /// snap-at-commit the user reported.
+        ///
+        /// `nil` between gestures so the first scroll callback after a
+        /// fresh gesture doesn't compare against a stale baseline from
+        /// the previous swipe. Also `nil`ed on pageWidth change
+        /// (rotation / split-view resize) — without that, a pre-rotation
+        /// baseline in old-pageWidth coordinates can falsely satisfy
+        /// the half-page jump threshold against the new pageWidth.
+        private var prevOffsetX: CGFloat?
+
+        /// Last observed pageWidth. Used to invalidate `prevOffsetX`
+        /// when the scrollview's bounds change (rotation / size
+        /// class). Without this guard, rotation-time offset shifts
+        /// can spuriously trigger the page-commit reset detection
+        /// and bump `selection` to a neighbour the user never
+        /// reached.
+        private var lastPageWidth: CGFloat = 0
+
         init(_ parent: PagedSwipeView) { self.parent = parent }
 
         // MARK: DataSource — returns adjacent pages on demand.
@@ -173,18 +205,92 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
         // MARK: ScrollView — feeds swipe progress in real time.
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
-            // Only feed live drag progress while the user's finger is
-            // on the screen. Once they release, we let the pager's
-            // settle animation play out and rely on
-            // `didFinishAnimating` to atomically update both
-            // `selection` and progress — without this guard, the
-            // settling scroll resets progress to 0 BEFORE selection
-            // catches up, which produced a one-frame flash on swipe-
-            // back to Today.
-            guard scrollView.isTracking else { return }
+            // Publish live progress for both finger-on-screen drag AND
+            // the post-release settle. The earlier `isTracking`-only
+            // guard froze progress at the release-moment value and
+            // produced a visible "opacity snaps to the committed value
+            // when the pager finishes settling" — see the rewrite note
+            // on `prevOffsetX`. Programmatic transitions (tap-to-switch
+            // via ViewPillsBar) leave both flags false, so they're
+            // still skipped — those snap via the `withAnimation` spring
+            // on `currentPage` at the tap site.
+            guard scrollView.isTracking || scrollView.isDecelerating else {
+                prevOffsetX = nil
+                return
+            }
             let pageWidth = scrollView.bounds.width
             guard pageWidth > 0 else { return }
-            let delta = scrollView.contentOffset.x - pageWidth
+
+            // Invalidate the prev baseline if pageWidth changed —
+            // rotation / size class. See `lastPageWidth`'s doc.
+            if pageWidth != lastPageWidth {
+                prevOffsetX = nil
+                lastPageWidth = pageWidth
+            }
+
+            let currentOffset = scrollView.contentOffset.x
+
+            // Page-commit reset detection. When the user's swipe
+            // commits, UIPageViewController:
+            //   1. Settles the inner scroll to ~0 or ~2·pageWidth
+            //      (the adjacent page's slot).
+            //   2. In ONE frame, reorganises its 3-page window so the
+            //      new page is centered, which yanks the contentOffset
+            //      back to pageWidth.
+            //   3. Fires `didFinishAnimating` shortly after.
+            //
+            // The frame between (1) and (2) is the snap source: from
+            // the consumer's perspective, `signedDragProgress` lurches
+            // from ±~1 back to 0 while `selection` still reflects the
+            // OLD centered page. If we publish that frame, the photo
+            // opacity drops to the old page's value (0 if committing
+            // away from Today) for one frame, then jumps back when
+            // `didFinishAnimating` commits the new selection.
+            //
+            // Detection: a single-frame contentOffset movement of more
+            // than half a pageWidth. No human finger can drag that
+            // fast, and UIScrollView's settle animation never advances
+            // more than a fraction of a page in 16ms — the only thing
+            // that produces a half-page jump in a frame is the UIPV
+            // window-reorganisation. When we see it, bump `selection`
+            // ourselves (direction from the SIGN of the previous
+            // delta — forward commits settle through +1, backward
+            // through -1). The immediately-following publish then
+            // lands `effectivePage = newPage + 0 = newPage`, matching
+            // the visible state. `didFinishAnimating` becomes a
+            // no-op for selection because the existing
+            // `if self.parent.selection != current.index` guard
+            // short-circuits.
+            if let bump = PagedSwipeResetDetector.bumpForReset(
+                prevOffset: prevOffsetX,
+                currentOffset: currentOffset,
+                pageWidth: pageWidth
+            ) {
+                let proposed = self.parent.selection + bump
+                if proposed >= 0 && proposed < self.parent.pageCount {
+                    self.parent.selection = proposed
+                    // Reset progress in the same tick — the centered
+                    // offset's signed = 0 is the value the next frame
+                    // would publish anyway, just made explicit so the
+                    // consumer sees the atomic post-commit state in
+                    // this tick rather than next.
+                    if self.parent.dragProgress != 0 {
+                        self.parent.dragProgress = 0
+                    }
+                    if self.parent.signedDragProgress != 0 {
+                        self.parent.signedDragProgress = 0
+                    }
+                    prevOffsetX = currentOffset
+                    return
+                }
+                // Out-of-bounds bump (e.g. edge bounce that crossed
+                // the threshold). Don't mutate selection; fall through
+                // to a normal publish so progress still tracks the
+                // observed offset truthfully.
+            }
+            prevOffsetX = currentOffset
+
+            let delta = currentOffset - pageWidth
             let signed = max(-1, min(1, delta / pageWidth))
             let magnitude = min(1, abs(delta) / pageWidth)
             if abs(self.parent.dragProgress - magnitude) > 0.001 {
@@ -198,7 +304,9 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
         func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
             // Safety reset in case `didFinishAnimating` missed a
             // tiny rounding tail. Selection is left alone here —
-            // the delegate path is the source of truth for that.
+            // the delegate path (and the in-scroll bump above) are
+            // the sources of truth for that.
+            prevOffsetX = nil
             DispatchQueue.main.async {
                 if self.parent.dragProgress != 0 {
                     self.parent.dragProgress = 0
@@ -215,4 +323,51 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
 /// for the `UIPageViewControllerDataSource` queries.
 final class PageHost: UIHostingController<AnyView> {
     var index: Int = 0
+}
+
+/// Pure threshold logic for detecting UIPageViewController's
+/// window-reorganisation frame. Extracted from `PagedSwipeView`'s
+/// `Coordinator` so the heuristic can be unit-tested without a live
+/// `UIScrollView` / `UIPageViewController` harness — the rest of
+/// the coordinator is too entangled with UIKit to test directly,
+/// but this is where the behaviour the user notices actually lives.
+///
+/// Not generic, not nested inside `PagedSwipeView<Page>` — keeping
+/// it at file scope means the test can call it without supplying a
+/// `Page` type parameter that has no bearing on the logic.
+enum PagedSwipeResetDetector {
+
+    /// Returns the index bump (+1 or -1) the coordinator should
+    /// apply when the inner scroll view's `contentOffset.x` moved by
+    /// more than half a `pageWidth` in a single frame — the
+    /// signature of UIPageViewController's window-reorganisation
+    /// after a commit (see `PagedSwipeView.Coordinator.prevOffsetX`
+    /// for the full rationale). Returns `nil` when:
+    ///
+    /// - `prevOffset` is `nil` (first callback of a gesture, or
+    ///   after rotation/size-class change wiped the baseline).
+    /// - The single-frame movement was less than `0.5 * pageWidth`
+    ///   (normal drag / settle, no reset).
+    /// - `pageWidth` is non-positive (degenerate layout).
+    ///
+    /// The caller still has to check the proposed
+    /// `selection + bump` against `pageCount` bounds — an
+    /// out-of-range bump means the detection fired falsely
+    /// (e.g., an edge bounce or rotation we didn't catch) and
+    /// the caller should fall through to a normal publish
+    /// rather than mutate selection.
+    static func bumpForReset(
+        prevOffset: CGFloat?,
+        currentOffset: CGFloat,
+        pageWidth: CGFloat
+    ) -> Int? {
+        guard pageWidth > 0, let prev = prevOffset else { return nil }
+        let movement = abs(currentOffset - prev)
+        guard movement > 0.5 * pageWidth else { return nil }
+        // Direction comes from the sign of the previous delta:
+        // forward commits settle through +1·pageWidth before
+        // resetting, backward through -1.
+        let prevDelta = prev - pageWidth
+        return prevDelta > 0 ? 1 : -1
+    }
 }

--- a/apps/ios/BrettTests/Views/BackgroundServiceRendererTests.swift
+++ b/apps/ios/BrettTests/Views/BackgroundServiceRendererTests.swift
@@ -119,20 +119,89 @@ struct BackgroundServiceRendererTests {
         svc.unregisterRenderer()
     }
 
-    @Test func updateProfilePopulatesDisplayedKeyForFallbackPath() {
+    @Test func updateProfileLeavesEmptyDisplayedKeyForWashFallback() {
         reset()
         let svc = BackgroundService.shared
         svc.registerRenderer()
         defer { svc.unregisterRenderer() }
 
-        // No manifest / storage URL loaded → service falls through
-        // to the asset-catalog fallback. `currentFallbackAsset` should
-        // populate and `displayedKey` should match.
+        // No manifest / storageBaseUrl loaded + no profile → wash-only
+        // fallback. `displayedKey` stays empty so `BackgroundView`
+        // renders only the wash bed; no image layer is inserted, no
+        // transition fires. The previous bundled-asset fallback would
+        // have populated `currentFallbackAsset` here and triggered a
+        // visible crossfade once the real photo resolved — this test
+        // pins the new "wash, then photo fades in" contract.
         svc.updateProfile(style: nil, pinned: nil, initial: true)
 
-        #expect(!svc.currentFallbackAsset.isEmpty)
-        #expect(svc.displayedKey == svc.currentFallbackAsset)
-        #expect(svc.currentRemoteURL == nil || svc.currentRemoteURL != nil) // tolerated either way — manifest may be cached from prior run
+        #expect(svc.displayedKey.isEmpty)
+        #expect(svc.currentRemoteURL == nil)
+        #expect(svc.currentSolidColor == nil)
+    }
+
+    @Test func freshSingletonStartsWithEmptyDisplayedKey() {
+        reset()
+        let svc = BackgroundService.shared
+
+        // Cold-launch contract: nothing painted until something is
+        // resolved. The previous design seeded `displayedKey` from
+        // UserDefaults at init so a cached URL painted before
+        // `/config` returned — that produced the cross-user leak +
+        // the visible swap. Now the only way to get a non-empty key
+        // is to actually resolve one this session.
+        #expect(svc.displayedKey.isEmpty)
+        #expect(svc.currentRemoteURL == nil)
+        #expect(svc.currentSolidColor == nil)
+    }
+
+    @Test func clearForSignOutResetsRenderState() {
+        reset()
+        let svc = BackgroundService.shared
+        svc.registerRenderer()
+        defer { svc.unregisterRenderer() }
+
+        // Drive the service into a "resolved solid" state — easier to
+        // assert than a remote URL because solid doesn't require the
+        // manifest / storageBaseUrl. Same state surface gets cleared
+        // either way; this just keeps the test hermetic.
+        svc.updateProfile(style: "solid", pinned: "solid:#0040DD", initial: true)
+        #expect(svc.currentSolidColor != nil)
+        #expect(svc.displayedKey == "solid:#0040DD")
+
+        // Sign-out fan-out lands here. The next render must start from
+        // the wash bed alone — no leftover solid, URL, or key from the
+        // signed-out user.
+        svc.clearForSignOut()
+
+        #expect(svc.currentSolidColor == nil)
+        #expect(svc.currentRemoteURL == nil)
+        #expect(svc.displayedKey.isEmpty)
+        #expect(!svc.currentWashIsLight)
+    }
+
+    @Test func clearForSignOutWipesBootstrapToDefendCrossUserLeak() {
+        reset()
+        let svc = BackgroundService.shared
+
+        // The defense this test guards: between `clearForSignOut`
+        // running and `PersistenceController.wipeAllData()` finishing,
+        // SignInView's BackgroundView may mount and push the
+        // (still-present) prior-user UserProfile row into
+        // `updateProfile(...)` via @Query + .onAppear. If the
+        // service's manifest + storageBaseUrl survive the clear,
+        // `currentImageURL(...)` happily rebuilds the prior user's
+        // pinned URL and `applyRemote(...)` paints it on the sign-in
+        // screen. Wiping the bootstrap forces the wash fallback for
+        // that intervening call — the worst case becomes "wash for
+        // ~100ms on next sign-in while /config re-fetches" rather
+        // than "prior user's photo flashes on the sign-in screen."
+        svc.updateProfile(style: "solid", pinned: "solid:#0040DD", initial: true)
+        #expect(svc.currentSolidColor != nil)
+
+        svc.clearForSignOut()
+
+        #expect(svc.manifest == nil)
+        #expect(svc.storageBaseUrl == nil)
     }
 
     @Test func updateProfileSolidPathSetsColorAndSentinelKey() {

--- a/apps/ios/BrettTests/Views/PagedSwipeResetDetectionTests.swift
+++ b/apps/ios/BrettTests/Views/PagedSwipeResetDetectionTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Coverage for `PagedSwipeView.bumpForReset` — the pure threshold
+/// logic that detects UIPageViewController's window-reorganisation
+/// frame. When the inner scroll view's contentOffset.x jumps by more
+/// than half a pageWidth in a single frame, that's the moment the
+/// pager committed a page change AND yanked the offset back to
+/// pageWidth in the new 3-page window. The coordinator uses the
+/// bump to update `selection` proactively so consumers don't see a
+/// one-frame stale-page-with-zero-progress flash, which is the snap
+/// the calm-hero photo opacity used to show at the end of every
+/// side-swipe.
+///
+/// The detection is intentionally heuristic — UIPageViewController
+/// doesn't expose the reset event directly — so the threshold has to
+/// reject normal drag/settle motion (max ~one frame's worth of
+/// movement, well under half a pageWidth) and accept the
+/// reset discontinuity (exactly one pageWidth in zero frames).
+@Suite("PagedSwipeReset")
+struct PagedSwipeResetDetectionTests {
+
+    /// Forward commit: previous frame had the offset settled near
+    /// the next-page slot (offset ≈ 2·pageWidth, prevDelta ≈ +1),
+    /// current frame has the offset reset back to pageWidth. That
+    /// pageWidth-magnitude jump in one frame is the signature.
+    @Test func forwardCommitProducesPositiveBump() {
+        let pageWidth: CGFloat = 400
+        let prev: CGFloat = 800   // ≈ 2·pageWidth (forward boundary)
+        let current: CGFloat = 400 // ≈ pageWidth (centered)
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: prev,
+            currentOffset: current,
+            pageWidth: pageWidth
+        ) == 1)
+    }
+
+    /// Backward commit mirrors forward — prevDelta < 0, expect -1.
+    @Test func backwardCommitProducesNegativeBump() {
+        let pageWidth: CGFloat = 400
+        let prev: CGFloat = 0      // ≈ 0 (backward boundary)
+        let current: CGFloat = 400 // ≈ pageWidth (centered)
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: prev,
+            currentOffset: current,
+            pageWidth: pageWidth
+        ) == -1)
+    }
+
+    /// Normal mid-swipe motion: a couple of percent of a page per
+    /// frame at most. Must never satisfy the threshold or we'd bump
+    /// selection mid-drag and snap the photo to a neighbouring
+    /// page's wallpaper.
+    @Test func normalDragMotionDoesNotBump() {
+        let pageWidth: CGFloat = 400
+        let prev: CGFloat = 380     // halfway into a leftward drag
+        let current: CGFloat = 360  // 20pt further left (5% of page)
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: prev,
+            currentOffset: current,
+            pageWidth: pageWidth
+        ) == nil)
+    }
+
+    /// Settle-back-to-center after a cancelled swipe: offset moves
+    /// gradually from, say, 0.3·pageWidth back to pageWidth across
+    /// many frames. Each per-frame step is small even on a fast
+    /// release. Verify a single step inside that settle doesn't
+    /// trigger the detection.
+    @Test func cancelledSwipeSettleDoesNotBump() {
+        let pageWidth: CGFloat = 400
+        // Frame in the middle of a cancel-settle: offset moving back
+        // from 280 toward pageWidth=400. ~40pt per-frame step is on
+        // the fast end of UIScrollView's spring deceleration.
+        let prev: CGFloat = 280
+        let current: CGFloat = 320
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: prev,
+            currentOffset: current,
+            pageWidth: pageWidth
+        ) == nil)
+    }
+
+    /// First scroll callback of a gesture — coordinator clears
+    /// `prevOffsetX` between gestures so the first comparison has no
+    /// baseline. Must return nil (no bump, no false positive).
+    @Test func nilPrevOffsetReturnsNil() {
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: nil,
+            currentOffset: 400,
+            pageWidth: 400
+        ) == nil)
+    }
+
+    /// Degenerate layout (pre-layout pass, zero-width container).
+    /// Must return nil rather than divide-by-zero or accept any
+    /// motion as a reset.
+    @Test func zeroPageWidthReturnsNil() {
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: 0,
+            currentOffset: 100,
+            pageWidth: 0
+        ) == nil)
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: 0,
+            currentOffset: 100,
+            pageWidth: -10
+        ) == nil)
+    }
+
+    /// Threshold is strictly greater-than half a pageWidth. Exactly
+    /// 50% does NOT bump — that protects against a hypothetical
+    /// pathological settle that hits the half-page line without an
+    /// actual reset.
+    @Test func exactlyHalfPageMovementDoesNotBump() {
+        let pageWidth: CGFloat = 400
+        // movement = |600 - 400| = 200 = 0.5·400, NOT > 0.5
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: 400,
+            currentOffset: 600,
+            pageWidth: pageWidth
+        ) == nil)
+    }
+
+    /// Just past half-page movement bumps — covers the fast-flick
+    /// case where the frame before the reset may not have reached
+    /// the full ±pageWidth boundary before UIPV committed.
+    @Test func justOverHalfPageMovementBumps() {
+        let pageWidth: CGFloat = 400
+        // Hypothetical fast-flick: prev was at 0.4·pageWidth past
+        // centered (delta = +160), current snapped back to centered.
+        // Movement = 240 > 200. Bump = +1 (prevDelta > 0).
+        #expect(PagedSwipeResetDetector.bumpForReset(
+            prevOffset: 560,
+            currentOffset: 320,
+            pageWidth: pageWidth
+        ) == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Ship the three iOS wallpaper fixes merged via [#168](https://github.com/brentbarkman/brett/pull/168). 100% iOS changes — no API, desktop, or shared-package code touched, so this release is **iOS-only**.

- Kill the cross-user wallpaper leak (previous user's pinned photo painted on a fresh sign-in)
- Replace cold-launch cached → resolved photo swap with wash → fade-in
- Smooth the side-scroll background transition (no more frozen-then-snap at commit)

Commits:
- [\`dacbc34\`](https://github.com/brentbarkman/brett/commit/dacbc34) fix(ios): kill cross-user wallpaper leak + cold-launch image swap
- [\`0c3b242\`](https://github.com/brentbarkman/brett/commit/0c3b242) fix(ios): smooth side-scroll background transition through commit

## Test plan

- [x] BackgroundServiceRendererTests, BackgroundServiceSegmentTests, PagedSwipeResetDetectionTests: all green (verified at the merge to main)
- [x] Debug + Release builds clean
- [ ] CI typecheck + tests pass on this PR
- [ ] Manual TestFlight verification post-release: cold launch + sign-out/sign-in, side-swipe Today↔Inbox and Today↔Calendar in both directions, watch for smooth photo opacity throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)