### PR TITLE
fix: keep create_task available through multi-turn refinement (#170)

### DIFF
--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -469,7 +469,7 @@ export function useListSuggestions(itemId: string | null) {
     queryKey: ["list-suggestions", itemId],
     queryFn: () =>
       apiFetch<{ suggestions: Array<{ listId: string; listName: string; similarity: number }> }>(
-        `/things/${itemId}/list-suggestions`
+        `/api/things/${itemId}/list-suggestions`
       ),
     enabled: !!itemId,
   });

--- a/packages/ai/src/orchestrator.ts
+++ b/packages/ai/src/orchestrator.ts
@@ -16,6 +16,11 @@ const MAX_TOTAL_TOKENS = AI_CONFIG.orchestrator.maxTotalTokens;
 const MAX_TOOL_RESULT_SIZE = AI_CONFIG.orchestrator.maxToolResultSize;
 const MAX_DURATION_MS = AI_CONFIG.orchestrator.maxDurationMs;
 
+// How many of the most recent user turns to feed into intent classification.
+// 3 covers a typical "ask → clarify → answer" loop without leaking unrelated
+// intent from earlier in a long session.
+const INTENT_HISTORY_WINDOW = 3;
+
 // Matches common API key patterns (Bearer tokens, sk-*, key-*, etc.) — an
 // allowlist of known-bad prefixes is more precise than entropy guessing and
 // won't over-redact legitimate identifiers.
@@ -132,10 +137,22 @@ export async function* orchestrate(
     // - "none": pure text generation (briefing, bretts_take) — saves ~2,500 tokens
     // - "contextual": filter tools by user message (omnibar, brett_thread) — saves ~1,000 tokens
     // - "all": send all registered tools (fallback)
+    //
+    // For contextual mode we also fold in intent from the last few user turns
+    // so a multi-turn refinement ("401k" → "yes" → "just to set it up") keeps
+    // create_task available even when the final turn only carries mutate words.
+    const recentUserMessages = messages
+      .filter((m) => m.role === "user")
+      .map((m) => m.content)
+      .filter((s) => s.length > 0)
+      .slice(-INTENT_HISTORY_WINDOW);
     const tools = ctx.toolMode === "none"
       ? []
       : ctx.toolMode === "contextual" && "message" in input
-        ? registry.toToolDefinitionsForMessage((input as { message: string }).message)
+        ? registry.toToolDefinitionsForMessage(
+            (input as { message: string }).message,
+            recentUserMessages,
+          )
         : registry.toToolDefinitions();
     let totalInputTokens = 0;
     let totalOutputTokens = 0;

--- a/packages/ai/src/skills/__tests__/registry.test.ts
+++ b/packages/ai/src/skills/__tests__/registry.test.ts
@@ -133,4 +133,54 @@ describe("SkillRegistry", () => {
       expect(tools.map((t) => t.name)).toContain("get_meeting_action_items");
     });
   });
+
+  describe("toToolDefinitionsForMessage — multi-turn intent propagation", () => {
+    // Regression for issue #170. In a multi-turn create flow, the latest
+    // user message may not carry create-intent words even though the
+    // conversation is clearly about creating a task. Without the history
+    // window, the LLM was sent only mutate tools (search/update/move/...)
+    // and hallucinated "I don't have a create tool available right now".
+    //
+    // Reproduces Brent's "401k" flow:
+    //   user: "401k"           → no patterns match → fallback (create + query + mutate)
+    //   asst: "want me to create one? what action — rollover, contribution, …?"
+    //   user: "yes"            → no patterns → fallback
+    //   asst: "what's the specific action?"
+    //   user: "just to set it up" → `set` matches MUTATE only → create_task gets dropped
+    beforeEach(() => {
+      registry.register(makeSkill({ name: "create_task" }));
+      registry.register(makeSkill({ name: "update_item" }));
+      registry.register(makeSkill({ name: "complete_task" }));
+      registry.register(makeSkill({ name: "move_to_list" }));
+      registry.register(makeSkill({ name: "snooze_item" }));
+      registry.register(makeSkill({ name: "archive_list" }));
+      registry.register(makeSkill({ name: "search_things" }));
+      registry.register(makeSkill({ name: "get_item_detail" }));
+    });
+
+    it("preserves create_task when prior user turns implied a create intent", () => {
+      const tools = registry.toToolDefinitionsForMessage(
+        "just to set it up",
+        ["401k", "yes"],
+      );
+      expect(tools.map((t) => t.name)).toContain("create_task");
+    });
+
+    it("ignores history when the latest message itself has clear create intent", () => {
+      const tools = registry.toToolDefinitionsForMessage(
+        "create a task to call mom",
+        ["what's on today"],
+      );
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("create_task");
+    });
+
+    it("backward-compatible: single-message call still works (no history arg)", () => {
+      const tools = registry.toToolDefinitionsForMessage("just to set it up");
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("update_item");
+      // Without history, create_task is correctly absent — pre-existing behavior.
+      expect(names).not.toContain("create_task");
+    });
+  });
 });

--- a/packages/ai/src/skills/registry.ts
+++ b/packages/ai/src/skills/registry.ts
@@ -62,31 +62,44 @@ export class SkillRegistry {
   }
 
   /**
-   * Intent-based tool selection — classifies the message into intents
-   * and sends only the tools for matched intent groups.
+   * Intent-based tool selection — classifies the message (and optionally
+   * a sliding window of recent prior user turns) into intents and sends
+   * only the tools for matched intent groups.
    * Falls back to query + create + mutate for ambiguous messages.
+   *
+   * `recentUserMessages` is included to handle multi-turn refinement flows
+   * where the latest turn ("just to set it up") no longer carries the
+   * original intent word ("create"). Without it, a clarifying back-and-forth
+   * can silently drop the create_task tool partway through the conversation.
    */
-  toToolDefinitionsForMessage(message: string): ToolDefinition[] {
-    const lower = message.toLowerCase();
-
-    // Classify intents from the message
+  toToolDefinitionsForMessage(
+    message: string,
+    recentUserMessages: string[] = [],
+  ): ToolDefinition[] {
+    // Classify each message independently. If a message matches no patterns,
+    // it's individually ambiguous and contributes the fallback (query + create
+    // + mutate) — same behavior as the original single-message path. The
+    // union across the window is what gets sent to the LLM, so ambiguous
+    // priors (e.g. "401k", "yes") keep create_task available even when the
+    // latest turn locks in on mutate.
+    const AMBIGUOUS_FALLBACK = ["query", "create", "mutate"];
     const matchedIntents = new Set<string>();
-    for (const { intent, pattern } of INTENT_PATTERNS) {
-      if (pattern.test(lower)) {
-        matchedIntents.add(intent);
+    for (const msg of [message, ...recentUserMessages]) {
+      const lower = msg.toLowerCase();
+      const msgIntents = new Set<string>();
+      for (const { intent, pattern } of INTENT_PATTERNS) {
+        if (pattern.test(lower)) {
+          msgIntents.add(intent);
+        }
       }
-    }
-
-    // URL in message → likely saving content
-    if (/https?:\/\//.test(lower)) {
-      matchedIntents.add("create");
-    }
-
-    // No intents matched → ambiguous, send query + create + mutate (skip meta)
-    if (matchedIntents.size === 0) {
-      matchedIntents.add("query");
-      matchedIntents.add("create");
-      matchedIntents.add("mutate");
+      // URL in message → likely saving content
+      if (/https?:\/\//.test(lower)) {
+        msgIntents.add("create");
+      }
+      if (msgIntents.size === 0) {
+        for (const i of AMBIGUOUS_FALLBACK) msgIntents.add(i);
+      }
+      for (const i of msgIntents) matchedIntents.add(i);
     }
 
     // Collect unique tool names from matched groups


### PR DESCRIPTION
Closes #170

## Root cause

Two bugs surfaced in the reported chat:

**1. Mid-conversation `create_task` drop (primary).** `SkillRegistry.toToolDefinitionsForMessage` only classifies the *latest* user turn. In Brent's flow:

| turn | message | intent match | tools sent |
|---|---|---|---|
| 1 | "401k" | none → fallback | query + create + mutate ✓ |
| 2 | "yes" | none → fallback | query + create + mutate ✓ |
| 3 | "just to set it up" | `set` → **mutate only** | update/complete/move/snooze/archive + lookup |

Turn 3 dropped `create_task`. The LLM correctly inferred the user wanted to create a task but had no tool to do it, so it said *"I don't have a create tool available right now"* — exactly what the issue reports.

**2. `/things/:id/list-suggestions` returns 404 (secondary).** `apps/api/src/app.ts:121` mounts the suggestions router at `/api`, but `apps/desktop/src/api/things.ts:472` was calling `/things/${id}/list-suggestions` without the `/api` prefix. The sibling calendar callers already use `/api/events/...`. Explains the 13× 404s in the issue's failed-API-calls list.

## Approach

**Bug 1.** Considered three options:
- **(A) Sliding window of recent user messages → union intents** (chosen). Minimal change, fixes the root cause for the multi-turn class of bug, not just the literal "401k" case.
- (B) Always include `create_task` regardless of intent. Cheaper to implement, but adds tokens to every request and doesn't fix the general "intent-locked-on-mutate mid-flow" class.
- (C) Detect "assistant just asked a clarifying question" and broaden tools. Requires brittle assistant-message inspection.

The window is bounded to 3 user turns — wide enough for typical "ask → clarify → answer" loops, narrow enough that intent from earlier in a long session doesn't leak. Each message in the window is classified independently: ambiguous priors contribute the same fallback (query + create + mutate) they'd contribute as standalone messages.

**Bug 2.** Patched the caller to use `/api/things/...` — consistent with the same router's calendar endpoints. Considered re-mounting the router at `/things` and `/events` instead, but that's more files / more deployment risk and the inconsistency exists across many other route mounts.

## Tests

`packages/ai/src/skills/__tests__/registry.test.ts` — three new tests covering the multi-turn intent propagation:
1. **Regression test for Brent's exact flow** — message `"just to set it up"` with history `["401k", "yes"]` keeps `create_task` available. Fails on `main`, passes with this change.
2. **History doesn't override clear current intent** — `"create a task to call mom"` with unrelated history still exposes `create_task`. Guards against the fix overcorrecting.
3. **Backward-compat** — single-message call still works, and the standalone `"just to set it up"` correctly drops `create_task` (documents that the multi-turn behavior is the intentional new path, not accidental).

These cover the **category** of multi-turn intent drop, not just the literal 401k case.

**No test added for the URL fix** — would amount to mocking `apiFetch` and asserting the URL string, which is exactly the "code calls what the code calls" tautology CLAUDE.md says to skip. The right test layer is an integration check between the desktop client and the live API; the codebase doesn't have that today.

## Verification

```
$ pnpm typecheck
17 tasks successful (api, ai, desktop, evals, admin-api, …)

$ pnpm --filter @brett/ai test
251 passed | 6 skipped (257)

$ pnpm --filter @brett/desktop test
185 passed (185)
```

The URL fix is in a React Query hook — to verify end-to-end: open a thing-detail sheet, watch network requests, confirm `GET /api/things/<id>/list-suggestions` returns 200 instead of 404.

## Risks / follow-ups

- **Slight tool-set widening in long ambiguous sessions.** A session with several "yes/ok/sure" replies will now route create+query+mutate tools at every turn. That's more tokens (~500-1000 extra) but never *fewer* tools, so it can't reintroduce this class of bug. Acceptable cost vs. the user-visible failure mode.
- **Route mount inconsistency** (`/api` vs bare paths). Worth normalizing across the suggestions/search routers in a future cleanup, but out of scope here.
- **Brent's UX suggestion** ("ambiguous 1-2 word messages should offer a quick-create chip instead of LLM back-and-forth") is real product work — needs a design pass on where the chip lives (chat? omnibar?) and the trigger heuristic. Filing as a follow-up rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJsrEfMVo2gVS3grZv6y5i)_