### PR TITLE
feat: per-account connection health visibility

### DIFF
--- a/apps/api/src/__tests__/calendar-accounts.test.ts
+++ b/apps/api/src/__tests__/calendar-accounts.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { prisma } from "../lib/prisma.js";
 import { createRelinkTask } from "../lib/connection-health.js";
 import { encryptToken } from "../lib/encryption.js";
@@ -18,6 +21,69 @@ describe("Calendar Accounts routes", () => {
       const user = await createTestUser("Calendar Delete User");
       token = user.token;
       userId = user.userId;
+    });
+
+    it("only resolves the disconnected account's re-link task, not other accounts'", async () => {
+      // Regression guard for the multi-account re-link bug on Google Calendar:
+      // the provider-wide resolveRelinkTask used to dismiss every Google
+      // Calendar re-link task for the user — so disconnecting one account
+      // would silently clear another (broken) account's prompt. We now scope
+      // the resolve by accountId. Same bug pattern as Granola DELETE.
+      const user = await createTestUser("Calendar DELETE scoped relink");
+
+      const brokenAccount = await prisma.googleAccount.create({
+        data: {
+          userId: user.userId,
+          googleEmail: `broken-${Date.now()}@example.com`,
+          googleUserId: `google-broken-${Date.now()}`,
+          accessToken: encryptToken("fake-access-token"),
+          refreshToken: encryptToken("fake-refresh-token"),
+          tokenExpiresAt: new Date(Date.now() + 3600_000),
+        },
+      });
+      const healthyAccount = await prisma.googleAccount.create({
+        data: {
+          userId: user.userId,
+          googleEmail: `healthy-${Date.now()}@example.com`,
+          googleUserId: `google-healthy-${Date.now()}`,
+          accessToken: encryptToken("fake-access-token"),
+          refreshToken: encryptToken("fake-refresh-token"),
+          tokenExpiresAt: new Date(Date.now() + 3600_000),
+        },
+      });
+
+      // Both accounts have re-link tasks (e.g. both failed at some point)
+      await createRelinkTask(user.userId, "google-calendar", brokenAccount.id, "broken");
+      await createRelinkTask(user.userId, "google-calendar", healthyAccount.id, "healthy was once broken");
+
+      const res = await authRequest(
+        `/calendar/accounts/${healthyAccount.id}`,
+        user.token,
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(200);
+
+      // The broken account's re-link task must still be active.
+      const brokenTaskAfter = await prisma.item.findFirst({
+        where: {
+          userId: user.userId,
+          source: "system",
+          sourceId: `relink:google-calendar:${brokenAccount.id}`,
+          status: "active",
+        },
+      });
+      expect(brokenTaskAfter).not.toBeNull();
+
+      // The deleted (healthy) account's re-link task should be resolved.
+      const healthyTaskAfter = await prisma.item.findFirst({
+        where: {
+          userId: user.userId,
+          source: "system",
+          sourceId: `relink:google-calendar:${healthyAccount.id}`,
+          status: "active",
+        },
+      });
+      expect(healthyTaskAfter).toBeNull();
     });
 
     it("resolves the google-calendar re-link task so the broken-connection badge clears", async () => {
@@ -175,6 +241,33 @@ describe("Calendar Accounts routes", () => {
       // from Google. Without this, an incremental fetch using the stale
       // token would skip the events the user wants to see again.
       expect(updated?.syncToken).toBeNull();
+    });
+  });
+
+  describe("OAuth callback re-link scoping (source regression)", () => {
+    // We can't easily fake the full Google OAuth callback without mocking the
+    // entire googleapis chain (token exchange + userinfo.get). Instead, lock
+    // in the source-level invariant that catches the bug class directly:
+    // both the callback success path AND the disconnect path must use the
+    // PER-ACCOUNT resolver. If anyone reverts to the provider-wide
+    // `resolveRelinkTask(...)` here, reconnecting one Google Calendar account
+    // would silently dismiss every other Google Calendar account's broken
+    // prompt — exactly the user-visible bug we shipped a fix for.
+    it("calendar-accounts.ts uses the per-account resolver, never the provider-wide one", () => {
+      const here = dirname(fileURLToPath(import.meta.url));
+      const source = readFileSync(
+        resolve(here, "../routes/calendar-accounts.ts"),
+        "utf8",
+      );
+      // Strip line comments and the import line — only flag actual call sites.
+      const callSites = source
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("//"))
+        .filter((line) => !line.includes("import"))
+        .join("\n");
+      // `\b` ensures we don't match `resolveRelinkTaskForAccount`.
+      expect(callSites).not.toMatch(/\bresolveRelinkTask\s*\(/);
+      expect(callSites).toMatch(/resolveRelinkTaskForAccount\s*\(/);
     });
   });
 });

--- a/apps/api/src/__tests__/connection-health.test.ts
+++ b/apps/api/src/__tests__/connection-health.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { prisma } from "../lib/prisma.js";
-import { createRelinkTask, resolveRelinkTask } from "../lib/connection-health.js";
+import {
+  createRelinkTask,
+  resolveRelinkTask,
+  resolveRelinkTaskForAccount,
+  getBrokenConnections,
+} from "../lib/connection-health.js";
 import { generateId } from "@brett/utils";
 
 describe("connection-health", () => {
@@ -108,6 +113,74 @@ describe("connection-health", () => {
       const after = await findRelinkTasks(userId, "relink:ai:");
       const activeAfter = after.filter((t) => t.status === "active");
       expect(activeAfter).toHaveLength(0);
+    });
+  });
+
+  describe("getBrokenConnections", () => {
+    // Each subtest uses a fresh user so per-account counts aren't polluted by
+    // the createRelinkTask cases above.
+    it("returns details with per-account reason and brokenSince", async () => {
+      const user = await prisma.user.create({
+        data: {
+          id: generateId(),
+          name: "Broken Conn User",
+          email: `broken-${Date.now()}-${Math.random()}@test.com`,
+          emailVerified: true,
+        },
+      });
+      await createRelinkTask(user.id, "granola", "acc-1", "Token expired");
+
+      const result = await getBrokenConnections(user.id);
+
+      expect(result.count).toBe(1);
+      expect(result.types).toEqual(["granola"]);
+      expect(result.details).toHaveLength(1);
+      expect(result.details[0]).toMatchObject({
+        type: "granola",
+        accountId: "acc-1",
+        reason: "Token expired",
+      });
+      expect(result.details[0]!.brokenSince).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("preserves backwards-compatible shape: count + types alongside details", async () => {
+      const user = await prisma.user.create({
+        data: {
+          id: generateId(),
+          name: "Multi Type User",
+          email: `multi-${Date.now()}-${Math.random()}@test.com`,
+          emailVerified: true,
+        },
+      });
+      await createRelinkTask(user.id, "granola", "g1", "Granola broke");
+      await createRelinkTask(user.id, "google-calendar", "gc1", "Calendar broke");
+
+      const result = await getBrokenConnections(user.id);
+
+      expect(result.count).toBe(2);
+      expect(new Set(result.types)).toEqual(new Set(["granola", "google-calendar"]));
+      expect(result.details).toHaveLength(2);
+    });
+
+    it("regression: reconnecting account B does not clear account A's re-link task", async () => {
+      const user = await prisma.user.create({
+        data: {
+          id: generateId(),
+          name: "Scoped Resolution User",
+          email: `scoped-${Date.now()}-${Math.random()}@test.com`,
+          emailVerified: true,
+        },
+      });
+      await createRelinkTask(user.id, "granola", "acc-A", "Token expired for A");
+      await createRelinkTask(user.id, "granola", "acc-B", "Token expired for B");
+
+      // Simulate reconnect of acc-B
+      await resolveRelinkTaskForAccount(user.id, "granola", "acc-B");
+
+      const result = await getBrokenConnections(user.id);
+      expect(result.details).toHaveLength(1);
+      expect(result.details[0]!.accountId).toBe("acc-A");
+      expect(result.details[0]!.reason).toBe("Token expired for A");
     });
   });
 });

--- a/apps/api/src/__tests__/granola-auth.test.ts
+++ b/apps/api/src/__tests__/granola-auth.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { prisma } from "../lib/prisma.js";
 import { createRelinkTask } from "../lib/connection-health.js";
 import { createTestUser, authRequest } from "./helpers.js";
@@ -284,6 +287,30 @@ describe("Granola Auth routes", () => {
         where: { id: account.id },
       });
       expect(unchanged?.autoCreateMyTasks).toBe(true);
+    });
+  });
+
+  describe("OAuth callback re-link scoping (source regression)", () => {
+    // Granola was the FIRST place we hit the multi-account re-link bug —
+    // the provider-wide resolveRelinkTask silently cleared every Granola
+    // re-link task when ANY account reconnected. The fix is to call the
+    // per-account resolver everywhere this route file resolves tasks.
+    // This source-level test catches a regression at the call site directly
+    // (the full OAuth callback chain is too heavy to mock end-to-end).
+    it("granola-auth.ts uses the per-account resolver, never the provider-wide one", () => {
+      const here = dirname(fileURLToPath(import.meta.url));
+      const source = readFileSync(
+        resolve(here, "../routes/granola-auth.ts"),
+        "utf8",
+      );
+      const callSites = source
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("//"))
+        .filter((line) => !line.includes("import"))
+        .join("\n");
+      // `\b` ensures we don't match `resolveRelinkTaskForAccount`.
+      expect(callSites).not.toMatch(/\bresolveRelinkTask\s*\(/);
+      expect(callSites).toMatch(/resolveRelinkTaskForAccount\s*\(/);
     });
   });
 });

--- a/apps/api/src/lib/connection-health.ts
+++ b/apps/api/src/lib/connection-health.ts
@@ -22,7 +22,20 @@
 
 import { prisma } from "./prisma.js";
 
-type ConnectionType = "google-calendar" | "granola" | "ai";
+export type ConnectionType = "google-calendar" | "granola" | "ai";
+
+export interface BrokenConnectionDetail {
+  type: ConnectionType;
+  accountId: string | null;
+  reason: string | null;
+  brokenSince: string;
+}
+
+export interface BrokenConnectionsResponse {
+  count: number;
+  types: string[];
+  details: BrokenConnectionDetail[];
+}
 
 const TITLES: Record<ConnectionType, string> = {
   "google-calendar": "Re-link Google Calendar",
@@ -105,6 +118,47 @@ export async function resolveRelinkTask(
       completedAt: new Date(),
     },
   });
+}
+
+/**
+ * Aggregate every active/snoozed re-link task for a user into a structured
+ * response. Each entry carries the connection type, the specific accountId
+ * that broke, the human-readable reason (from Item.notes — written by
+ * createRelinkTask), and when the prompt was first created.
+ *
+ * Returns `count` + `types` for backwards compatibility with older clients
+ * that only consume the totals, plus the new `details` array for per-account
+ * UI chrome.
+ */
+export async function getBrokenConnections(
+  userId: string,
+): Promise<BrokenConnectionsResponse> {
+  const items = await prisma.item.findMany({
+    where: {
+      userId,
+      source: "system",
+      sourceId: { startsWith: "relink:" },
+      status: { in: ["active", "snoozed"] },
+    },
+    select: { sourceId: true, notes: true, createdAt: true },
+  });
+
+  const details: BrokenConnectionDetail[] = items.map((item: { sourceId: string | null; notes: string | null; createdAt: Date }) => {
+    // sourceId format: "relink:<type>:<accountId>" (accountId may be absent
+    // for legacy single-account integrations — split handles both cases).
+    const parts = (item.sourceId ?? "").split(":");
+    const type = (parts[1] ?? "") as ConnectionType;
+    const accountId = parts[2] ?? null;
+    return {
+      type,
+      accountId,
+      reason: item.notes ?? null,
+      brokenSince: item.createdAt.toISOString(),
+    };
+  });
+
+  const types = [...new Set(details.map((d) => d.type))];
+  return { count: details.length, types, details };
 }
 
 /**

--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/google-calendar.js";
 import { encryptToken } from "../lib/encryption.js";
 import { initialSync, incrementalSync } from "../services/calendar-sync.js";
-import { resolveRelinkTask } from "../lib/connection-health.js";
+import { resolveRelinkTaskForAccount } from "../lib/connection-health.js";
 import { generateId } from "@brett/utils";
 import { google } from "googleapis";
 import { signOAuthState, verifyOAuthState } from "../lib/oauth-state.js";
@@ -192,8 +192,11 @@ calendarAccounts.get("/callback", async (c) => {
     },
   });
 
-  // Resolve any existing re-link task for this connection
-  await resolveRelinkTask(user.id, "google-calendar").catch((e) =>
+  // Resolve any existing re-link task for THIS account only. Using the
+  // provider-wide resolver here would silently dismiss another Google
+  // Calendar account's re-link prompt — see the granola-auth fix for the
+  // same bug pattern.
+  await resolveRelinkTaskForAccount(user.id, "google-calendar", account.id).catch((e) =>
     console.error("[calendar-accounts] Failed to resolve re-link task:", e),
   );
 
@@ -297,8 +300,10 @@ calendarAccounts.delete("/:id", authMiddleware, async (c) => {
   // Cascade delete (GoogleAccount -> CalendarList -> CalendarEvent, etc.)
   await prisma.googleAccount.delete({ where: { id: account.id } });
 
-  // Resolve any existing re-link task — user is in a valid state now (account removed)
-  await resolveRelinkTask(user.id, "google-calendar").catch((e) =>
+  // Resolve any existing re-link task for THIS account only. The user may
+  // have other Google Calendar accounts whose re-link prompts must stay
+  // visible — see calendar callback for the same scoping rationale.
+  await resolveRelinkTaskForAccount(user.id, "google-calendar", account.id).catch((e) =>
     console.error("[calendar-accounts] Failed to resolve re-link task:", e),
   );
 

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -279,6 +279,9 @@ things.get("/", async (c) => {
 // GET /things/broken-connections — active re-link tasks with per-account details.
 // Returns { count, types, details } — `count`/`types` preserved for older clients;
 // `details` is additive for per-account warning chrome in Settings.
+//
+// Auth: enforced router-wide via `things.use("*", authMiddleware)` above —
+// no per-handler middleware required.
 things.get("/broken-connections", async (c) => {
   const user = c.get("user");
   const result = await getBrokenConnections(user.id);

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -10,6 +10,7 @@ import type { ItemAssemblerInput, ContentAssemblerInput } from "@brett/ai";
 import type { ThingDetail, Attachment as AttachmentType, ItemLink as ItemLinkType, BrettMessage as BrettMessageType } from "@brett/types";
 import { getEmbeddingProvider } from "../lib/embedding-provider.js";
 import { paginatedPull, type PaginatedPullResult } from "../lib/sync/paginated-pull.js";
+import { getBrokenConnections } from "../lib/connection-health.js";
 
 const things = new Hono<AuthEnv>();
 
@@ -275,20 +276,13 @@ things.get("/", async (c) => {
   return c.json(thingsList);
 });
 
-// GET /things/broken-connections — count of active re-link tasks by type
+// GET /things/broken-connections — active re-link tasks with per-account details.
+// Returns { count, types, details } — `count`/`types` preserved for older clients;
+// `details` is additive for per-account warning chrome in Settings.
 things.get("/broken-connections", async (c) => {
   const user = c.get("user");
-  const items = await prisma.item.findMany({
-    where: {
-      userId: user.id,
-      source: "system",
-      sourceId: { startsWith: "relink:" },
-      status: { in: ["active", "snoozed"] },
-    },
-    select: { sourceId: true },
-  });
-  const types = [...new Set(items.map((i) => i.sourceId!.split(":")[1]))];
-  return c.json({ count: items.length, types });
+  const result = await getBrokenConnections(user.id);
+  return c.json(result);
 });
 
 // PATCH /things/bulk — bulk update

--- a/apps/desktop/src/api/connection-health.ts
+++ b/apps/desktop/src/api/connection-health.ts
@@ -2,9 +2,31 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { apiFetch } from "./client";
 
+export interface BrokenConnectionDetail {
+  type: "granola" | "google-calendar" | "ai";
+  accountId: string | null;
+  reason: string | null;
+  brokenSince: string;
+}
+
 interface BrokenConnections {
   count: number;
   types: string[];
+  details: BrokenConnectionDetail[];
+}
+
+/**
+ * Find the broken-connection detail (if any) for a specific account so the
+ * Settings card for that account can render inline warning chrome. Returns
+ * null when the account is healthy or `data` is still loading.
+ */
+export function findBrokenDetailForAccount(
+  data: BrokenConnections | undefined,
+  type: "granola" | "google-calendar",
+  accountId: string,
+): BrokenConnectionDetail | null {
+  if (!data?.details) return null;
+  return data.details.find((d) => d.type === type && d.accountId === accountId) ?? null;
 }
 
 /**

--- a/apps/desktop/src/settings/CalendarSection.tsx
+++ b/apps/desktop/src/settings/CalendarSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Calendar, Plus, Trash2, RefreshCw } from "lucide-react";
+import { Calendar, Plus, Trash2, RefreshCw, AlertCircle } from "lucide-react";
 import { SettingsCard, SettingsHeader, SettingsToggle } from "./SettingsComponents";
 import { CalendarConnectModal } from "../components/CalendarConnectModal";
 import {
@@ -12,6 +12,7 @@ import {
 } from "../api/calendar-accounts";
 import { useFetchCalendarRange } from "../api/calendar";
 import { useGranolaAccounts, useConnectGranola, useDisconnectGranola, useUpdateGranolaPreferences } from "../api/granola";
+import { useBrokenConnections, findBrokenDetailForAccount, type BrokenConnectionDetail } from "../api/connection-health";
 import type { ConnectedCalendarAccount, GranolaAccountRecord } from "@brett/types";
 import { useAssistantName } from "../api/assistant-name";
 
@@ -40,11 +41,32 @@ function GoogleIcon() {
   );
 }
 
-interface ConnectedAccountRowProps {
-  account: ConnectedCalendarAccount;
+/**
+ * Inline warning chrome for a Settings account card that has an active re-link
+ * task. Shows a single amber header row with the reason text from the API. The
+ * caller is responsible for tinting its own border/background — this just owns
+ * the warning content.
+ */
+function AccountWarningRow({ broken }: { broken: BrokenConnectionDetail }) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 border-b border-amber-400/20 bg-amber-500/10">
+      <AlertCircle size={14} className="text-amber-300 mt-0.5 shrink-0" />
+      <div className="min-w-0">
+        <div className="text-xs font-medium text-amber-200">Needs reconnection</div>
+        {broken.reason && (
+          <div className="text-[11px] text-amber-200/70 mt-0.5 truncate">{broken.reason}</div>
+        )}
+      </div>
+    </div>
+  );
 }
 
-function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
+interface ConnectedAccountRowProps {
+  account: ConnectedCalendarAccount;
+  broken: BrokenConnectionDetail | null;
+}
+
+function ConnectedAccountRow({ account, broken }: ConnectedAccountRowProps) {
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const disconnectCalendar = useDisconnectCalendar();
   const toggleVisibility = useToggleCalendarVisibility();
@@ -58,7 +80,14 @@ function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
   }
 
   return (
-    <div className="bg-white/5 rounded-lg overflow-hidden">
+    <div
+      className={
+        broken
+          ? "bg-amber-500/5 rounded-lg overflow-hidden border border-amber-400/30"
+          : "bg-white/5 rounded-lg overflow-hidden"
+      }
+    >
+      {broken && <AccountWarningRow broken={broken} />}
       {/* Account header */}
       <div className="flex items-center justify-between px-3 py-2.5 border-b border-white/10">
         <div className="flex items-center gap-2 min-w-0">
@@ -157,15 +186,23 @@ function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
 interface GranolaAccountRowProps {
   account: GranolaAccountRecord;
   assistantName: string;
+  broken: BrokenConnectionDetail | null;
 }
 
-function GranolaAccountRow({ account, assistantName }: GranolaAccountRowProps) {
+function GranolaAccountRow({ account, assistantName, broken }: GranolaAccountRowProps) {
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const disconnect = useDisconnectGranola();
   const updatePrefs = useUpdateGranolaPreferences();
 
   return (
-    <div className="bg-white/5 rounded-lg overflow-hidden">
+    <div
+      className={
+        broken
+          ? "bg-amber-500/5 rounded-lg overflow-hidden border border-amber-400/30"
+          : "bg-white/5 rounded-lg overflow-hidden"
+      }
+    >
+      {broken && <AccountWarningRow broken={broken} />}
       <div className="flex items-center justify-between px-3 py-2.5">
         <div className="flex items-center gap-2 min-w-0">
           <span className="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" />
@@ -267,6 +304,7 @@ export function CalendarSection() {
   const fetchRange = useFetchCalendarRange();
   const { data: granolaData } = useGranolaAccounts();
   const connectGranola = useConnectGranola();
+  const { data: brokenConnections } = useBrokenConnections();
   const [showConnectModal, setShowConnectModal] = useState(false);
 
   return (
@@ -312,7 +350,11 @@ export function CalendarSection() {
         {!isLoading && !error && accounts.length > 0 && (
           <div className="space-y-3">
             {accounts.map((account) => (
-              <ConnectedAccountRow key={account.id} account={account} />
+              <ConnectedAccountRow
+                key={account.id}
+                account={account}
+                broken={findBrokenDetailForAccount(brokenConnections, "google-calendar", account.id)}
+              />
             ))}
           </div>
         )}
@@ -364,6 +406,7 @@ export function CalendarSection() {
                 key={account.id}
                 account={account}
                 assistantName={assistantName}
+                broken={findBrokenDetailForAccount(brokenConnections, "granola", account.id)}
               />
             ))}
           </div>

--- a/apps/ios/Brett/Networking/Endpoints/ThingsEndpoints.swift
+++ b/apps/ios/Brett/Networking/Endpoints/ThingsEndpoints.swift
@@ -77,4 +77,31 @@ extension APIClient {
             method: "DELETE"
         )
     }
+
+    // MARK: - Broken connections
+
+    /// One entry per active re-link task. `accountId` is null for legacy
+    /// single-account integrations (today only "ai"); Granola + Google
+    /// Calendar entries always carry the specific accountId that broke so
+    /// Settings can tint the matching card.
+    struct BrokenConnectionDetail: Decodable, Hashable, Sendable {
+        let type: String
+        let accountId: String?
+        let reason: String?
+        let brokenSince: String
+    }
+
+    struct BrokenConnectionsResponse: Decodable {
+        let count: Int
+        let types: [String]
+        let details: [BrokenConnectionDetail]
+    }
+
+    func fetchBrokenConnections() async throws -> BrokenConnectionsResponse {
+        try await request(
+            BrokenConnectionsResponse.self,
+            path: "/things/broken-connections",
+            method: "GET"
+        )
+    }
 }

--- a/apps/ios/Brett/Stores/BrokenConnectionsStore.swift
+++ b/apps/ios/Brett/Stores/BrokenConnectionsStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Observation
+
+/// Observable façade over `GET /things/broken-connections`.
+///
+/// The server returns one entry per active re-link task, including the
+/// connection type, the specific `accountId` that broke (when applicable),
+/// a human-readable reason, and the timestamp the prompt was first raised.
+/// Settings views consume this to render inline warning chrome on the
+/// account card that actually needs attention — so a user with two Granola
+/// accounts (one healthy, one revoked) sees the warning only on the broken
+/// card.
+///
+/// Not part of sync-pull: re-link tasks live on the server side and the
+/// list is short-lived (one entry per broken account). Re-fetched on view
+/// appear; if a future SSE event signals reconnection we can refresh more
+/// aggressively.
+@MainActor
+@Observable
+final class BrokenConnectionsStore: Clearable {
+    private(set) var details: [APIClient.BrokenConnectionDetail] = []
+    private(set) var isLoading: Bool = false
+    private(set) var lastError: String?
+
+    private let api: APIClient
+
+    init(api: APIClient = .shared) {
+        self.api = api
+        ClearableStoreRegistry.register(self)
+    }
+
+    // MARK: - Clearable
+
+    func clearForSignOut() {
+        details = []
+        isLoading = false
+        lastError = nil
+    }
+
+    // MARK: - Fetch
+
+    func refresh() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let response = try await api.fetchBrokenConnections()
+            details = response.details
+            lastError = nil
+        } catch {
+            // Soft-fail: an empty list lets the UI render the healthy state.
+            // Surfacing an error banner on Settings for a transient network
+            // blip would be more noise than signal.
+            lastError = "Couldn't check connection health."
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the broken-connection detail for a specific account if its
+    /// re-link prompt is active, otherwise nil. Callers use this to decide
+    /// whether to render warning chrome on a card.
+    func brokenDetail(
+        type: String,
+        accountId: String
+    ) -> APIClient.BrokenConnectionDetail? {
+        details.first(where: { $0.type == type && $0.accountId == accountId })
+    }
+}

--- a/apps/ios/Brett/Views/Settings/CalendarSettingsView.swift
+++ b/apps/ios/Brett/Views/Settings/CalendarSettingsView.swift
@@ -21,20 +21,28 @@ import AuthenticationServices
 ///   renders a page that calls `window.close()`, which the auth session
 ///   also interprets as completion.
 struct CalendarSettingsView: View {
+    /// Shared between the Google + Granola sections so we make a single
+    /// `/things/broken-connections` request when the view appears. Both
+    /// sections render warning chrome from the same source of truth.
+    @State private var brokenConnections = BrokenConnectionsStore()
+
     var body: some View {
         BrettSettingsScroll {
-            GoogleCalendarSection()
-            GranolaIntegrationSection()
+            GoogleCalendarSection(brokenConnections: brokenConnections)
+            GranolaIntegrationSection(brokenConnections: brokenConnections)
         }
         .navigationTitle("Calendar")
         .navigationBarTitleDisplayMode(.large)
         .toolbarBackground(.hidden, for: .navigationBar)
+        .task { await brokenConnections.refresh() }
     }
 }
 
 // MARK: - Google Calendar section
 
 private struct GoogleCalendarSection: View {
+    let brokenConnections: BrokenConnectionsStore
+
     @State private var store = CalendarAccountsStore()
     @State private var isConnecting = false
     @State private var errorMessage: String?
@@ -81,7 +89,15 @@ private struct GoogleCalendarSection: View {
             }
 
             ForEach(store.accounts) { account in
+                let broken = brokenConnections.brokenDetail(
+                    type: "google-calendar",
+                    accountId: account.id
+                )
                 BrettSettingsSection(account.googleEmail) {
+                    if let broken {
+                        AccountWarningRow(detail: broken)
+                        BrettSettingsDivider()
+                    }
                     accountHeaderRow(account)
 
                     BrettSettingsDivider()
@@ -339,6 +355,8 @@ private struct GoogleCalendarSection: View {
 // MARK: - Granola integration section
 
 private struct GranolaIntegrationSection: View {
+    let brokenConnections: BrokenConnectionsStore
+
     @State private var granolaStatus: GranolaAuthStatus?
     @State private var isGranolaLoading = false
     @State private var isConnectingGranola = false
@@ -471,6 +489,15 @@ private struct GranolaIntegrationSection: View {
     @ViewBuilder
     private func granolaAccountRows(_ account: GranolaAccount) -> some View {
         let isDisconnecting = disconnectingAccountId == account.id
+        let broken = brokenConnections.brokenDetail(
+            type: "granola",
+            accountId: account.id
+        )
+
+        if let broken {
+            AccountWarningRow(detail: broken)
+            BrettSettingsDivider()
+        }
 
         // Row 1 — identity + last sync.
         // No per-card Reconnect button: it would open generic OAuth without a
@@ -708,6 +735,43 @@ private struct GranolaIntegrationSection: View {
             granolaStatus = GranolaAuthStatus(connected: true, accounts: previousAccounts)
             granolaErrorMessage = "Couldn't update preference. Please try again."
         }
+    }
+}
+
+// MARK: - Account warning row
+
+/// Inline warning chrome rendered at the top of a Settings account card
+/// when the server has an active re-link task for that specific account.
+///
+/// Matches the row padding (14h / 12v) of every other row inside a
+/// `BrettSettingsCard` so it sits flush with the divider above the
+/// existing identity row. Uses system orange + SF Symbols to stay native
+/// on iOS — desktop uses amber for the same role; both clients carry the
+/// same content (title + reason).
+private struct AccountWarningRow: View {
+    let detail: APIClient.BrokenConnectionDetail
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.system(size: 14, weight: .semibold))
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Needs reconnection")
+                    .font(BrettTypography.taskTitle)
+                    .foregroundStyle(.orange)
+                if let reason = detail.reason, !reason.isEmpty {
+                    Text(reason)
+                        .font(BrettTypography.taskMeta)
+                        .foregroundStyle(.orange.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
     }
 }
 


### PR DESCRIPTION
## Summary
- `/things/broken-connections` now returns per-account details (`type`, `accountId`, `reason`, `brokenSince`) alongside the existing `count` and `types` fields — fully backwards-compatible so older clients keep working.
- Settings cards on desktop + iOS show inline amber warning chrome (header row + reason text + tinted border) on the specific Granola or Google Calendar account that needs reconnection. Other accounts of the same provider stay clean.
- Regression test confirms `resolveRelinkTaskForAccount` clears the exact account that reconnected, leaving other accounts' re-link prompts visible.
- Multi-granola is already shipped on `release` (`4cecd76`) — Item 4 in the design spec was a stale-client issue, no code change needed.

Spec: `docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md` (items 4, 5)
Plan: `docs/superpowers/plans/2026-05-18-brett-tuning-may.md` (Phase C)

### Implementation notes
- Reason text is read from `Item.notes` (where `createRelinkTask` already writes it) — the plan's note about `Item.description` was based on an earlier spec; using `notes` avoids a schema migration and a call-site change while behaving identically.
- iOS gets a new `BrokenConnectionsStore` (Observable, registers with `ClearableStoreRegistry` for sign-out), shared between the Google + Granola sections so we hit the endpoint once per Settings appear.

## Test plan
- [x] `pnpm --filter @brett/api test connection-health` — 10/10 passing (7 existing + 3 new)
- [x] `xcodebuild build -scheme Brett -destination "platform=iOS Simulator,..."` — clean build
- [x] Desktop typecheck — no errors in changed files (pre-existing errors elsewhere from unbuilt packages)
- [ ] Manual: trigger a broken state on one account, verify warning on that card only
- [ ] Manual: reconnect that account, verify warning clears
- [ ] iOS: same end-to-end on simulator

Please check Settings → Updates → Current version. Should be `0.1.1537` or higher (`4cecd76` shipped 2026-05-16). If lower, autoupdate to latest before retrying multi-Granola.