### PR TITLE
feat: today view tuning — narrow badge + collapsible sections

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { useTodayKey } from "./hooks/useTodayKey";
 import { usePinnedDate } from "./hooks/usePinnedDate";
 import { getEndOfWeekUTC, isHiddenDeclined } from "@brett/business";
 import type { BackgroundStyle } from "@brett/business";
+import { computeBadgeCount } from "./lib/badgeCount";
 import {
   DndContext,
   DragOverlay,
@@ -503,29 +504,22 @@ export function App() {
 
   // Push the Today count to the macOS dock via the main process.
   //
-  // Inclusion rules:
-  //   - Always: overdue + today + this_week (the upcoming workweek)
-  //   - On Sat/Sun only: + this_weekend (the current weekend has arrived)
+  // Inclusion rules (kept narrow on purpose; see lib/badgeCount.ts for history):
+  //   - overdue + due today only
+  //   - Tonight items count as today (dueDate = today end)
   //
-  // Weekend items are intentionally excluded from the badge during the
-  // workweek — the user shouldn't see a Saturday item pestering them on
-  // Tuesday. Once Saturday rolls around, those items roll into the badge.
+  // The week-long fetch above stays — the rest of the Today view still needs
+  // this_week + this_weekend items. The badge just filters them down here.
   //
   // Gates on `todayQuerySuccess` so the dock doesn't flash 0 during the
   // hydration window. Clears to 0 when signed out. No-op in browsers /
-  // Windows. iOS parity lives in apps/ios/Brett/Services/BadgeManager.
+  // Windows. iOS parity lives in apps/ios/Brett/Views/Today/TodaySections.swift
+  // (`badgeCount` static method) — keep them in lockstep.
   const badgeUserId = user?.id ?? null;
-  const isWeekendNow = useMemo(() => {
-    const dow = new Date(todayKey).getUTCDay();
-    return dow === 0 || dow === 6;
-  }, [todayKey]);
   const badgeCount = useMemo(() => {
     if (!badgeUserId) return 0;
-    return activeThingsForCount.filter((t: { urgency?: string }) => {
-      if (t.urgency === "this_weekend") return isWeekendNow;
-      return true;
-    }).length;
-  }, [badgeUserId, activeThingsForCount, isWeekendNow]);
+    return computeBadgeCount(activeThingsForCount);
+  }, [badgeUserId, activeThingsForCount]);
   useEffect(() => {
     const api = (window as { electronAPI?: { setBadgeCount?: (n: number) => Promise<void> } }).electronAPI;
     if (!api?.setBadgeCount) return;

--- a/apps/desktop/src/__tests__/badgeCount.test.ts
+++ b/apps/desktop/src/__tests__/badgeCount.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { computeBadgeCount } from "../lib/badgeCount";
+
+// These tests encode the invariant that the Today badge counts ONLY overdue +
+// today (Tonight items live in the today bucket via dueDate). If you change
+// these expectations, also update apps/ios/BrettTests/TodaySectionsTests.swift
+// and the spec at docs/superpowers/specs/2026-04-24-today-count-badge-design.md.
+
+const today = new Date("2026-05-18T12:00:00Z");
+
+describe("computeBadgeCount", () => {
+  it("counts overdue items", () => {
+    const items = [
+      { dueDate: "2026-05-17T12:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("counts today items", () => {
+    const items = [
+      { dueDate: "2026-05-18T18:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("counts tonight items as today (they live in the today bucket)", () => {
+    // Tonight items have dueDate = end of today, so the same predicate
+    // catches them. No special handling needed.
+    const items = [
+      { dueDate: "2026-05-18T23:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("excludes this_week items", () => {
+    const items = [
+      { dueDate: "2026-05-20T12:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+
+  it("excludes this_weekend items even on a weekend", () => {
+    // Critical regression guard: before 2026-05-18, the badge included
+    // weekend items on Sat/Sun. The new spec drops that — weekend items
+    // never count unless they're already overdue.
+    const saturday = new Date("2026-05-23T12:00:00Z");
+    const weekendItems = [
+      { dueDate: "2026-05-24T12:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(weekendItems, saturday)).toBe(0);
+  });
+
+  it("excludes completed items", () => {
+    const items = [
+      { dueDate: "2026-05-18T18:00:00Z", isCompleted: true },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+
+  it("excludes items with no dueDate", () => {
+    const items = [{ dueDate: null, isCompleted: false }];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+});

--- a/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
+++ b/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
@@ -37,12 +37,33 @@ describe("useLocalStorageBoolean", () => {
   it("scopes state per user — two accounts on the same device don't share", () => {
     // Multi-user invariant from CLAUDE.md: UI state must not leak across
     // accounts on the same device.
-    setStorageUser("alice");
+    act(() => setStorageUser("alice"));
     const { result: aliceHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
     act(() => aliceHook.current[1](true));
 
-    setStorageUser("bob");
+    act(() => setStorageUser("bob"));
     const { result: bobHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
     expect(bobHook.current[0]).toBe(false); // bob should see fallback, not alice's true
+  });
+
+  it("re-reads from storage when scoped user changes mid-mount", () => {
+    // Regression guard: if user A collapses a section and then signs out
+    // and user B signs in WITHOUT this hook's host component unmounting,
+    // B must see B's preference (fallback), not A's stored value. The hook
+    // subscribes to `setStorageUser` for exactly this reason — relying
+    // only on `key`-change re-sync would leak A's state into B's session.
+    setStorageUser("alice");
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+
+    // Same hook instance — pretend the user just switched.
+    act(() => setStorageUser("bob"));
+    expect(result.current[0]).toBe(false); // bob's fallback, not alice's true
+
+    // And if carol had a pre-existing stored value, the hook should pick it up.
+    localStorage.setItem("test.key.user=carol", "true");
+    act(() => setStorageUser("carol"));
+    expect(result.current[0]).toBe(true);
   });
 });

--- a/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
+++ b/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
+import { setStorageUser } from "../lib/userScopedStorage";
+
+beforeEach(() => {
+  localStorage.clear();
+  // Default to a known user so the scoped key is stable across tests.
+  setStorageUser("test-user");
+});
+
+describe("useLocalStorageBoolean", () => {
+  it("returns default value when no key in storage", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("returns the explicit default when fallback=true", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", true));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("persists toggled value to localStorage", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+    // userScopedStorage appends `.user=<id>` — verify the actual key.
+    expect(localStorage.getItem("test.key.user=test-user")).toBe("true");
+  });
+
+  it("reads existing value on mount", () => {
+    localStorage.setItem("test.key.user=test-user", "true");
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("scopes state per user — two accounts on the same device don't share", () => {
+    // Multi-user invariant from CLAUDE.md: UI state must not leak across
+    // accounts on the same device.
+    setStorageUser("alice");
+    const { result: aliceHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => aliceHook.current[1](true));
+
+    setStorageUser("bob");
+    const { result: bobHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(bobHook.current[0]).toBe(false); // bob should see fallback, not alice's true
+  });
+});

--- a/apps/desktop/src/lib/badgeCount.ts
+++ b/apps/desktop/src/lib/badgeCount.ts
@@ -1,0 +1,40 @@
+// Today badge count — kept narrow on purpose: overdue + today only.
+//
+// History: before 2026-05-18 the badge also included "this_week" items (and,
+// on weekends, "this_weekend" items). That made the badge noisy during the
+// workweek and conflated "things to do today" with "things due eventually
+// this week". Spec: docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md.
+//
+// Tonight items are counted as today — they have `dueDate = today end`, so the
+// same `dueDate <= endOfToday` predicate captures them. The `tonight` flag
+// only affects sectioning, not counting.
+//
+// iOS parity lives in apps/ios/Brett/Views/Today/TodaySections.swift's
+// `badgeCount` static method — they must move in lockstep.
+
+type BadgeInputThing = {
+  dueDate?: string | Date | null;
+  isCompleted?: boolean;
+};
+
+export function computeBadgeCount(
+  things: BadgeInputThing[],
+  now: Date = new Date(),
+): number {
+  const endOfToday = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      23,
+      59,
+      59,
+      999,
+    ),
+  );
+  return things.filter((t) => {
+    if (t.isCompleted) return false;
+    if (!t.dueDate) return false;
+    return new Date(t.dueDate) <= endOfToday;
+  }).length;
+}

--- a/apps/desktop/src/lib/useLocalStorageBoolean.ts
+++ b/apps/desktop/src/lib/useLocalStorageBoolean.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import { userStorage } from "./userScopedStorage";
+
+/**
+ * Per-user persisted boolean state for UI affordances (collapsed sections,
+ * dismissed banners, etc.).
+ *
+ * Uses `userStorage` (apps/desktop/src/lib/userScopedStorage.ts) under the
+ * hood, so two accounts on the same machine don't share collapsed-state.
+ *
+ * `key` is the base key — `userStorage` appends `.user=<id>` automatically.
+ * Pick names like `today.section.this-week.open` (feature.subkey.what).
+ */
+function read(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = userStorage.getItem(key);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useLocalStorageBoolean(
+  key: string,
+  fallback: boolean,
+): [boolean, (next: boolean) => void] {
+  const [value, setValue] = useState<boolean>(() => read(key, fallback));
+
+  // Re-sync if the key changes (rare — defensive). Intentionally NOT
+  // depending on `fallback`: changing the default after first render should
+  // not clobber a user's explicit choice.
+  useEffect(() => {
+    setValue(read(key, fallback));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const update = useCallback(
+    (next: boolean) => {
+      setValue(next);
+      try {
+        userStorage.setItem(key, next ? "true" : "false");
+      } catch {
+        // localStorage unavailable — in-memory state still works.
+      }
+    },
+    [key],
+  );
+
+  return [value, update];
+}

--- a/apps/desktop/src/lib/useLocalStorageBoolean.ts
+++ b/apps/desktop/src/lib/useLocalStorageBoolean.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { userStorage } from "./userScopedStorage";
+import { subscribeToStorageUser, userStorage } from "./userScopedStorage";
 
 /**
  * Per-user persisted boolean state for UI affordances (collapsed sections,
@@ -10,6 +10,12 @@ import { userStorage } from "./userScopedStorage";
  *
  * `key` is the base key — `userStorage` appends `.user=<id>` automatically.
  * Pick names like `today.section.this-week.open` (feature.subkey.what).
+ *
+ * Re-syncs on `setStorageUser` so a sign-out + sign-in flip (without remount
+ * of the consuming component) shows the new user's value, not the previous
+ * user's. Without that subscription, App.tsx is the only place that re-reads
+ * after a user switch (see SIDEBAR_DISMISSED_KEY pattern) and every other
+ * caller silently leaks A's UI state to B.
  */
 function read(key: string, fallback: boolean): boolean {
   if (typeof window === "undefined") return fallback;
@@ -29,11 +35,15 @@ export function useLocalStorageBoolean(
 ): [boolean, (next: boolean) => void] {
   const [value, setValue] = useState<boolean>(() => read(key, fallback));
 
-  // Re-sync if the key changes (rare — defensive). Intentionally NOT
-  // depending on `fallback`: changing the default after first render should
-  // not clobber a user's explicit choice.
+  // Re-sync if the key changes (rare — defensive) OR if the scoped user
+  // changes. Intentionally NOT depending on `fallback`: changing the default
+  // after first render should not clobber a user's explicit choice.
   useEffect(() => {
     setValue(read(key, fallback));
+    const unsubscribe = subscribeToStorageUser(() => {
+      setValue(read(key, fallback));
+    });
+    return unsubscribe;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 

--- a/apps/desktop/src/lib/userScopedStorage.ts
+++ b/apps/desktop/src/lib/userScopedStorage.ts
@@ -9,9 +9,38 @@
  */
 
 let currentUserId: string | null = null;
+const subscribers = new Set<(userId: string | null) => void>();
 
 export function setStorageUser(userId: string | null): void {
+  if (currentUserId === userId) return;
   currentUserId = userId;
+  // Fire-and-forget notify — subscribers are React hooks re-syncing local
+  // state, so they must be cheap. Snapshot before iterating in case a
+  // subscriber unsubscribes synchronously.
+  for (const fn of Array.from(subscribers)) {
+    fn(userId);
+  }
+}
+
+export function getStorageUser(): string | null {
+  return currentUserId;
+}
+
+/**
+ * Subscribe to user-switch events. Returns an unsubscribe function.
+ *
+ * Used by `useLocalStorageBoolean` (and any future user-scoped hook) to
+ * re-read storage after `setStorageUser` flips. Without this, a hook that
+ * mounted under user A and stayed mounted across a sign-out + sign-in
+ * to user B would keep showing A's value.
+ */
+export function subscribeToStorageUser(
+  fn: (userId: string | null) => void,
+): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
 }
 
 function scopedKey(base: string): string {

--- a/apps/desktop/src/views/TodayView.tsx
+++ b/apps/desktop/src/views/TodayView.tsx
@@ -24,6 +24,12 @@ import { useBriefing, useBriefingSummary } from "../api/briefing";
 import { usePreference } from "../api/preferences";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
 import { useTodayKey } from "../hooks/useTodayKey";
+import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
+
+/** Section keys that render as collapsibles (default collapsed) on Today.
+ *  Overdue + Today stay always-expanded — they're the badge bucket and the
+ *  reason the user opened the view. */
+const COLLAPSIBLE_SECTION_KEYS = new Set(["this-week", "this-weekend", "done-today"]);
 
 interface TodayViewProps {
   lists: NavList[];
@@ -165,19 +171,48 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
     return list;
   }, [grouped]);
 
+  // Per-section collapsed state. Persisted per-user via localStorage so
+  // toggling a section, navigating away, and coming back retains the choice.
+  // Default `false` (collapsed) per the 2026-05-18 tuning spec.
+  const [thisWeekOpen, setThisWeekOpen] = useLocalStorageBoolean("today.section.this-week.open", false);
+  const [thisWeekendOpen, setThisWeekendOpen] = useLocalStorageBoolean("today.section.this-weekend.open", false);
+  const [doneTodayOpen, setDoneTodayOpen] = useLocalStorageBoolean("today.section.done-today.open", false);
+
+  const collapsibleSections = useMemo(() => ({
+    "this-week": { open: thisWeekOpen, onOpenChange: setThisWeekOpen },
+    "this-weekend": { open: thisWeekendOpen, onOpenChange: setThisWeekendOpen },
+    "done-today": { open: doneTodayOpen, onOpenChange: setDoneTodayOpen },
+  }), [thisWeekOpen, setThisWeekOpen, thisWeekendOpen, setThisWeekendOpen, doneTodayOpen, setDoneTodayOpen]);
+
+  // For the chrome active-section header above the inner scroll: a collapsed
+  // section has no items to scroll past, so it must never become the active
+  // section. Track-only the visible (open or always-on) sections.
+  const trackableSectionKeys = useMemo(() => {
+    return new Set(
+      sections
+        .filter((s) =>
+          !COLLAPSIBLE_SECTION_KEYS.has(s.key) ||
+          collapsibleSections[s.key as keyof typeof collapsibleSections]?.open === true
+        )
+        .map((s) => s.key)
+    );
+  }, [sections, collapsibleSections]);
+
   const [activeSectionKey, setActiveSectionKey] = useState<string | null>(null);
   const sectionsScrollRef = useRef<HTMLDivElement>(null);
   const outerScrollRef = useRef<HTMLDivElement>(null);
   const thingsCardRef = useRef<HTMLDivElement>(null);
 
   // Re-sync active section when the section list changes (filter pill,
-  // toggling done, etc.) so we don't stick on a key that no longer exists.
+  // toggling done, collapsing a section, etc.) so we don't stick on a key
+  // that no longer exists OR has been collapsed.
   useEffect(() => {
     setActiveSectionKey((prev) => {
-      if (prev && sections.some((s) => s.key === prev)) return prev;
-      return sections[0]?.key ?? null;
+      if (prev && trackableSectionKeys.has(prev)) return prev;
+      const firstVisible = sections.find((s) => trackableSectionKeys.has(s.key));
+      return firstVisible?.key ?? null;
     });
-  }, [sections]);
+  }, [sections, trackableSectionKeys]);
 
   // Scroll tracker — picks the LAST section whose top is at or above the
   // inner-scroll's viewport top. That's the section the user is currently
@@ -192,7 +227,11 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
   //  3. An IntersectionObserver on each section, which fires whenever a
   //     section's intersection with the inner-scroll viewport changes —
   //     catches anything the scroll events might miss.
-  const sectionKeysHash = sections.map((s) => s.key).join(",");
+  // Hash also includes trackable keys so collapse/expand re-runs the
+  // recalc effect (the scroll listeners need fresh `trackableSectionKeys`
+  // in their closure).
+  const sectionKeysHash = sections.map((s) => s.key).join(",") +
+    "|" + Array.from(trackableSectionKeys).sort().join(",");
   useEffect(() => {
     const el = sectionsScrollRef.current;
     if (!el || sections.length === 0) return;
@@ -204,11 +243,16 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
         const sectionEls = el.querySelectorAll<HTMLElement>("[data-section-key]");
         if (sectionEls.length === 0) return;
         const scrollTop = el.getBoundingClientRect().top;
-        let activeKey: string | null = sections[0]?.key ?? null;
+        // Default to the first TRACKABLE section — never let a collapsed
+        // section become the chrome active section (no items to scroll past).
+        const firstTrackable = sections.find((s) => trackableSectionKeys.has(s.key));
+        let activeKey: string | null = firstTrackable?.key ?? null;
         for (const sectionEl of sectionEls) {
+          const key = sectionEl.dataset.sectionKey;
+          if (!key || !trackableSectionKeys.has(key)) continue;
           const t = sectionEl.getBoundingClientRect().top;
           if (t <= scrollTop + 1) {
-            activeKey = sectionEl.dataset.sectionKey ?? activeKey;
+            activeKey = key;
           } else {
             break;
           }
@@ -327,10 +371,11 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
       reconnectPendingSourceId={reconnectPendingSourceId}
       onInstallUpdate={installUpdate}
       hiddenHeaderKey={activeSectionKey}
+      collapsibleSections={collapsibleSections}
       header={<ThingsEmptyState activeFilter={activeFilter} hasThingsElsewhere allCompleted inline lists={lists} onAddTask={handleAddTask} onAddContent={handleAddContent} />}
     />
   ) : (
-    <ThingsList things={filteredThings} lists={lists} onItemClick={onItemClick} onToggle={handleToggle} onAdd={handleAddTask} onAddContent={handleQuickAddContent} onTriageOpen={onTriageOpen} onFocusChange={onFocusChange} activeFilter={activeFilter} bare onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={installUpdate} hiddenHeaderKey={activeSectionKey} />
+    <ThingsList things={filteredThings} lists={lists} onItemClick={onItemClick} onToggle={handleToggle} onAdd={handleAddTask} onAddContent={handleQuickAddContent} onTriageOpen={onTriageOpen} onFocusChange={onFocusChange} activeFilter={activeFilter} bare onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={installUpdate} hiddenHeaderKey={activeSectionKey} collapsibleSections={collapsibleSections} />
   );
 
   return (

--- a/apps/ios/Brett/Views/Today/TodaySections.swift
+++ b/apps/ios/Brett/Views/Today/TodaySections.swift
@@ -27,28 +27,24 @@ struct TodaySections {
 
     /// Count shown on the iOS home-screen badge and the macOS dock badge.
     ///
-    /// Inclusion rules (must stay in lockstep with desktop's `App.tsx`
-    /// `badgeCount`):
-    ///   - Always: overdue + today + thisWeek
-    ///   - On Sat/Sun: + thisWeekend (the weekend has arrived)
+    /// Inclusion rules (kept narrow on purpose — must stay in lockstep
+    /// with desktop's `apps/desktop/src/lib/badgeCount.ts`):
+    ///   - overdue + today only
+    ///   - Tonight items count as today (they live in the today bucket
+    ///     via dueDate = today; the `tonight` flag only affects
+    ///     sectioning, not counting)
     ///
-    /// Weekend items deliberately stay out of the badge on weekdays —
-    /// a Saturday task shouldn't nag the user on Tuesday — but roll in
-    /// once the weekend itself arrives.
+    /// History: before 2026-05-18 this also added `thisWeek` (and, on
+    /// Sat/Sun, `thisWeekend`). That made the badge noisy during the
+    /// workweek and conflated "due today" with "due eventually". Spec:
+    /// docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md.
     static func badgeCount(
         items: [Item],
         now: Date = Date(),
         localCalendar: Calendar = .current
     ) -> Int {
         let s = bucket(items: items, reflowKey: 0, now: now, localCalendar: localCalendar)
-        // "Weekend now" is decided from the user's LOCAL day-of-week, not
-        // UTC's. Friday 9:43 PM MT is still Friday for the badge.
-        let weekday = localCalendar.component(.weekday, from: now) // Sun=1..Sat=7
-        let isWeekend = weekday == 1 || weekday == 7
-        return s.overdue.count
-            + s.today.count
-            + s.thisWeek.count
-            + (isWeekend ? s.thisWeekend.count : 0)
+        return s.overdue.count + s.today.count
     }
 
     /// UTC calendar — used for reading calendar-date components of stored

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -5,10 +5,15 @@ import Testing
 /// Tests for `TodaySections.badgeCount(items:now:)` — the number that
 /// drives the iOS home-screen badge.
 ///
-/// Rules under test:
-///   - Always: overdue + today + thisWeek
-///   - On Sat/Sun only: + thisWeekend (weekend items roll in once it IS
-///     the weekend)
+/// Rules under test (2026-05-18 tuning spec — must stay in lockstep with
+/// desktop's `apps/desktop/src/lib/badgeCount.ts`):
+///   - Always: overdue + today only
+///   - Tonight items count as today (they have dueDate = today; the
+///     `tonight` flag only affects sectioning, not counting)
+///
+/// History: before 2026-05-18 the badge also included `thisWeek` (and, on
+/// weekends, `thisWeekend`). The `excludesThisWeek*` / `excludesWeekend*`
+/// tests guard against regressing back to that.
 ///
 /// Anchored on fixed dates (Wednesday + Saturday) to make assertions
 /// time-independent. Calendar is forced to UTC so date arithmetic agrees
@@ -66,21 +71,21 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 1)
     }
 
-    @Test func countsThisWeekOnWeekday() {
-        // Thu/Fri from Wed → thisWeek bucket → counted.
+    @Test func excludesThisWeekOnWeekday() {
+        // Regression guard: before 2026-05-18 the badge included thisWeek
+        // items. The spec narrowed it to overdue + today only.
         let thursday = days(1, from: Self.wednesdayNow)
         let friday = days(2, from: Self.wednesdayNow)
         let items = [
             TestFixtures.makeItem(status: .active, dueDate: thursday),
             TestFixtures.makeItem(status: .active, dueDate: friday),
         ]
-        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 2)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
     @Test func excludesThisWeekendOnWeekday() {
-        // The key new rule: Saturday and Sunday do NOT count toward the
-        // badge while today is a weekday. Sat/Sun from Wed land in
-        // `thisWeekend`, which is excluded until the weekend arrives.
+        // Sat/Sun from Wed land in `thisWeekend`, which is now excluded
+        // from the badge unconditionally.
         let saturday = days(3, from: Self.wednesdayNow)
         let sunday = days(4, from: Self.wednesdayNow)
         let items = [
@@ -90,15 +95,17 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
-    @Test func includesThisWeekendOnSaturday() {
-        // Same Sat/Sun items, now evaluated on Saturday — they should
-        // count toward the badge ("until it IS the weekend").
+    @Test func excludesThisWeekendEvenOnSaturday() {
+        // Critical regression guard: before 2026-05-18, weekend items DID
+        // count once Saturday arrived. The new spec drops that — weekend
+        // items only count once they're overdue or today. Sunday-from-
+        // Saturday lands in `thisWeekend`, not `today`, so it stays out.
         let sunday = days(1, from: Self.saturdayNow)
         let items = [
-            TestFixtures.makeItem(status: .active, dueDate: Self.saturdayNow), // today urgency
-            TestFixtures.makeItem(status: .active, dueDate: sunday),            // thisWeekend
+            TestFixtures.makeItem(status: .active, dueDate: Self.saturdayNow), // today ✓
+            TestFixtures.makeItem(status: .active, dueDate: sunday),            // thisWeekend ✗
         ]
-        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow, localCalendar: calendar) == 2)
+        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow, localCalendar: calendar) == 1)
     }
 
     @Test func excludesNextWeek() {
@@ -151,13 +158,13 @@ struct TodaySectionsBadgeTests {
         let items = [
             TestFixtures.makeItem(status: .active,  dueDate: yesterday),         // overdue ✓
             TestFixtures.makeItem(status: .active,  dueDate: Self.wednesdayNow), // today ✓
-            TestFixtures.makeItem(status: .active,  dueDate: thursday),          // thisWeek ✓
-            TestFixtures.makeItem(status: .active,  dueDate: saturday),          // thisWeekend ✗ (weekday)
+            TestFixtures.makeItem(status: .active,  dueDate: thursday),          // thisWeek ✗
+            TestFixtures.makeItem(status: .active,  dueDate: saturday),          // thisWeekend ✗
             TestFixtures.makeItem(status: .active,  dueDate: nextThursday),      // nextWeek ✗
             TestFixtures.makeItem(status: .done,    dueDate: Self.wednesdayNow), // ✗
             TestFixtures.makeItem(status: .snoozed, dueDate: yesterday),         // ✗
             TestFixtures.makeItem(status: .active,  dueDate: nil),               // ✗
         ]
-        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 3)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 2)
     }
 }

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -150,6 +150,62 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
+    // MARK: - Spec-named regression guards (2026-05-18 brett-tuning plan, Task A2)
+    //
+    // These tests intentionally duplicate behavior already covered above. The
+    // 2026-05-18 plan named three regression guards by exact identifier
+    // (`narrowsToTodayOnly`, `excludesWeekendOnWeekend`, `countsTonight`) so
+    // future reviewers grepping the plan can find them without trawling the
+    // broader suite. Don't fold them back in — the explicit names are the
+    // point.
+
+    @Test func narrowsToTodayOnly() {
+        // The badge counts overdue + today and NOTHING ELSE. Plan §A2 spec:
+        // "overdue + today only". This is the canonical assertion — if you
+        // add a new bucket to TodaySections, this test must keep passing
+        // unchanged.
+        let yesterday = days(-1, from: Self.wednesdayNow)
+        let thursday = days(1, from: Self.wednesdayNow)         // thisWeek
+        let saturday = days(3, from: Self.wednesdayNow)         // thisWeekend
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: yesterday),         // overdue ✓
+            TestFixtures.makeItem(status: .active, dueDate: Self.wednesdayNow), // today ✓
+            TestFixtures.makeItem(status: .active, dueDate: thursday),          // ✗
+            TestFixtures.makeItem(status: .active, dueDate: saturday),          // ✗
+        ]
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 2)
+    }
+
+    @Test func excludesWeekendOnWeekend() {
+        // On Saturday, the upcoming Sunday is in the `thisWeekend` bucket and
+        // MUST NOT count toward the badge. Before 2026-05-18, the badge added
+        // `thisWeekend` on weekends — drop that, or the badge stays noisy
+        // through the weekend.
+        let sunday = days(1, from: Self.saturdayNow) // thisWeekend on Saturday
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: sunday),
+        ]
+        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow, localCalendar: calendar) == 0)
+    }
+
+    @Test func countsTonight() {
+        // Forward-looking stub for Phase B. "Tonight" items are items dated
+        // for today's end (dueDate = today). They live in the `today` bucket
+        // via dueDate; the `tonight` flag only affects sectioning, not
+        // counting. This branch doesn't yet have the `tonight` field on
+        // Item — when Phase B merges, replace the dueDate-only setup with
+        // a real tonight=true item and confirm the count is unchanged.
+        let today = Self.wednesdayNow
+        // Simulate the "tonight" shape we'll get post-Phase B: a today-dated
+        // item with no other distinguishing field. Adds to the badge today.
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: today),
+        ]
+        // TODO(phase-b): once Item.tonight exists, set tonight=true here and
+        // re-confirm the count == 1 (tonight-flag must not change counting).
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 1)
+    }
+
     @Test func sumsBucketsTogetherOnWeekday() {
         let yesterday = days(-1, from: Self.wednesdayNow)
         let thursday = days(1, from: Self.wednesdayNow)

--- a/docs/superpowers/specs/2026-04-24-today-count-badge-design.md
+++ b/docs/superpowers/specs/2026-04-24-today-count-badge-design.md
@@ -16,15 +16,23 @@ outstanding items for the Today view.
 
 ## Count definition
 
-**`overdue + due today + due this week`**, excluding Next Week and completed
-items. Matches the existing in-app sidebar badge on desktop.
+**`overdue + due today`**, excluding This Week, This Weekend, Next Week, and
+completed items. The badge is intentionally narrow — it answers "what needs my
+attention right now," not "what's coming up."
 
-- Desktop: `activeThingsForCount.length` from `apps/desktop/src/App.tsx`
-  (active items whose `dueDate ≤ endOfWeekUTC`) is already exactly this number
-  — reuse it.
-- iOS: a new `TodaySections.badgeCount` computed property returns
-  `overdue.count + today.count + thisWeek.count`. Keeps the bucket math in one
-  place, so desktop and iOS agree on what "Today" means.
+Tonight items are counted as today (they have `dueDate = today`; the `tonight`
+flag only affects sectioning, not counting).
+
+- Desktop: `computeBadgeCount(activeThingsForCount)` from
+  `apps/desktop/src/lib/badgeCount.ts` — filters the week-long fetch down to
+  items whose `dueDate ≤ end of today UTC`, dropping completed.
+- iOS: `TodaySections.badgeCount(items:)` returns
+  `overdue.count + today.count`. Keeps the bucket math in one place, so
+  desktop and iOS agree on what "Today" means.
+
+History: between 2026-04-24 and 2026-05-18 the badge included This Week (and,
+on Sat/Sun, This Weekend). The 2026-05-18 tuning spec narrowed it to overdue
++ today — see `docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md`.
 
 ## Desktop — macOS dock badge
 

--- a/packages/ui/src/CollapsibleSection.tsx
+++ b/packages/ui/src/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 /**
@@ -7,14 +7,27 @@ import { ChevronRight } from "lucide-react";
  * collapsed section sits next to a static one without a chrome jump.
  *
  * Hand-rolled rather than wrapping Radix Collapsible — the behavior here is
- * trivial (toggle a boolean, conditionally render children) and pulling in
+ * trivial (toggle a boolean, animate height + opacity) and pulling in
  * `@radix-ui/react-collapsible` for one component would add ~7KB and a new
- * dep without buying us animation or a11y the spec demands.
+ * dep without buying us anything the spec demands.
  *
  * a11y: the header is a real `<button>` with `aria-expanded`. Screen readers
- * announce "Collapsed/Expanded" on toggle. Children mount/unmount with `open`
- * — collapsed sections also drop from the DOM, which matters for the
- * always-rendered Today view where every extra card is a paint cost.
+ * announce "Collapsed/Expanded" on toggle. The collapsed body is marked
+ * `aria-hidden` and removed from tab order.
+ *
+ * Animation: 220ms height + opacity transition on the `cubic-bezier(0.16, 1,
+ * 0.3, 1)` curve the DESIGN_GUIDE designates for "section enters, toggles,
+ * cross-fades" (matches ConfirmDialog, CrossFade, calendar/feedback modals,
+ * LeftNav stroke transitions). Implemented via `grid-template-rows: 0fr/1fr`
+ * — the modern technique that animates to unknown content height without a
+ * JS `ResizeObserver` or a hardcoded `max-height` ceiling that would clip
+ * tall sections (Done Today can grow to 50+ rows). The inner grid child is
+ * `overflow: hidden` so the row clip looks like a shutter, not a scrollbar.
+ *
+ * Children mount on open and unmount AFTER the close transition completes
+ * (transitionEnd-driven, with a setTimeout fallback in case the event drops).
+ * For the always-rendered Today view this keeps the original perf property:
+ * collapsed sections add zero ThingCard paint cost once the animation ends.
  */
 interface CollapsibleSectionProps {
   title: string;
@@ -27,6 +40,8 @@ interface CollapsibleSectionProps {
   className?: string;
 }
 
+const ANIMATION_MS = 220;
+
 export function CollapsibleSection({
   title,
   count,
@@ -36,6 +51,43 @@ export function CollapsibleSection({
   headerExtras,
   className,
 }: CollapsibleSectionProps) {
+  // `bodyMounted` lags `open` on close: stays true through the close
+  // transition so the children have something to animate FROM, then flips
+  // false once the height collapse finishes — restoring the original
+  // "collapsed sections don't pay paint cost" property of the unanimated
+  // version.
+  const [bodyMounted, setBodyMounted] = useState<boolean>(open);
+  const closeTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      // Cancel any pending unmount + mount immediately so the open
+      // transition starts on the same frame the user clicked.
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+      setBodyMounted(true);
+      return;
+    }
+    // Close: keep mounted until the height transition finishes, then drop.
+    // +30ms cushion absorbs jitter in transitionend timing (browsers
+    // occasionally drop the event under load); setTimeout is the floor.
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+    }
+    closeTimerRef.current = window.setTimeout(() => {
+      setBodyMounted(false);
+      closeTimerRef.current = null;
+    }, ANIMATION_MS + 30);
+    return () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    };
+  }, [open]);
+
   return (
     <div className={className}>
       <button
@@ -49,10 +101,13 @@ export function CollapsibleSection({
       >
         <ChevronRight
           size={10}
-          className={
-            "flex-shrink-0 text-white/40 transition-transform duration-150 " +
-            (open ? "rotate-90" : "rotate-0")
-          }
+          // Chevron rotation rides the same curve + duration as the height
+          // transition below so the gesture reads as one motion, not two.
+          className="flex-shrink-0 text-white/40"
+          style={{
+            transform: open ? "rotate(90deg)" : "rotate(0deg)",
+            transition: `transform ${ANIMATION_MS}ms cubic-bezier(0.16, 1, 0.3, 1)`,
+          }}
         />
         <h3 className="text-[10px] uppercase tracking-[0.15em] font-semibold text-white/40 flex-shrink-0 group-hover:text-white/60 transition-colors">
           {title}
@@ -65,7 +120,24 @@ export function CollapsibleSection({
         )}
         {headerExtras && <span className="flex-shrink-0">{headerExtras}</span>}
       </button>
-      {open && <div>{children}</div>}
+      <div
+        // grid-template-rows: 0fr ↔ 1fr is the modern animatable-to-auto
+        // pattern. The inner wrapper is overflow:hidden so the grid clip
+        // looks like a shutter rather than revealing a scrollbar.
+        style={{
+          display: "grid",
+          gridTemplateRows: open ? "1fr" : "0fr",
+          opacity: open ? 1 : 0,
+          transition:
+            `grid-template-rows ${ANIMATION_MS}ms cubic-bezier(0.16, 1, 0.3, 1), ` +
+            `opacity ${ANIMATION_MS - 40}ms cubic-bezier(0.16, 1, 0.3, 1)`,
+        }}
+        aria-hidden={!open}
+      >
+        <div style={{ overflow: "hidden", minHeight: 0 }}>
+          {bodyMounted ? children : null}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/CollapsibleSection.tsx
+++ b/packages/ui/src/CollapsibleSection.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { ChevronRight } from "lucide-react";
+
+/**
+ * Collapsible Today-view section. Visually matches `SectionHeader` exactly
+ * (same 10px uppercase title, same divider line, same count chip) so a
+ * collapsed section sits next to a static one without a chrome jump.
+ *
+ * Hand-rolled rather than wrapping Radix Collapsible — the behavior here is
+ * trivial (toggle a boolean, conditionally render children) and pulling in
+ * `@radix-ui/react-collapsible` for one component would add ~7KB and a new
+ * dep without buying us animation or a11y the spec demands.
+ *
+ * a11y: the header is a real `<button>` with `aria-expanded`. Screen readers
+ * announce "Collapsed/Expanded" on toggle. Children mount/unmount with `open`
+ * — collapsed sections also drop from the DOM, which matters for the
+ * always-rendered Today view where every extra card is a paint cost.
+ */
+interface CollapsibleSectionProps {
+  title: string;
+  count?: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+  /** Optional element rendered to the far right of the header (e.g. an action). */
+  headerExtras?: React.ReactNode;
+  className?: string;
+}
+
+export function CollapsibleSection({
+  title,
+  count,
+  open,
+  onOpenChange,
+  children,
+  headerExtras,
+  className,
+}: CollapsibleSectionProps) {
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        // Mirror SectionHeader's chrome: 10px uppercase tracked label,
+        // divider line, optional count chip. Add a chevron up front.
+        className="group flex w-full items-center gap-3 mb-2 text-left"
+        data-testid={`collapsible-${title.toLowerCase().replace(/\s+/g, "-")}`}
+      >
+        <ChevronRight
+          size={10}
+          className={
+            "flex-shrink-0 text-white/40 transition-transform duration-150 " +
+            (open ? "rotate-90" : "rotate-0")
+          }
+        />
+        <h3 className="text-[10px] uppercase tracking-[0.15em] font-semibold text-white/40 flex-shrink-0 group-hover:text-white/60 transition-colors">
+          {title}
+        </h3>
+        <div className="h-px bg-white/10 flex-1" />
+        {typeof count === "number" && count > 0 && (
+          <span className="text-[10px] tabular-nums text-white/40 flex-shrink-0">
+            {count}
+          </span>
+        )}
+        {headerExtras && <span className="flex-shrink-0">{headerExtras}</span>}
+      </button>
+      {open && <div>{children}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/ThingsList.tsx
+++ b/packages/ui/src/ThingsList.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from "react";
 import type { Thing, NavList } from "@brett/types";
 import { ThingCard } from "./ThingCard";
 import { SectionHeader } from "./SectionHeader";
+import { CollapsibleSection } from "./CollapsibleSection";
 import { QuickAddInput, type QuickAddInputHandle } from "./QuickAddInput";
 import { useListKeyboardNav } from "./useListKeyboardNav";
 import { useDeferredToggle } from "./useDeferredToggle";
@@ -33,9 +34,16 @@ interface ThingsListProps {
    * `visibility: hidden` so it still occupies layout space but doesn't
    * duplicate the chrome active-section header above the inner scroll. */
   hiddenHeaderKey?: string | null;
+  /** Controlled open-state map for sections that should be collapsible.
+   * Keys are section keys (e.g. "this-week", "this-weekend", "done-today");
+   * absent keys = section is always-expanded (Overdue, Today). When the
+   * parent owns this map (persisting state per-user via
+   * useLocalStorageBoolean), a section with `false` hides its items and
+   * shows a chevron header. */
+  collapsibleSections?: Record<string, { open: boolean; onOpenChange: (open: boolean) => void }>;
 }
 
-export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddContent, onTriageOpen, onFocusChange, header, activeFilter, bare, onReconnect, reconnectPendingSourceId, onInstallUpdate, hiddenHeaderKey }: ThingsListProps) {
+export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddContent, onTriageOpen, onFocusChange, header, activeFilter, bare, onReconnect, reconnectPendingSourceId, onInstallUpdate, hiddenHeaderKey, collapsibleSections }: ThingsListProps) {
   // Shared across ThingsList, InboxView, and UpcomingView — see CLAUDE.md
   // list-consistency rule.
   const handleToggleWithFreeze = useDeferredToggle(onToggle);
@@ -124,27 +132,27 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
           {header && <div>{header}</div>}
 
           {grouped.overdue.length > 0 && (
-            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} />
+            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} collapse={collapsibleSections?.["overdue"]} />
           )}
           {grouped.today.length > 0 && (
-            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} />
+            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} />
           )}
           {isWeekendNow ? (
             <>
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
               )}
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
               )}
             </>
           ) : (
             <>
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
               )}
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
               )}
             </>
           )}
@@ -155,7 +163,7 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
 
           {done.length > 0 && (
             <div>
-              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} />
+              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} collapse={collapsibleSections?.["done-today"]} />
             </div>
           )}
         </div>
@@ -196,6 +204,7 @@ function Section({
   onInstallUpdate,
   cardEls,
   hideHeader,
+  collapse,
 }: {
   /** Stable identifier matched against TodayView's section list to drive the
    * chrome active-section header. The chrome header pins at the top of the
@@ -218,7 +227,53 @@ function Section({
    * duplicate. Layout space is preserved so the chrome→in-flow handoff during
    * scroll doesn't jump. */
   hideHeader?: boolean;
+  /** When provided, renders a CollapsibleSection header. Items render only
+   * when `open` is true. The chrome active-section header in TodayView
+   * already skips collapsed sections because there are no items to scroll
+   * past. */
+  collapse?: { open: boolean; onOpenChange: (open: boolean) => void };
 }) {
+  const items = (
+    <div className="flex flex-col">
+      {things.map((item, i) => (
+        <ThingCard
+          key={item.id}
+          thing={item}
+          onClick={() => onItemClick(item)}
+          onToggle={onToggle}
+          isFocused={focusedIndex === indexOffset + i}
+          onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
+            ? () => onReconnect(item.sourceId!)
+            : undefined}
+          reconnectPending={item.sourceId === reconnectPendingSourceId}
+          onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
+          onElementRef={(el) => {
+            if (el) cardEls.current.set(item.id, el);
+            else cardEls.current.delete(item.id);
+          }}
+        />
+      ))}
+    </div>
+  );
+
+  // Collapsible variant: header is a chevron button, items render only when
+  // open. `hideHeader` doesn't apply — the chrome active-section header in
+  // TodayView never tracks collapsed sections.
+  if (collapse) {
+    return (
+      <div data-section-key={sectionKey}>
+        <CollapsibleSection
+          title={title}
+          count={things.length}
+          open={collapse.open}
+          onOpenChange={collapse.onOpenChange}
+        >
+          {items}
+        </CollapsibleSection>
+      </div>
+    );
+  }
+
   return (
     <div data-section-key={sectionKey}>
       {/* For non-active sections the in-flow header is a visible divider.
@@ -232,26 +287,7 @@ function Section({
       {!hideHeader && (
         <SectionHeader title={title} count={things.length} />
       )}
-      <div className="flex flex-col">
-        {things.map((item, i) => (
-          <ThingCard
-            key={item.id}
-            thing={item}
-            onClick={() => onItemClick(item)}
-            onToggle={onToggle}
-            isFocused={focusedIndex === indexOffset + i}
-            onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
-              ? () => onReconnect(item.sourceId!)
-              : undefined}
-            reconnectPending={item.sourceId === reconnectPendingSourceId}
-            onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
-            onElementRef={(el) => {
-              if (el) cardEls.current.set(item.id, el);
-              else cardEls.current.delete(item.id);
-            }}
-          />
-        ))}
-      </div>
+      {items}
     </div>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,6 +50,7 @@ export { useListKeyboardNav } from "./useListKeyboardNav";
 export { useDeferredToggle } from "./useDeferredToggle";
 export { ItemListShell } from "./ItemListShell";
 export { SectionHeader } from "./SectionHeader";
+export { CollapsibleSection } from "./CollapsibleSection";
 export { useClickOutside } from "./useClickOutside";
 export { TaskDetailPanel } from "./TaskDetailPanel";
 export { OverflowMenu } from "./OverflowMenu";


### PR DESCRIPTION
## Summary

Phase A of the 2026-05-18 Brett tuning plan — Today view tuning items 1 and 2.

- Narrow the Today badge count to **overdue + today only** on both desktop and iOS (drops This Week and weekend logic). Tonight items still count via the today bucket (dueDate = today end). New per-platform helpers (`apps/desktop/src/lib/badgeCount.ts`, updated `TodaySections.badgeCount` on iOS) so the rule lives in one place per client.
- Add **collapsible sections** to the desktop Today view: This Week, This Weekend, Done Today are now default-collapsed accordions. State is persisted per-user via `useLocalStorageBoolean` (uses the existing `userScopedStorage` helper so two accounts on the same Mac don't share collapse state). Overdue + Today stay always-expanded.
- Update the badge spec at `docs/superpowers/specs/2026-04-24-today-count-badge-design.md` to match the narrowed rule.

Spec: `docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md` (items 1, 2).

## What changed

- **New:** `apps/desktop/src/lib/badgeCount.ts` + tests
- **New:** `apps/desktop/src/lib/useLocalStorageBoolean.ts` + tests (per-user scoped)
- **New:** `packages/ui/src/CollapsibleSection.tsx` (hand-rolled, no Radix dep)
- **Modified:** `apps/desktop/src/App.tsx` — uses `computeBadgeCount` helper, drops `isWeekendNow`
- **Modified:** `apps/desktop/src/views/TodayView.tsx` — wires `useLocalStorageBoolean` per collapsible section, threads `collapsibleSections` map to `ThingsList`, skips collapsed sections from chrome active-section tracking
- **Modified:** `packages/ui/src/ThingsList.tsx` — `Section` renders a `CollapsibleSection` when `collapse` prop is supplied; existing behavior preserved when prop is absent
- **Modified:** `apps/ios/Brett/Views/Today/TodaySections.swift` — `badgeCount` returns `overdue.count + today.count` only
- **Modified:** `apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift` — updates expectations + renames tests into regression guards

## Test plan

- [x] `pnpm --filter @brett/desktop typecheck` — clean
- [x] `pnpm --filter @brett/ui typecheck` — clean
- [x] `pnpm --filter @brett/desktop test` — 197/197 pass (includes new `badgeCount` and `useLocalStorageBoolean` suites)
- [x] `pnpm --filter @brett/ui test` — 133/133 pass
- [ ] **iOS:** `xcodebuild test -scheme Brett -only-testing:BrettTests/TodaySectionsBadgeTests` — not runnable in this worktree (pbxproj is gitignored). Run locally on macOS before TestFlight.
- [ ] **Manual desktop:** load Today with mixed sections; verify This Week / This Weekend / Done Today are collapsed by default; click to expand This Week → reload → still expanded; verify the count chip is visible in collapsed state; verify the chrome active-section header never tracks a collapsed section.
- [ ] **Manual badge:** badge count drops by the number of This Week items previously included.

## Deviations from plan

- **Per-user scoping for `useLocalStorageBoolean`:** the plan's Step 1 said to reuse `userScopedStorage`, and Step 4's example used a global `brett:` prefix. Followed Step 1's intent since CLAUDE.md treats multi-user mindset as mandatory. The hook now scopes keys via `userStorage.getItem/setItem`, so two accounts on the same Mac don't share collapsed state.
- **CollapsibleSection is hand-rolled, not Radix-backed:** the plan offered "add `@radix-ui/react-collapsible` or hand-roll if dep absent." The dep wasn't present; the behavior is trivial; hand-rolling saved ~7KB and a dep. Chevron + header chrome mirror `SectionHeader` exactly so collapsible and static sections look identical.
- **Section collapsibility lives in `ThingsList`, not `TodayView`:** TodayView only renders the chrome active-section header above the inner scroll. The actual `<Section>` divs are inside `ThingsList`. Threaded a `collapsibleSections` map prop down rather than reworking the section render to live in TodayView (smaller surgical change, preserves the existing scroll-tracking architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)