### PR TITLE
release: brett tuning may 2026 (badge + collapse + tonight + connection health)

### DIFF
--- a/apps/api/prisma/migrations/20260518221146_add_item_tonight/migration.sql
+++ b/apps/api/prisma/migrations/20260518221146_add_item_tonight/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN "tonight" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -161,6 +161,7 @@ model Item {
   reminder         String?   // "morning_of" | "1_hour_before" | "day_before" | "custom"
   recurrence       String?   // "daily" | "weekly" | "monthly" | "custom"
   recurrenceRule   String?   // iCal RRULE string for custom recurrence
+  tonight          Boolean   @default(false)
   brettTakeGeneratedAt DateTime?
   contentType        String?   // "tweet" | "article" | "video" | "pdf" | "podcast" | "web_page"
   contentStatus      String?   // "pending" | "extracted" | "failed"

--- a/apps/api/src/__tests__/calendar-accounts.test.ts
+++ b/apps/api/src/__tests__/calendar-accounts.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { prisma } from "../lib/prisma.js";
 import { createRelinkTask } from "../lib/connection-health.js";
 import { encryptToken } from "../lib/encryption.js";
@@ -18,6 +21,69 @@ describe("Calendar Accounts routes", () => {
       const user = await createTestUser("Calendar Delete User");
       token = user.token;
       userId = user.userId;
+    });
+
+    it("only resolves the disconnected account's re-link task, not other accounts'", async () => {
+      // Regression guard for the multi-account re-link bug on Google Calendar:
+      // the provider-wide resolveRelinkTask used to dismiss every Google
+      // Calendar re-link task for the user — so disconnecting one account
+      // would silently clear another (broken) account's prompt. We now scope
+      // the resolve by accountId. Same bug pattern as Granola DELETE.
+      const user = await createTestUser("Calendar DELETE scoped relink");
+
+      const brokenAccount = await prisma.googleAccount.create({
+        data: {
+          userId: user.userId,
+          googleEmail: `broken-${Date.now()}@example.com`,
+          googleUserId: `google-broken-${Date.now()}`,
+          accessToken: encryptToken("fake-access-token"),
+          refreshToken: encryptToken("fake-refresh-token"),
+          tokenExpiresAt: new Date(Date.now() + 3600_000),
+        },
+      });
+      const healthyAccount = await prisma.googleAccount.create({
+        data: {
+          userId: user.userId,
+          googleEmail: `healthy-${Date.now()}@example.com`,
+          googleUserId: `google-healthy-${Date.now()}`,
+          accessToken: encryptToken("fake-access-token"),
+          refreshToken: encryptToken("fake-refresh-token"),
+          tokenExpiresAt: new Date(Date.now() + 3600_000),
+        },
+      });
+
+      // Both accounts have re-link tasks (e.g. both failed at some point)
+      await createRelinkTask(user.userId, "google-calendar", brokenAccount.id, "broken");
+      await createRelinkTask(user.userId, "google-calendar", healthyAccount.id, "healthy was once broken");
+
+      const res = await authRequest(
+        `/calendar/accounts/${healthyAccount.id}`,
+        user.token,
+        { method: "DELETE" },
+      );
+      expect(res.status).toBe(200);
+
+      // The broken account's re-link task must still be active.
+      const brokenTaskAfter = await prisma.item.findFirst({
+        where: {
+          userId: user.userId,
+          source: "system",
+          sourceId: `relink:google-calendar:${brokenAccount.id}`,
+          status: "active",
+        },
+      });
+      expect(brokenTaskAfter).not.toBeNull();
+
+      // The deleted (healthy) account's re-link task should be resolved.
+      const healthyTaskAfter = await prisma.item.findFirst({
+        where: {
+          userId: user.userId,
+          source: "system",
+          sourceId: `relink:google-calendar:${healthyAccount.id}`,
+          status: "active",
+        },
+      });
+      expect(healthyTaskAfter).toBeNull();
     });
 
     it("resolves the google-calendar re-link task so the broken-connection badge clears", async () => {
@@ -175,6 +241,33 @@ describe("Calendar Accounts routes", () => {
       // from Google. Without this, an incremental fetch using the stale
       // token would skip the events the user wants to see again.
       expect(updated?.syncToken).toBeNull();
+    });
+  });
+
+  describe("OAuth callback re-link scoping (source regression)", () => {
+    // We can't easily fake the full Google OAuth callback without mocking the
+    // entire googleapis chain (token exchange + userinfo.get). Instead, lock
+    // in the source-level invariant that catches the bug class directly:
+    // both the callback success path AND the disconnect path must use the
+    // PER-ACCOUNT resolver. If anyone reverts to the provider-wide
+    // `resolveRelinkTask(...)` here, reconnecting one Google Calendar account
+    // would silently dismiss every other Google Calendar account's broken
+    // prompt — exactly the user-visible bug we shipped a fix for.
+    it("calendar-accounts.ts uses the per-account resolver, never the provider-wide one", () => {
+      const here = dirname(fileURLToPath(import.meta.url));
+      const source = readFileSync(
+        resolve(here, "../routes/calendar-accounts.ts"),
+        "utf8",
+      );
+      // Strip line comments and the import line — only flag actual call sites.
+      const callSites = source
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("//"))
+        .filter((line) => !line.includes("import"))
+        .join("\n");
+      // `\b` ensures we don't match `resolveRelinkTaskForAccount`.
+      expect(callSites).not.toMatch(/\bresolveRelinkTask\s*\(/);
+      expect(callSites).toMatch(/resolveRelinkTaskForAccount\s*\(/);
     });
   });
 });

--- a/apps/api/src/__tests__/connection-health.test.ts
+++ b/apps/api/src/__tests__/connection-health.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { prisma } from "../lib/prisma.js";
-import { createRelinkTask, resolveRelinkTask } from "../lib/connection-health.js";
+import {
+  createRelinkTask,
+  resolveRelinkTask,
+  resolveRelinkTaskForAccount,
+  getBrokenConnections,
+} from "../lib/connection-health.js";
 import { generateId } from "@brett/utils";
 
 describe("connection-health", () => {
@@ -108,6 +113,74 @@ describe("connection-health", () => {
       const after = await findRelinkTasks(userId, "relink:ai:");
       const activeAfter = after.filter((t) => t.status === "active");
       expect(activeAfter).toHaveLength(0);
+    });
+  });
+
+  describe("getBrokenConnections", () => {
+    // Each subtest uses a fresh user so per-account counts aren't polluted by
+    // the createRelinkTask cases above.
+    it("returns details with per-account reason and brokenSince", async () => {
+      const user = await prisma.user.create({
+        data: {
+          id: generateId(),
+          name: "Broken Conn User",
+          email: `broken-${Date.now()}-${Math.random()}@test.com`,
+          emailVerified: true,
+        },
+      });
+      await createRelinkTask(user.id, "granola", "acc-1", "Token expired");
+
+      const result = await getBrokenConnections(user.id);
+
+      expect(result.count).toBe(1);
+      expect(result.types).toEqual(["granola"]);
+      expect(result.details).toHaveLength(1);
+      expect(result.details[0]).toMatchObject({
+        type: "granola",
+        accountId: "acc-1",
+        reason: "Token expired",
+      });
+      expect(result.details[0]!.brokenSince).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("preserves backwards-compatible shape: count + types alongside details", async () => {
+      const user = await prisma.user.create({
+        data: {
+          id: generateId(),
+          name: "Multi Type User",
+          email: `multi-${Date.now()}-${Math.random()}@test.com`,
+          emailVerified: true,
+        },
+      });
+      await createRelinkTask(user.id, "granola", "g1", "Granola broke");
+      await createRelinkTask(user.id, "google-calendar", "gc1", "Calendar broke");
+
+      const result = await getBrokenConnections(user.id);
+
+      expect(result.count).toBe(2);
+      expect(new Set(result.types)).toEqual(new Set(["granola", "google-calendar"]));
+      expect(result.details).toHaveLength(2);
+    });
+
+    it("regression: reconnecting account B does not clear account A's re-link task", async () => {
+      const user = await prisma.user.create({
+        data: {
+          id: generateId(),
+          name: "Scoped Resolution User",
+          email: `scoped-${Date.now()}-${Math.random()}@test.com`,
+          emailVerified: true,
+        },
+      });
+      await createRelinkTask(user.id, "granola", "acc-A", "Token expired for A");
+      await createRelinkTask(user.id, "granola", "acc-B", "Token expired for B");
+
+      // Simulate reconnect of acc-B
+      await resolveRelinkTaskForAccount(user.id, "granola", "acc-B");
+
+      const result = await getBrokenConnections(user.id);
+      expect(result.details).toHaveLength(1);
+      expect(result.details[0]!.accountId).toBe("acc-A");
+      expect(result.details[0]!.reason).toBe("Token expired for A");
     });
   });
 });

--- a/apps/api/src/__tests__/granola-auth.test.ts
+++ b/apps/api/src/__tests__/granola-auth.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { prisma } from "../lib/prisma.js";
 import { createRelinkTask } from "../lib/connection-health.js";
 import { createTestUser, authRequest } from "./helpers.js";
@@ -284,6 +287,30 @@ describe("Granola Auth routes", () => {
         where: { id: account.id },
       });
       expect(unchanged?.autoCreateMyTasks).toBe(true);
+    });
+  });
+
+  describe("OAuth callback re-link scoping (source regression)", () => {
+    // Granola was the FIRST place we hit the multi-account re-link bug —
+    // the provider-wide resolveRelinkTask silently cleared every Granola
+    // re-link task when ANY account reconnected. The fix is to call the
+    // per-account resolver everywhere this route file resolves tasks.
+    // This source-level test catches a regression at the call site directly
+    // (the full OAuth callback chain is too heavy to mock end-to-end).
+    it("granola-auth.ts uses the per-account resolver, never the provider-wide one", () => {
+      const here = dirname(fileURLToPath(import.meta.url));
+      const source = readFileSync(
+        resolve(here, "../routes/granola-auth.ts"),
+        "utf8",
+      );
+      const callSites = source
+        .split("\n")
+        .filter((line) => !line.trim().startsWith("//"))
+        .filter((line) => !line.includes("import"))
+        .join("\n");
+      // `\b` ensures we don't match `resolveRelinkTaskForAccount`.
+      expect(callSites).not.toMatch(/\bresolveRelinkTask\s*\(/);
+      expect(callSites).toMatch(/resolveRelinkTaskForAccount\s*\(/);
     });
   });
 });

--- a/apps/api/src/__tests__/recurrence.test.ts
+++ b/apps/api/src/__tests__/recurrence.test.ts
@@ -119,6 +119,59 @@ describe("Recurring task toggle", () => {
     expect(matches.length).toBe(2); // original + 1 from toggle, NOT 3
   });
 
+  it("completing a recurring task with tonight=true spawns next occurrence with tonight=true", async () => {
+    // Recurring evening tasks (e.g. "take medication tonight", "review tomorrow's
+    // calendar tonight") are the whole point of the Tonight bucket — the flag
+    // MUST carry across spawns. Resetting it would silently change behavior.
+    const createRes = await authRequest("/things", token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Tonight recurring" }),
+    });
+    const task = (await createRes.json()) as any;
+
+    // Set tonight + recurrence on the original (tonight is only mutable via PATCH).
+    await authRequest(`/things/${task.id}`, token, {
+      method: "PATCH",
+      body: JSON.stringify({ recurrence: "daily", tonight: true }),
+    });
+
+    await authRequest(`/things/${task.id}/toggle`, token, { method: "PATCH" });
+
+    const allRes = await authRequest("/things?status=active", token);
+    const all = (await allRes.json()) as any[];
+    const newTask = all.find(
+      (t: any) => t.title === "Tonight recurring" && t.id !== task.id,
+    );
+    expect(newTask).toBeTruthy();
+    expect(newTask.tonight).toBe(true);
+  });
+
+  it("completing a recurring task with tonight=false spawns next occurrence with tonight=false", async () => {
+    // Sanity check: when the source isn't a Tonight task, the spawn must NOT
+    // suddenly opt-in to the Tonight bucket. Default flag stays default.
+    const createRes = await authRequest("/things", token, {
+      method: "POST",
+      body: JSON.stringify({ type: "task", title: "Non-tonight recurring" }),
+    });
+    const task = (await createRes.json()) as any;
+    expect(task.tonight).toBe(false);
+
+    await authRequest(`/things/${task.id}`, token, {
+      method: "PATCH",
+      body: JSON.stringify({ recurrence: "daily" }),
+    });
+
+    await authRequest(`/things/${task.id}/toggle`, token, { method: "PATCH" });
+
+    const allRes = await authRequest("/things?status=active", token);
+    const all = (await allRes.json()) as any[];
+    const newTask = all.find(
+      (t: any) => t.title === "Non-tonight recurring" && t.id !== task.id,
+    );
+    expect(newTask).toBeTruthy();
+    expect(newTask.tonight).toBe(false);
+  });
+
   it("uncompleting a task does NOT create a new task", async () => {
     const createRes = await authRequest("/things", token, {
       method: "POST",

--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -1363,3 +1363,135 @@ describe("Sync Push", () => {
     expect(body.results[0].record!.contentStatus).toBeNull();
   });
 });
+
+describe("Sync — tonight field", () => {
+  let token: string;
+  const nonce = `tonight-${Date.now().toString(36)}`;
+
+  beforeAll(async () => {
+    const user = await createTestUser("Tonight Sync User");
+    token = user.token;
+  });
+
+  it("accepts tonight=true on item CREATE and returns it on pull", async () => {
+    clearAllRateLimits();
+    const entityId = generateId();
+
+    const pushRes = await authRequest("/sync/push", token, {
+      method: "POST",
+      body: JSON.stringify({
+        protocolVersion: 1,
+        mutations: [{
+          idempotencyKey: `${nonce}-create-${entityId}`,
+          entityType: "item",
+          entityId,
+          action: "CREATE",
+          payload: {
+            type: "task",
+            title: "Pick up groceries",
+            status: "active",
+            dueDate: new Date().toISOString(),
+            dueDatePrecision: "day",
+            tonight: true,
+          },
+        }],
+      }),
+    });
+    expect(pushRes.status).toBe(200);
+    const pushBody = (await pushRes.json()) as SyncPushResponse;
+    expect(pushBody.results[0].status).toBe("applied");
+    expect((pushBody.results[0].record as any).tonight).toBe(true);
+
+    clearAllRateLimits();
+
+    const pullRes = await authRequest("/sync/pull", token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    expect(pullRes.status).toBe(200);
+    const pullBody = (await pullRes.json()) as any;
+    const row = pullBody.changes.items.upserted.find((r: any) => r.id === entityId);
+    expect(row).toBeDefined();
+    expect(row.tonight).toBe(true);
+  });
+
+  it("accepts tonight=true on item UPDATE with previousValues", async () => {
+    clearAllRateLimits();
+
+    // Create with tonight=false via /things to get a baseline
+    const createRes = await authRequest("/things", token, {
+      method: "POST",
+      body: JSON.stringify({
+        type: "task",
+        title: "Tonight UPDATE target",
+        status: "active",
+      }),
+    });
+    const created = (await createRes.json()) as any;
+
+    clearAllRateLimits();
+
+    const updateRes = await authRequest("/sync/push", token, {
+      method: "POST",
+      body: JSON.stringify({
+        protocolVersion: 1,
+        mutations: [{
+          idempotencyKey: `${nonce}-update-${created.id}`,
+          entityType: "item",
+          entityId: created.id,
+          action: "UPDATE",
+          payload: { tonight: true },
+          changedFields: ["tonight"],
+          previousValues: { tonight: false },
+          baseUpdatedAt: created.updatedAt,
+        }],
+      }),
+    });
+    expect(updateRes.status).toBe(200);
+    const updateBody = (await updateRes.json()) as SyncPushResponse;
+    expect(updateBody.results[0].status).toBe("applied");
+
+    clearAllRateLimits();
+
+    const pullRes = await authRequest("/sync/pull", token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    const pullBody = (await pullRes.json()) as any;
+    const row = pullBody.changes.items.upserted.find((r: any) => r.id === created.id);
+    expect(row.tonight).toBe(true);
+  });
+
+  it("defaults tonight=false on items created without it (older clients)", async () => {
+    clearAllRateLimits();
+    const entityId = generateId();
+
+    // Simulate an older client that omits `tonight` in the payload.
+    await authRequest("/sync/push", token, {
+      method: "POST",
+      body: JSON.stringify({
+        protocolVersion: 1,
+        mutations: [{
+          idempotencyKey: `${nonce}-legacy-${entityId}`,
+          entityType: "item",
+          entityId,
+          action: "CREATE",
+          payload: { type: "task", title: "Legacy client item", status: "active" },
+        }],
+      }),
+    });
+
+    clearAllRateLimits();
+
+    const pullRes = await authRequest("/sync/pull", token, {
+      method: "POST",
+      body: JSON.stringify({ protocolVersion: 1, cursors: {} }),
+    });
+    const pullBody = (await pullRes.json()) as any;
+    const row = pullBody.changes.items.upserted.find((r: any) => r.id === entityId);
+    expect(row).toBeDefined();
+    // Default value must surface explicitly (false), not undefined — older clients
+    // that don't know the field still receive a stable shape.
+    expect(row.tonight).toBe(false);
+  });
+});

--- a/apps/api/src/lib/connection-health.ts
+++ b/apps/api/src/lib/connection-health.ts
@@ -22,7 +22,20 @@
 
 import { prisma } from "./prisma.js";
 
-type ConnectionType = "google-calendar" | "granola" | "ai";
+export type ConnectionType = "google-calendar" | "granola" | "ai";
+
+export interface BrokenConnectionDetail {
+  type: ConnectionType;
+  accountId: string | null;
+  reason: string | null;
+  brokenSince: string;
+}
+
+export interface BrokenConnectionsResponse {
+  count: number;
+  types: string[];
+  details: BrokenConnectionDetail[];
+}
 
 const TITLES: Record<ConnectionType, string> = {
   "google-calendar": "Re-link Google Calendar",
@@ -105,6 +118,47 @@ export async function resolveRelinkTask(
       completedAt: new Date(),
     },
   });
+}
+
+/**
+ * Aggregate every active/snoozed re-link task for a user into a structured
+ * response. Each entry carries the connection type, the specific accountId
+ * that broke, the human-readable reason (from Item.notes — written by
+ * createRelinkTask), and when the prompt was first created.
+ *
+ * Returns `count` + `types` for backwards compatibility with older clients
+ * that only consume the totals, plus the new `details` array for per-account
+ * UI chrome.
+ */
+export async function getBrokenConnections(
+  userId: string,
+): Promise<BrokenConnectionsResponse> {
+  const items = await prisma.item.findMany({
+    where: {
+      userId,
+      source: "system",
+      sourceId: { startsWith: "relink:" },
+      status: { in: ["active", "snoozed"] },
+    },
+    select: { sourceId: true, notes: true, createdAt: true },
+  });
+
+  const details: BrokenConnectionDetail[] = items.map((item: { sourceId: string | null; notes: string | null; createdAt: Date }) => {
+    // sourceId format: "relink:<type>:<accountId>" (accountId may be absent
+    // for legacy single-account integrations — split handles both cases).
+    const parts = (item.sourceId ?? "").split(":");
+    const type = (parts[1] ?? "") as ConnectionType;
+    const accountId = parts[2] ?? null;
+    return {
+      type,
+      accountId,
+      reason: item.notes ?? null,
+      brokenSince: item.createdAt.toISOString(),
+    };
+  });
+
+  const types = [...new Set(details.map((d) => d.type))];
+  return { count: details.length, types, details };
 }
 
 /**

--- a/apps/api/src/routes/calendar-accounts.ts
+++ b/apps/api/src/routes/calendar-accounts.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/google-calendar.js";
 import { encryptToken } from "../lib/encryption.js";
 import { initialSync, incrementalSync } from "../services/calendar-sync.js";
-import { resolveRelinkTask } from "../lib/connection-health.js";
+import { resolveRelinkTaskForAccount } from "../lib/connection-health.js";
 import { generateId } from "@brett/utils";
 import { google } from "googleapis";
 import { signOAuthState, verifyOAuthState } from "../lib/oauth-state.js";
@@ -192,8 +192,11 @@ calendarAccounts.get("/callback", async (c) => {
     },
   });
 
-  // Resolve any existing re-link task for this connection
-  await resolveRelinkTask(user.id, "google-calendar").catch((e) =>
+  // Resolve any existing re-link task for THIS account only. Using the
+  // provider-wide resolver here would silently dismiss another Google
+  // Calendar account's re-link prompt — see the granola-auth fix for the
+  // same bug pattern.
+  await resolveRelinkTaskForAccount(user.id, "google-calendar", account.id).catch((e) =>
     console.error("[calendar-accounts] Failed to resolve re-link task:", e),
   );
 
@@ -297,8 +300,10 @@ calendarAccounts.delete("/:id", authMiddleware, async (c) => {
   // Cascade delete (GoogleAccount -> CalendarList -> CalendarEvent, etc.)
   await prisma.googleAccount.delete({ where: { id: account.id } });
 
-  // Resolve any existing re-link task — user is in a valid state now (account removed)
-  await resolveRelinkTask(user.id, "google-calendar").catch((e) =>
+  // Resolve any existing re-link task for THIS account only. The user may
+  // have other Google Calendar accounts whose re-link prompts must stay
+  // visible — see calendar callback for the same scoping rationale.
+  await resolveRelinkTaskForAccount(user.id, "google-calendar", account.id).catch((e) =>
     console.error("[calendar-accounts] Failed to resolve re-link task:", e),
   );
 

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -38,7 +38,7 @@ const PUSHABLE_ENTITY_TYPES: readonly PushableEntityType[] = ["item", "list", "c
 const MUTABLE_FIELDS: Record<PushableEntityType, readonly string[]> = {
   item: ["title", "description", "notes", "status", "dueDate", "dueDatePrecision",
          "completedAt", "snoozedUntil", "reminder", "recurrence", "recurrenceRule",
-         "listId", "brettObservation", "contentType", "contentStatus"],
+         "listId", "brettObservation", "contentType", "contentStatus", "tonight"],
   list: ["name", "colorClass", "sortOrder", "archivedAt"],
   calendar_event_note: ["content"],
 };
@@ -56,7 +56,7 @@ const CREATABLE_FIELDS: Record<PushableEntityType, readonly string[]> = {
     "status", "dueDate", "dueDatePrecision", "completedAt", "snoozedUntil",
     "reminder", "recurrence", "recurrenceRule",
     "listId", "brettObservation",
-    "contentType", "contentStatus",
+    "contentType", "contentStatus", "tonight",
   ],
   list: ["name", "colorClass", "sortOrder", "archivedAt"],
   calendar_event_note: ["calendarEventId", "content"],

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -279,6 +279,9 @@ things.get("/", async (c) => {
 // GET /things/broken-connections — active re-link tasks with per-account details.
 // Returns { count, types, details } — `count`/`types` preserved for older clients;
 // `details` is additive for per-account warning chrome in Settings.
+//
+// Auth: enforced router-wide via `things.use("*", authMiddleware)` above —
+// no per-handler middleware required.
 things.get("/broken-connections", async (c) => {
   const user = c.get("user");
   const result = await getBrokenConnections(user.id);

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -510,7 +510,7 @@ things.post("/", async (c) => {
 
 /** Spawn the next occurrence of a recurring task */
 async function spawnNextRecurrence(
-  item: { id: string; type: string; title: string; notes: string | null; description: string | null; source: string; dueDate: Date | null; dueDatePrecision: string | null; recurrence: string | null; recurrenceRule: string | null; listId: string | null; userId: string },
+  item: { id: string; type: string; title: string; notes: string | null; description: string | null; source: string; dueDate: Date | null; dueDatePrecision: string | null; recurrence: string | null; recurrenceRule: string | null; listId: string | null; userId: string; tonight: boolean },
   linksFrom: { toItemId: string; toItemType: string }[],
 ) {
   if (!item.recurrence) return;
@@ -534,6 +534,10 @@ async function spawnNextRecurrence(
       recurrenceRule: item.recurrenceRule,
       listId: item.listId,
       userId: item.userId,
+      // Carry tonight across spawns. Recurring evening tasks (e.g. nightly
+      // medication, "review tomorrow's calendar tonight") rely on this — the
+      // Tonight bucket is exactly the point of having those recurrences.
+      tonight: item.tonight,
     },
   });
 

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -324,6 +324,7 @@ things.patch("/bulk", async (c) => {
     updateData.dueDate = data.updates.dueDate ? new Date(data.updates.dueDate) : null;
   if (data.updates.dueDatePrecision !== undefined)
     updateData.dueDatePrecision = data.updates.dueDatePrecision;
+  if (data.updates.tonight !== undefined) updateData.tonight = data.updates.tonight;
   if (data.updates.status !== undefined) updateData.status = data.updates.status;
 
   const result = await prisma.item.updateMany({
@@ -581,6 +582,7 @@ things.patch("/:id", async (c) => {
     updateData.dueDate = data.dueDate ? new Date(data.dueDate) : null;
   if (data.dueDatePrecision !== undefined)
     updateData.dueDatePrecision = data.dueDatePrecision;
+  if (data.tonight !== undefined) updateData.tonight = data.tonight;
   if (data.brettObservation !== undefined)
     updateData.brettObservation = data.brettObservation;
   if (data.listId !== undefined) updateData.listId = data.listId;

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -10,6 +10,7 @@ import type { ItemAssemblerInput, ContentAssemblerInput } from "@brett/ai";
 import type { ThingDetail, Attachment as AttachmentType, ItemLink as ItemLinkType, BrettMessage as BrettMessageType } from "@brett/types";
 import { getEmbeddingProvider } from "../lib/embedding-provider.js";
 import { paginatedPull, type PaginatedPullResult } from "../lib/sync/paginated-pull.js";
+import { getBrokenConnections } from "../lib/connection-health.js";
 
 const things = new Hono<AuthEnv>();
 
@@ -275,20 +276,13 @@ things.get("/", async (c) => {
   return c.json(thingsList);
 });
 
-// GET /things/broken-connections — count of active re-link tasks by type
+// GET /things/broken-connections — active re-link tasks with per-account details.
+// Returns { count, types, details } — `count`/`types` preserved for older clients;
+// `details` is additive for per-account warning chrome in Settings.
 things.get("/broken-connections", async (c) => {
   const user = c.get("user");
-  const items = await prisma.item.findMany({
-    where: {
-      userId: user.id,
-      source: "system",
-      sourceId: { startsWith: "relink:" },
-      status: { in: ["active", "snoozed"] },
-    },
-    select: { sourceId: true },
-  });
-  const types = [...new Set(items.map((i) => i.sourceId!.split(":")[1]))];
-  return c.json({ count: items.length, types });
+  const result = await getBrokenConnections(user.id);
+  return c.json(result);
 });
 
 // PATCH /things/bulk — bulk update

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -282,6 +282,10 @@ export function App() {
      *  Hard-coding "day" here silently corrupts week-precision picks into
      *  weekend-bucketed day items. */
     pendingPrecision?: "day" | "week";
+    /** Tonight flag committed alongside pendingDate. Set to `true` only when
+     *  the Tonight chip was picked; every other commit path passes `false`,
+     *  which clears a previously set flag. */
+    pendingTonight?: boolean;
     pendingListId?: string | null;
   } | null>(null);
 
@@ -889,10 +893,13 @@ export function App() {
   const closeTriageWithFlush = useCallback(() => {
     setTriageState((s) => {
       if (!s) return null;
-      const updates: { listId?: string | null; dueDate?: string | null; dueDatePrecision?: "day" | "week" | null } = {};
+      const updates: { listId?: string | null; dueDate?: string | null; dueDatePrecision?: "day" | "week" | null; tonight?: boolean } = {};
       if (s.pendingDate !== undefined) {
         updates.dueDate = s.pendingDate ? s.pendingDate.toISOString() : null;
         updates.dueDatePrecision = s.pendingDate ? (s.pendingPrecision ?? "day") : null;
+        // Clearing the date clears tonight; otherwise carry through whatever
+        // the picker reported (defaults to `false` for every non-Tonight chip).
+        updates.tonight = s.pendingDate ? (s.pendingTonight ?? false) : false;
       }
       if (s.pendingListId !== undefined) {
         updates.listId = s.pendingListId;
@@ -1081,7 +1088,7 @@ export function App() {
 
   const handleInboxTriage = (
     ids: string[],
-    updates: { listId?: string | null; dueDate?: string | null; dueDatePrecision?: "day" | "week" | null }
+    updates: { listId?: string | null; dueDate?: string | null; dueDatePrecision?: "day" | "week" | null; tonight?: boolean }
   ) => {
     bulkUpdate.mutate({ ids, updates });
   };
@@ -1444,8 +1451,8 @@ export function App() {
           onDuplicate={handleDuplicateThing}
           lists={lists}
           onSetList={handleSetList}
-          onUpdateDueDate={(dueDate, precision) => {
-            if (selectedId) updateThing.mutate({ id: selectedId, dueDate, dueDatePrecision: precision });
+          onUpdateDueDate={(dueDate, precision, tonight) => {
+            if (selectedId) updateThing.mutate({ id: selectedId, dueDate, dueDatePrecision: precision, tonight });
           }}
           onUpdateReminder={(reminder) => {
             if (selectedId) updateThing.mutate({ id: selectedId, reminder });
@@ -1639,8 +1646,8 @@ export function App() {
                 suggestedListIds={suggestedListIds}
                 suggestionMode={suggestionMode}
                 startWith={triageState.mode === "list-first" ? "list" : "date"}
-                onCommitDate={(date, precision) =>
-                  setTriageState((s) => (s ? { ...s, pendingDate: date, pendingPrecision: precision } : s))
+                onCommitDate={(date, precision, tonight) =>
+                  setTriageState((s) => (s ? { ...s, pendingDate: date, pendingPrecision: precision, pendingTonight: tonight } : s))
                 }
                 onCommitList={(listId) =>
                   setTriageState((s) => (s ? { ...s, pendingListId: listId } : s))
@@ -1655,10 +1662,11 @@ export function App() {
               <QuickDatePicker
                 anchorEl={triageState.anchorEl}
                 initialDate={initialDate}
-                onCommit={(date, precision) => {
+                onCommit={(date, precision, tonight) => {
                   handleInboxTriage(triageState.ids, {
                     dueDate: date ? date.toISOString() : null,
                     dueDatePrecision: date ? precision : null,
+                    tonight,
                   });
                   handleTriageCancel();
                 }}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { useTodayKey } from "./hooks/useTodayKey";
 import { usePinnedDate } from "./hooks/usePinnedDate";
 import { getEndOfWeekUTC, isHiddenDeclined } from "@brett/business";
 import type { BackgroundStyle } from "@brett/business";
+import { computeBadgeCount } from "./lib/badgeCount";
 import {
   DndContext,
   DragOverlay,
@@ -503,29 +504,22 @@ export function App() {
 
   // Push the Today count to the macOS dock via the main process.
   //
-  // Inclusion rules:
-  //   - Always: overdue + today + this_week (the upcoming workweek)
-  //   - On Sat/Sun only: + this_weekend (the current weekend has arrived)
+  // Inclusion rules (kept narrow on purpose; see lib/badgeCount.ts for history):
+  //   - overdue + due today only
+  //   - Tonight items count as today (dueDate = today end)
   //
-  // Weekend items are intentionally excluded from the badge during the
-  // workweek — the user shouldn't see a Saturday item pestering them on
-  // Tuesday. Once Saturday rolls around, those items roll into the badge.
+  // The week-long fetch above stays — the rest of the Today view still needs
+  // this_week + this_weekend items. The badge just filters them down here.
   //
   // Gates on `todayQuerySuccess` so the dock doesn't flash 0 during the
   // hydration window. Clears to 0 when signed out. No-op in browsers /
-  // Windows. iOS parity lives in apps/ios/Brett/Services/BadgeManager.
+  // Windows. iOS parity lives in apps/ios/Brett/Views/Today/TodaySections.swift
+  // (`badgeCount` static method) — keep them in lockstep.
   const badgeUserId = user?.id ?? null;
-  const isWeekendNow = useMemo(() => {
-    const dow = new Date(todayKey).getUTCDay();
-    return dow === 0 || dow === 6;
-  }, [todayKey]);
   const badgeCount = useMemo(() => {
     if (!badgeUserId) return 0;
-    return activeThingsForCount.filter((t: { urgency?: string }) => {
-      if (t.urgency === "this_weekend") return isWeekendNow;
-      return true;
-    }).length;
-  }, [badgeUserId, activeThingsForCount, isWeekendNow]);
+    return computeBadgeCount(activeThingsForCount);
+  }, [badgeUserId, activeThingsForCount]);
   useEffect(() => {
     const api = (window as { electronAPI?: { setBadgeCount?: (n: number) => Promise<void> } }).electronAPI;
     if (!api?.setBadgeCount) return;

--- a/apps/desktop/src/__tests__/badgeCount.test.ts
+++ b/apps/desktop/src/__tests__/badgeCount.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { computeBadgeCount } from "../lib/badgeCount";
+
+// These tests encode the invariant that the Today badge counts ONLY overdue +
+// today (Tonight items live in the today bucket via dueDate). If you change
+// these expectations, also update apps/ios/BrettTests/TodaySectionsTests.swift
+// and the spec at docs/superpowers/specs/2026-04-24-today-count-badge-design.md.
+
+const today = new Date("2026-05-18T12:00:00Z");
+
+describe("computeBadgeCount", () => {
+  it("counts overdue items", () => {
+    const items = [
+      { dueDate: "2026-05-17T12:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("counts today items", () => {
+    const items = [
+      { dueDate: "2026-05-18T18:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("counts tonight items as today (they live in the today bucket)", () => {
+    // Tonight items have dueDate = end of today, so the same predicate
+    // catches them. No special handling needed.
+    const items = [
+      { dueDate: "2026-05-18T23:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("excludes this_week items", () => {
+    const items = [
+      { dueDate: "2026-05-20T12:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+
+  it("excludes this_weekend items even on a weekend", () => {
+    // Critical regression guard: before 2026-05-18, the badge included
+    // weekend items on Sat/Sun. The new spec drops that — weekend items
+    // never count unless they're already overdue.
+    const saturday = new Date("2026-05-23T12:00:00Z");
+    const weekendItems = [
+      { dueDate: "2026-05-24T12:00:00Z", isCompleted: false },
+    ];
+    expect(computeBadgeCount(weekendItems, saturday)).toBe(0);
+  });
+
+  it("excludes completed items", () => {
+    const items = [
+      { dueDate: "2026-05-18T18:00:00Z", isCompleted: true },
+    ];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+
+  it("excludes items with no dueDate", () => {
+    const items = [{ dueDate: null, isCompleted: false }];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+});

--- a/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
+++ b/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
@@ -37,12 +37,33 @@ describe("useLocalStorageBoolean", () => {
   it("scopes state per user — two accounts on the same device don't share", () => {
     // Multi-user invariant from CLAUDE.md: UI state must not leak across
     // accounts on the same device.
-    setStorageUser("alice");
+    act(() => setStorageUser("alice"));
     const { result: aliceHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
     act(() => aliceHook.current[1](true));
 
-    setStorageUser("bob");
+    act(() => setStorageUser("bob"));
     const { result: bobHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
     expect(bobHook.current[0]).toBe(false); // bob should see fallback, not alice's true
+  });
+
+  it("re-reads from storage when scoped user changes mid-mount", () => {
+    // Regression guard: if user A collapses a section and then signs out
+    // and user B signs in WITHOUT this hook's host component unmounting,
+    // B must see B's preference (fallback), not A's stored value. The hook
+    // subscribes to `setStorageUser` for exactly this reason — relying
+    // only on `key`-change re-sync would leak A's state into B's session.
+    setStorageUser("alice");
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+
+    // Same hook instance — pretend the user just switched.
+    act(() => setStorageUser("bob"));
+    expect(result.current[0]).toBe(false); // bob's fallback, not alice's true
+
+    // And if carol had a pre-existing stored value, the hook should pick it up.
+    localStorage.setItem("test.key.user=carol", "true");
+    act(() => setStorageUser("carol"));
+    expect(result.current[0]).toBe(true);
   });
 });

--- a/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
+++ b/apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
+import { setStorageUser } from "../lib/userScopedStorage";
+
+beforeEach(() => {
+  localStorage.clear();
+  // Default to a known user so the scoped key is stable across tests.
+  setStorageUser("test-user");
+});
+
+describe("useLocalStorageBoolean", () => {
+  it("returns default value when no key in storage", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("returns the explicit default when fallback=true", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", true));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("persists toggled value to localStorage", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+    // userScopedStorage appends `.user=<id>` — verify the actual key.
+    expect(localStorage.getItem("test.key.user=test-user")).toBe("true");
+  });
+
+  it("reads existing value on mount", () => {
+    localStorage.setItem("test.key.user=test-user", "true");
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("scopes state per user — two accounts on the same device don't share", () => {
+    // Multi-user invariant from CLAUDE.md: UI state must not leak across
+    // accounts on the same device.
+    setStorageUser("alice");
+    const { result: aliceHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => aliceHook.current[1](true));
+
+    setStorageUser("bob");
+    const { result: bobHook } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(bobHook.current[0]).toBe(false); // bob should see fallback, not alice's true
+  });
+});

--- a/apps/desktop/src/__tests__/useTonightAutoExpand.test.ts
+++ b/apps/desktop/src/__tests__/useTonightAutoExpand.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTonightExpansion } from "../lib/useTonightAutoExpand";
+
+/**
+ * The hook drives whether the Today view's Tonight section is open or
+ * collapsed. The rules are intentionally tested at the level the user
+ * cares about — "what does the section show when I open Today at X
+ * o'clock?" — not at the localStorage-key level.
+ */
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useTonightExpansion", () => {
+  it("defaults closed before 6pm local when the user hasn't touched it today", () => {
+    vi.setSystemTime(new Date("2026-05-18T17:30:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("defaults open at 6pm or later when the user hasn't touched it today", () => {
+    vi.setSystemTime(new Date("2026-05-18T18:00:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("respects a manual collapse after 6pm — sticky for the rest of the day", () => {
+    // User opens the app at 8pm; the section auto-opens. They explicitly
+    // collapse it. Until midnight (the date key changes) the auto rule
+    // must not re-open it on the next mount.
+    vi.setSystemTime(new Date("2026-05-18T20:00:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    expect(result.current[0]).toBe(true);
+
+    act(() => result.current[1](false));
+    expect(result.current[0]).toBe(false);
+
+    // Re-mount — the persisted user override must win over the auto rule.
+    const { result: result2 } = renderHook(() => useTonightExpansion());
+    expect(result2.current[0]).toBe(false);
+  });
+
+  it("starts fresh on a new local calendar date", () => {
+    // Day 1: user collapses after 6pm.
+    vi.setSystemTime(new Date("2026-05-18T20:00:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    act(() => result.current[1](false));
+    expect(result.current[0]).toBe(false);
+
+    // Day 2 morning: a brand-new mount on a new date must reset to the
+    // pre-6pm auto default (closed), NOT carry the previous day's override.
+    vi.setSystemTime(new Date("2026-05-19T09:00:00"));
+    const { result: result2 } = renderHook(() => useTonightExpansion());
+    expect(result2.current[0]).toBe(false); // pre-6pm default
+
+    // …and at 6pm on day 2, the auto rule re-applies because the day-2 key
+    // hasn't been touched.
+    vi.setSystemTime(new Date("2026-05-19T18:30:00"));
+    const { result: result3 } = renderHook(() => useTonightExpansion());
+    expect(result3.current[0]).toBe(true);
+  });
+});

--- a/apps/desktop/src/api/connection-health.ts
+++ b/apps/desktop/src/api/connection-health.ts
@@ -2,9 +2,31 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { apiFetch } from "./client";
 
+export interface BrokenConnectionDetail {
+  type: "granola" | "google-calendar" | "ai";
+  accountId: string | null;
+  reason: string | null;
+  brokenSince: string;
+}
+
 interface BrokenConnections {
   count: number;
   types: string[];
+  details: BrokenConnectionDetail[];
+}
+
+/**
+ * Find the broken-connection detail (if any) for a specific account so the
+ * Settings card for that account can render inline warning chrome. Returns
+ * null when the account is healthy or `data` is still loading.
+ */
+export function findBrokenDetailForAccount(
+  data: BrokenConnections | undefined,
+  type: "granola" | "google-calendar",
+  accountId: string,
+): BrokenConnectionDetail | null {
+  if (!data?.details) return null;
+  return data.details.find((d) => d.type === type && d.accountId === accountId) ?? null;
 }
 
 /**

--- a/apps/desktop/src/lib/badgeCount.ts
+++ b/apps/desktop/src/lib/badgeCount.ts
@@ -1,0 +1,40 @@
+// Today badge count — kept narrow on purpose: overdue + today only.
+//
+// History: before 2026-05-18 the badge also included "this_week" items (and,
+// on weekends, "this_weekend" items). That made the badge noisy during the
+// workweek and conflated "things to do today" with "things due eventually
+// this week". Spec: docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md.
+//
+// Tonight items are counted as today — they have `dueDate = today end`, so the
+// same `dueDate <= endOfToday` predicate captures them. The `tonight` flag
+// only affects sectioning, not counting.
+//
+// iOS parity lives in apps/ios/Brett/Views/Today/TodaySections.swift's
+// `badgeCount` static method — they must move in lockstep.
+
+type BadgeInputThing = {
+  dueDate?: string | Date | null;
+  isCompleted?: boolean;
+};
+
+export function computeBadgeCount(
+  things: BadgeInputThing[],
+  now: Date = new Date(),
+): number {
+  const endOfToday = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      23,
+      59,
+      59,
+      999,
+    ),
+  );
+  return things.filter((t) => {
+    if (t.isCompleted) return false;
+    if (!t.dueDate) return false;
+    return new Date(t.dueDate) <= endOfToday;
+  }).length;
+}

--- a/apps/desktop/src/lib/useLocalStorageBoolean.ts
+++ b/apps/desktop/src/lib/useLocalStorageBoolean.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import { userStorage } from "./userScopedStorage";
+
+/**
+ * Per-user persisted boolean state for UI affordances (collapsed sections,
+ * dismissed banners, etc.).
+ *
+ * Uses `userStorage` (apps/desktop/src/lib/userScopedStorage.ts) under the
+ * hood, so two accounts on the same machine don't share collapsed-state.
+ *
+ * `key` is the base key — `userStorage` appends `.user=<id>` automatically.
+ * Pick names like `today.section.this-week.open` (feature.subkey.what).
+ */
+function read(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = userStorage.getItem(key);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useLocalStorageBoolean(
+  key: string,
+  fallback: boolean,
+): [boolean, (next: boolean) => void] {
+  const [value, setValue] = useState<boolean>(() => read(key, fallback));
+
+  // Re-sync if the key changes (rare — defensive). Intentionally NOT
+  // depending on `fallback`: changing the default after first render should
+  // not clobber a user's explicit choice.
+  useEffect(() => {
+    setValue(read(key, fallback));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const update = useCallback(
+    (next: boolean) => {
+      setValue(next);
+      try {
+        userStorage.setItem(key, next ? "true" : "false");
+      } catch {
+        // localStorage unavailable — in-memory state still works.
+      }
+    },
+    [key],
+  );
+
+  return [value, update];
+}

--- a/apps/desktop/src/lib/useLocalStorageBoolean.ts
+++ b/apps/desktop/src/lib/useLocalStorageBoolean.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { userStorage } from "./userScopedStorage";
+import { subscribeToStorageUser, userStorage } from "./userScopedStorage";
 
 /**
  * Per-user persisted boolean state for UI affordances (collapsed sections,
@@ -10,6 +10,12 @@ import { userStorage } from "./userScopedStorage";
  *
  * `key` is the base key — `userStorage` appends `.user=<id>` automatically.
  * Pick names like `today.section.this-week.open` (feature.subkey.what).
+ *
+ * Re-syncs on `setStorageUser` so a sign-out + sign-in flip (without remount
+ * of the consuming component) shows the new user's value, not the previous
+ * user's. Without that subscription, App.tsx is the only place that re-reads
+ * after a user switch (see SIDEBAR_DISMISSED_KEY pattern) and every other
+ * caller silently leaks A's UI state to B.
  */
 function read(key: string, fallback: boolean): boolean {
   if (typeof window === "undefined") return fallback;
@@ -29,11 +35,15 @@ export function useLocalStorageBoolean(
 ): [boolean, (next: boolean) => void] {
   const [value, setValue] = useState<boolean>(() => read(key, fallback));
 
-  // Re-sync if the key changes (rare — defensive). Intentionally NOT
-  // depending on `fallback`: changing the default after first render should
-  // not clobber a user's explicit choice.
+  // Re-sync if the key changes (rare — defensive) OR if the scoped user
+  // changes. Intentionally NOT depending on `fallback`: changing the default
+  // after first render should not clobber a user's explicit choice.
   useEffect(() => {
     setValue(read(key, fallback));
+    const unsubscribe = subscribeToStorageUser(() => {
+      setValue(read(key, fallback));
+    });
+    return unsubscribe;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 

--- a/apps/desktop/src/lib/useTonightAutoExpand.ts
+++ b/apps/desktop/src/lib/useTonightAutoExpand.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Default open/closed state for the Today view's Tonight section.
+ *
+ * Rules:
+ *  - Closed by default before 6pm local (the user is in mid-day mode and
+ *    Tonight items are noise).
+ *  - Open by default at 6pm local or later (the section becomes relevant).
+ *  - Sticky user override: once the user manually toggles the section on
+ *    a given day, the auto rule yields for the rest of that day. The
+ *    override is keyed by the local calendar date so each day starts
+ *    fresh with the auto rule.
+ *
+ * The hook re-evaluates every minute so the 6pm "tip over" happens
+ * without a page reload.
+ */
+const TOUCHED_KEY_PREFIX = "brett:today.tonight.userToggled.";
+const STATE_KEY_PREFIX = "brett:today.tonight.openState.";
+const EVENING_HOUR = 18;
+const REEVALUATE_INTERVAL_MS = 60_000;
+
+function todayKey(now: Date = new Date()): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function computeDefault(now: Date = new Date()): boolean {
+  return now.getHours() >= EVENING_HOUR;
+}
+
+function readPersistedOpen(key: string): boolean | null {
+  try {
+    const touched = window.localStorage.getItem(TOUCHED_KEY_PREFIX + key);
+    if (touched !== "true") return null;
+    return window.localStorage.getItem(STATE_KEY_PREFIX + key) === "true";
+  } catch {
+    // localStorage unavailable (private mode / iframe sandbox) — fall back
+    // to the auto rule. Tonight is not load-bearing enough to break here.
+    return null;
+  }
+}
+
+export function useTonightExpansion(): [boolean, (open: boolean) => void] {
+  const [open, setOpenState] = useState<boolean>(() => {
+    const persisted = readPersistedOpen(todayKey());
+    return persisted ?? computeDefault();
+  });
+
+  // Re-evaluate every minute so 6pm "tips over" without page reload. If
+  // the user has explicitly toggled today, leave their choice alone.
+  useEffect(() => {
+    const id = setInterval(() => {
+      const persisted = readPersistedOpen(todayKey());
+      if (persisted !== null) return; // user-controlled, skip
+      setOpenState(computeDefault());
+    }, REEVALUATE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const setOpen = (next: boolean) => {
+    setOpenState(next);
+    const key = todayKey();
+    try {
+      window.localStorage.setItem(TOUCHED_KEY_PREFIX + key, "true");
+      window.localStorage.setItem(STATE_KEY_PREFIX + key, next ? "true" : "false");
+    } catch {
+      // Best-effort persistence — see readPersistedOpen for the rationale.
+    }
+  };
+
+  return [open, setOpen];
+}

--- a/apps/desktop/src/lib/userScopedStorage.ts
+++ b/apps/desktop/src/lib/userScopedStorage.ts
@@ -9,9 +9,38 @@
  */
 
 let currentUserId: string | null = null;
+const subscribers = new Set<(userId: string | null) => void>();
 
 export function setStorageUser(userId: string | null): void {
+  if (currentUserId === userId) return;
   currentUserId = userId;
+  // Fire-and-forget notify — subscribers are React hooks re-syncing local
+  // state, so they must be cheap. Snapshot before iterating in case a
+  // subscriber unsubscribes synchronously.
+  for (const fn of Array.from(subscribers)) {
+    fn(userId);
+  }
+}
+
+export function getStorageUser(): string | null {
+  return currentUserId;
+}
+
+/**
+ * Subscribe to user-switch events. Returns an unsubscribe function.
+ *
+ * Used by `useLocalStorageBoolean` (and any future user-scoped hook) to
+ * re-read storage after `setStorageUser` flips. Without this, a hook that
+ * mounted under user A and stayed mounted across a sign-out + sign-in
+ * to user B would keep showing A's value.
+ */
+export function subscribeToStorageUser(
+  fn: (userId: string | null) => void,
+): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
 }
 
 function scopedKey(base: string): string {

--- a/apps/desktop/src/settings/CalendarSection.tsx
+++ b/apps/desktop/src/settings/CalendarSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Calendar, Plus, Trash2, RefreshCw } from "lucide-react";
+import { Calendar, Plus, Trash2, RefreshCw, AlertCircle } from "lucide-react";
 import { SettingsCard, SettingsHeader, SettingsToggle } from "./SettingsComponents";
 import { CalendarConnectModal } from "../components/CalendarConnectModal";
 import {
@@ -12,6 +12,7 @@ import {
 } from "../api/calendar-accounts";
 import { useFetchCalendarRange } from "../api/calendar";
 import { useGranolaAccounts, useConnectGranola, useDisconnectGranola, useUpdateGranolaPreferences } from "../api/granola";
+import { useBrokenConnections, findBrokenDetailForAccount, type BrokenConnectionDetail } from "../api/connection-health";
 import type { ConnectedCalendarAccount, GranolaAccountRecord } from "@brett/types";
 import { useAssistantName } from "../api/assistant-name";
 
@@ -40,11 +41,32 @@ function GoogleIcon() {
   );
 }
 
-interface ConnectedAccountRowProps {
-  account: ConnectedCalendarAccount;
+/**
+ * Inline warning chrome for a Settings account card that has an active re-link
+ * task. Shows a single amber header row with the reason text from the API. The
+ * caller is responsible for tinting its own border/background — this just owns
+ * the warning content.
+ */
+function AccountWarningRow({ broken }: { broken: BrokenConnectionDetail }) {
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 border-b border-amber-400/20 bg-amber-500/10">
+      <AlertCircle size={14} className="text-amber-300 mt-0.5 shrink-0" />
+      <div className="min-w-0">
+        <div className="text-xs font-medium text-amber-200">Needs reconnection</div>
+        {broken.reason && (
+          <div className="text-[11px] text-amber-200/70 mt-0.5 truncate">{broken.reason}</div>
+        )}
+      </div>
+    </div>
+  );
 }
 
-function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
+interface ConnectedAccountRowProps {
+  account: ConnectedCalendarAccount;
+  broken: BrokenConnectionDetail | null;
+}
+
+function ConnectedAccountRow({ account, broken }: ConnectedAccountRowProps) {
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const disconnectCalendar = useDisconnectCalendar();
   const toggleVisibility = useToggleCalendarVisibility();
@@ -58,7 +80,14 @@ function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
   }
 
   return (
-    <div className="bg-white/5 rounded-lg overflow-hidden">
+    <div
+      className={
+        broken
+          ? "bg-amber-500/5 rounded-lg overflow-hidden border border-amber-400/30"
+          : "bg-white/5 rounded-lg overflow-hidden"
+      }
+    >
+      {broken && <AccountWarningRow broken={broken} />}
       {/* Account header */}
       <div className="flex items-center justify-between px-3 py-2.5 border-b border-white/10">
         <div className="flex items-center gap-2 min-w-0">
@@ -157,15 +186,23 @@ function ConnectedAccountRow({ account }: ConnectedAccountRowProps) {
 interface GranolaAccountRowProps {
   account: GranolaAccountRecord;
   assistantName: string;
+  broken: BrokenConnectionDetail | null;
 }
 
-function GranolaAccountRow({ account, assistantName }: GranolaAccountRowProps) {
+function GranolaAccountRow({ account, assistantName, broken }: GranolaAccountRowProps) {
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const disconnect = useDisconnectGranola();
   const updatePrefs = useUpdateGranolaPreferences();
 
   return (
-    <div className="bg-white/5 rounded-lg overflow-hidden">
+    <div
+      className={
+        broken
+          ? "bg-amber-500/5 rounded-lg overflow-hidden border border-amber-400/30"
+          : "bg-white/5 rounded-lg overflow-hidden"
+      }
+    >
+      {broken && <AccountWarningRow broken={broken} />}
       <div className="flex items-center justify-between px-3 py-2.5">
         <div className="flex items-center gap-2 min-w-0">
           <span className="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" />
@@ -267,6 +304,7 @@ export function CalendarSection() {
   const fetchRange = useFetchCalendarRange();
   const { data: granolaData } = useGranolaAccounts();
   const connectGranola = useConnectGranola();
+  const { data: brokenConnections } = useBrokenConnections();
   const [showConnectModal, setShowConnectModal] = useState(false);
 
   return (
@@ -312,7 +350,11 @@ export function CalendarSection() {
         {!isLoading && !error && accounts.length > 0 && (
           <div className="space-y-3">
             {accounts.map((account) => (
-              <ConnectedAccountRow key={account.id} account={account} />
+              <ConnectedAccountRow
+                key={account.id}
+                account={account}
+                broken={findBrokenDetailForAccount(brokenConnections, "google-calendar", account.id)}
+              />
             ))}
           </div>
         )}
@@ -364,6 +406,7 @@ export function CalendarSection() {
                 key={account.id}
                 account={account}
                 assistantName={assistantName}
+                broken={findBrokenDetailForAccount(brokenConnections, "granola", account.id)}
               />
             ))}
           </div>

--- a/apps/desktop/src/views/TodayView.tsx
+++ b/apps/desktop/src/views/TodayView.tsx
@@ -24,6 +24,12 @@ import { useBriefing, useBriefingSummary } from "../api/briefing";
 import { usePreference } from "../api/preferences";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
 import { useTodayKey } from "../hooks/useTodayKey";
+import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
+
+/** Section keys that render as collapsibles (default collapsed) on Today.
+ *  Overdue + Today stay always-expanded — they're the badge bucket and the
+ *  reason the user opened the view. */
+const COLLAPSIBLE_SECTION_KEYS = new Set(["this-week", "this-weekend", "done-today"]);
 
 interface TodayViewProps {
   lists: NavList[];
@@ -165,19 +171,48 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
     return list;
   }, [grouped]);
 
+  // Per-section collapsed state. Persisted per-user via localStorage so
+  // toggling a section, navigating away, and coming back retains the choice.
+  // Default `false` (collapsed) per the 2026-05-18 tuning spec.
+  const [thisWeekOpen, setThisWeekOpen] = useLocalStorageBoolean("today.section.this-week.open", false);
+  const [thisWeekendOpen, setThisWeekendOpen] = useLocalStorageBoolean("today.section.this-weekend.open", false);
+  const [doneTodayOpen, setDoneTodayOpen] = useLocalStorageBoolean("today.section.done-today.open", false);
+
+  const collapsibleSections = useMemo(() => ({
+    "this-week": { open: thisWeekOpen, onOpenChange: setThisWeekOpen },
+    "this-weekend": { open: thisWeekendOpen, onOpenChange: setThisWeekendOpen },
+    "done-today": { open: doneTodayOpen, onOpenChange: setDoneTodayOpen },
+  }), [thisWeekOpen, setThisWeekOpen, thisWeekendOpen, setThisWeekendOpen, doneTodayOpen, setDoneTodayOpen]);
+
+  // For the chrome active-section header above the inner scroll: a collapsed
+  // section has no items to scroll past, so it must never become the active
+  // section. Track-only the visible (open or always-on) sections.
+  const trackableSectionKeys = useMemo(() => {
+    return new Set(
+      sections
+        .filter((s) =>
+          !COLLAPSIBLE_SECTION_KEYS.has(s.key) ||
+          collapsibleSections[s.key as keyof typeof collapsibleSections]?.open === true
+        )
+        .map((s) => s.key)
+    );
+  }, [sections, collapsibleSections]);
+
   const [activeSectionKey, setActiveSectionKey] = useState<string | null>(null);
   const sectionsScrollRef = useRef<HTMLDivElement>(null);
   const outerScrollRef = useRef<HTMLDivElement>(null);
   const thingsCardRef = useRef<HTMLDivElement>(null);
 
   // Re-sync active section when the section list changes (filter pill,
-  // toggling done, etc.) so we don't stick on a key that no longer exists.
+  // toggling done, collapsing a section, etc.) so we don't stick on a key
+  // that no longer exists OR has been collapsed.
   useEffect(() => {
     setActiveSectionKey((prev) => {
-      if (prev && sections.some((s) => s.key === prev)) return prev;
-      return sections[0]?.key ?? null;
+      if (prev && trackableSectionKeys.has(prev)) return prev;
+      const firstVisible = sections.find((s) => trackableSectionKeys.has(s.key));
+      return firstVisible?.key ?? null;
     });
-  }, [sections]);
+  }, [sections, trackableSectionKeys]);
 
   // Scroll tracker — picks the LAST section whose top is at or above the
   // inner-scroll's viewport top. That's the section the user is currently
@@ -192,7 +227,11 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
   //  3. An IntersectionObserver on each section, which fires whenever a
   //     section's intersection with the inner-scroll viewport changes —
   //     catches anything the scroll events might miss.
-  const sectionKeysHash = sections.map((s) => s.key).join(",");
+  // Hash also includes trackable keys so collapse/expand re-runs the
+  // recalc effect (the scroll listeners need fresh `trackableSectionKeys`
+  // in their closure).
+  const sectionKeysHash = sections.map((s) => s.key).join(",") +
+    "|" + Array.from(trackableSectionKeys).sort().join(",");
   useEffect(() => {
     const el = sectionsScrollRef.current;
     if (!el || sections.length === 0) return;
@@ -204,11 +243,16 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
         const sectionEls = el.querySelectorAll<HTMLElement>("[data-section-key]");
         if (sectionEls.length === 0) return;
         const scrollTop = el.getBoundingClientRect().top;
-        let activeKey: string | null = sections[0]?.key ?? null;
+        // Default to the first TRACKABLE section — never let a collapsed
+        // section become the chrome active section (no items to scroll past).
+        const firstTrackable = sections.find((s) => trackableSectionKeys.has(s.key));
+        let activeKey: string | null = firstTrackable?.key ?? null;
         for (const sectionEl of sectionEls) {
+          const key = sectionEl.dataset.sectionKey;
+          if (!key || !trackableSectionKeys.has(key)) continue;
           const t = sectionEl.getBoundingClientRect().top;
           if (t <= scrollTop + 1) {
-            activeKey = sectionEl.dataset.sectionKey ?? activeKey;
+            activeKey = key;
           } else {
             break;
           }
@@ -327,10 +371,11 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
       reconnectPendingSourceId={reconnectPendingSourceId}
       onInstallUpdate={installUpdate}
       hiddenHeaderKey={activeSectionKey}
+      collapsibleSections={collapsibleSections}
       header={<ThingsEmptyState activeFilter={activeFilter} hasThingsElsewhere allCompleted inline lists={lists} onAddTask={handleAddTask} onAddContent={handleAddContent} />}
     />
   ) : (
-    <ThingsList things={filteredThings} lists={lists} onItemClick={onItemClick} onToggle={handleToggle} onAdd={handleAddTask} onAddContent={handleQuickAddContent} onTriageOpen={onTriageOpen} onFocusChange={onFocusChange} activeFilter={activeFilter} bare onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={installUpdate} hiddenHeaderKey={activeSectionKey} />
+    <ThingsList things={filteredThings} lists={lists} onItemClick={onItemClick} onToggle={handleToggle} onAdd={handleAddTask} onAddContent={handleQuickAddContent} onTriageOpen={onTriageOpen} onFocusChange={onFocusChange} activeFilter={activeFilter} bare onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={installUpdate} hiddenHeaderKey={activeSectionKey} collapsibleSections={collapsibleSections} />
   );
 
   return (

--- a/apps/desktop/src/views/TodayView.tsx
+++ b/apps/desktop/src/views/TodayView.tsx
@@ -25,11 +25,14 @@ import { usePreference } from "../api/preferences";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
 import { useTodayKey } from "../hooks/useTodayKey";
 import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
+import { useTonightExpansion } from "../lib/useTonightAutoExpand";
 
-/** Section keys that render as collapsibles (default collapsed) on Today.
+/** Section keys that render as collapsibles on Today. `tonight` is
+ *  collapsible too but its open-state comes from `useTonightExpansion` (6pm
+ *  auto-open with sticky per-day override) instead of localStorage.
  *  Overdue + Today stay always-expanded — they're the badge bucket and the
  *  reason the user opened the view. */
-const COLLAPSIBLE_SECTION_KEYS = new Set(["this-week", "this-weekend", "done-today"]);
+const COLLAPSIBLE_SECTION_KEYS = new Set(["tonight", "this-week", "this-weekend", "done-today"]);
 
 interface TodayViewProps {
   lists: NavList[];
@@ -137,9 +140,13 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
   const grouped = useMemo(() => {
     const uncompleted = filteredThings.filter((t) => !t.isCompleted);
     const done = filteredThings.filter((t) => t.isCompleted);
+    const todayAll = uncompleted.filter((t) => t.urgency === "today");
     return {
       overdue: uncompleted.filter((t) => t.urgency === "overdue"),
-      today: uncompleted.filter((t) => t.urgency === "today"),
+      // Split today-day items: tonight render in their own section but
+      // remain "today" tasks semantically (badge, urgency, etc.).
+      today: todayAll.filter((t) => !t.tonight),
+      tonight: todayAll.filter((t) => t.tonight),
       thisWeek: uncompleted.filter((t) => t.urgency === "this_week"),
       thisWeekend: uncompleted.filter((t) => t.urgency === "this_weekend"),
       done,
@@ -152,6 +159,7 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
     const list: Array<{ key: string; title: string; count: number }> = [];
     if (grouped.overdue.length > 0) list.push({ key: "overdue", title: "Overdue", count: grouped.overdue.length });
     if (grouped.today.length > 0) list.push({ key: "today", title: "Today", count: grouped.today.length });
+    if (grouped.tonight.length > 0) list.push({ key: "tonight", title: "Tonight", count: grouped.tonight.length });
     const weekend = grouped.thisWeekend.length > 0
       ? { key: "this-weekend", title: "This Weekend", count: grouped.thisWeekend.length }
       : null;
@@ -178,11 +186,17 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
   const [thisWeekendOpen, setThisWeekendOpen] = useLocalStorageBoolean("today.section.this-weekend.open", false);
   const [doneTodayOpen, setDoneTodayOpen] = useLocalStorageBoolean("today.section.done-today.open", false);
 
+  // Tonight section's open/closed state: 6pm auto-expand with sticky user
+  // override (per-date). Only meaningful on Today since custom-list and
+  // Upcoming views don't surface Tonight as a separate section.
+  const [tonightOpen, setTonightOpen] = useTonightExpansion();
+
   const collapsibleSections = useMemo(() => ({
+    "tonight": { open: tonightOpen, onOpenChange: setTonightOpen },
     "this-week": { open: thisWeekOpen, onOpenChange: setThisWeekOpen },
     "this-weekend": { open: thisWeekendOpen, onOpenChange: setThisWeekendOpen },
     "done-today": { open: doneTodayOpen, onOpenChange: setDoneTodayOpen },
-  }), [thisWeekOpen, setThisWeekOpen, thisWeekendOpen, setThisWeekendOpen, doneTodayOpen, setDoneTodayOpen]);
+  }), [tonightOpen, setTonightOpen, thisWeekOpen, setThisWeekOpen, thisWeekendOpen, setThisWeekendOpen, doneTodayOpen, setDoneTodayOpen]);
 
   // For the chrome active-section header above the inner scroll: a collapsed
   // section has no items to scroll past, so it must never become the active

--- a/apps/ios/Brett/Models/Item+Fields.swift
+++ b/apps/ios/Brett/Models/Item+Fields.swift
@@ -35,6 +35,7 @@ extension Item: MutableFieldModel {
         case contentImageUrl
         case contentFavicon
         case contentDomain
+        case tonight
     }
 
     /// Every case is mutable from the client today. If we ever mark a field
@@ -64,6 +65,7 @@ extension Item: MutableFieldModel {
         case .contentImageUrl: return contentImageUrl
         case .contentFavicon: return contentFavicon
         case .contentDomain: return contentDomain
+        case .tonight: return tonight
         }
     }
 
@@ -94,6 +96,14 @@ extension Item: MutableFieldModel {
         case .contentImageUrl: self.contentImageUrl = v as? String
         case .contentFavicon: self.contentFavicon = v as? String
         case .contentDomain: self.contentDomain = v as? String
+        case .tonight:
+            // Bool field — accept Bool wire values; clear-on-null collapses
+            // to false (the schema default), matching the API behavior.
+            if let b = v as? Bool {
+                self.tonight = b
+            } else if value is NSNull || v == nil {
+                self.tonight = false
+            }
         }
     }
 }

--- a/apps/ios/Brett/Models/Item.swift
+++ b/apps/ios/Brett/Models/Item.swift
@@ -29,6 +29,11 @@ final class Item {
     var brettObservation: String?
     var brettTakeGeneratedAt: Date?
 
+    /// Evening hint: a today-day task that should surface in the "Tonight"
+    /// section of the Today view. Stored on the server; default `false` so
+    /// older clients that don't know the field still produce valid items.
+    var tonight: Bool = false
+
     // MARK: - Content (link / article / etc.)
     var contentType: String?
     var contentStatus: String?
@@ -121,6 +126,7 @@ extension Item: Codable {
         case recurrenceRule
         case brettObservation
         case brettTakeGeneratedAt
+        case tonight
         case contentType
         case contentStatus
         case contentTitle
@@ -181,6 +187,9 @@ extension Item: Codable {
         self.recurrenceRule = try container.decodeIfPresent(String.self, forKey: .recurrenceRule)
         self.brettObservation = try container.decodeIfPresent(String.self, forKey: .brettObservation)
         self.brettTakeGeneratedAt = try container.decodeIfPresent(Date.self, forKey: .brettTakeGeneratedAt)
+        // Older API responses may omit `tonight`; default to false so the
+        // model still decodes cleanly.
+        self.tonight = try container.decodeIfPresent(Bool.self, forKey: .tonight) ?? false
         self.contentType = try container.decodeIfPresent(String.self, forKey: .contentType)
         self.contentStatus = try container.decodeIfPresent(String.self, forKey: .contentStatus)
         self.contentTitle = try container.decodeIfPresent(String.self, forKey: .contentTitle)
@@ -217,6 +226,7 @@ extension Item: Codable {
         try container.encode(recurrenceRule, forKey: .recurrenceRule)
         try container.encode(brettObservation, forKey: .brettObservation)
         try container.encode(brettTakeGeneratedAt, forKey: .brettTakeGeneratedAt)
+        try container.encode(tonight, forKey: .tonight)
         try container.encode(contentType, forKey: .contentType)
         try container.encode(contentStatus, forKey: .contentStatus)
         try container.encode(contentTitle, forKey: .contentTitle)

--- a/apps/ios/Brett/Networking/Endpoints/ThingsEndpoints.swift
+++ b/apps/ios/Brett/Networking/Endpoints/ThingsEndpoints.swift
@@ -77,4 +77,31 @@ extension APIClient {
             method: "DELETE"
         )
     }
+
+    // MARK: - Broken connections
+
+    /// One entry per active re-link task. `accountId` is null for legacy
+    /// single-account integrations (today only "ai"); Granola + Google
+    /// Calendar entries always carry the specific accountId that broke so
+    /// Settings can tint the matching card.
+    struct BrokenConnectionDetail: Decodable, Hashable, Sendable {
+        let type: String
+        let accountId: String?
+        let reason: String?
+        let brokenSince: String
+    }
+
+    struct BrokenConnectionsResponse: Decodable {
+        let count: Int
+        let types: [String]
+        let details: [BrokenConnectionDetail]
+    }
+
+    func fetchBrokenConnections() async throws -> BrokenConnectionsResponse {
+        try await request(
+            BrokenConnectionsResponse.self,
+            path: "/things/broken-connections",
+            method: "GET"
+        )
+    }
 }

--- a/apps/ios/Brett/Stores/BrokenConnectionsStore.swift
+++ b/apps/ios/Brett/Stores/BrokenConnectionsStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Observation
+
+/// Observable façade over `GET /things/broken-connections`.
+///
+/// The server returns one entry per active re-link task, including the
+/// connection type, the specific `accountId` that broke (when applicable),
+/// a human-readable reason, and the timestamp the prompt was first raised.
+/// Settings views consume this to render inline warning chrome on the
+/// account card that actually needs attention — so a user with two Granola
+/// accounts (one healthy, one revoked) sees the warning only on the broken
+/// card.
+///
+/// Not part of sync-pull: re-link tasks live on the server side and the
+/// list is short-lived (one entry per broken account). Re-fetched on view
+/// appear; if a future SSE event signals reconnection we can refresh more
+/// aggressively.
+@MainActor
+@Observable
+final class BrokenConnectionsStore: Clearable {
+    private(set) var details: [APIClient.BrokenConnectionDetail] = []
+    private(set) var isLoading: Bool = false
+    private(set) var lastError: String?
+
+    private let api: APIClient
+
+    init(api: APIClient = .shared) {
+        self.api = api
+        ClearableStoreRegistry.register(self)
+    }
+
+    // MARK: - Clearable
+
+    func clearForSignOut() {
+        details = []
+        isLoading = false
+        lastError = nil
+    }
+
+    // MARK: - Fetch
+
+    func refresh() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let response = try await api.fetchBrokenConnections()
+            details = response.details
+            lastError = nil
+        } catch {
+            // Soft-fail: an empty list lets the UI render the healthy state.
+            // Surfacing an error banner on Settings for a transient network
+            // blip would be more noise than signal.
+            lastError = "Couldn't check connection health."
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the broken-connection detail for a specific account if its
+    /// re-link prompt is active, otherwise nil. Callers use this to decide
+    /// whether to render warning chrome on a card.
+    func brokenDetail(
+        type: String,
+        accountId: String
+    ) -> APIClient.BrokenConnectionDetail? {
+        details.first(where: { $0.type == type && $0.accountId == accountId })
+    }
+}

--- a/apps/ios/Brett/Views/List/ListView.swift
+++ b/apps/ios/Brett/Views/List/ListView.swift
@@ -214,7 +214,7 @@ private struct ListViewBody: View {
                                             // `.taskDetail` is a sheet case.
                                             NavStore.shared.go(to: .taskDetail(id: item.id))
                                         },
-                                        onSchedule: { dueDate, precision in schedule(item.id, dueDate: dueDate, precision: precision) },
+                                        onSchedule: { dueDate, precision, tonight in schedule(item.id, dueDate: dueDate, precision: precision, tonight: tonight) },
                                         onArchive: { archive(item.id) },
                                         onDelete: { delete(item.id) },
                                         onReorder: { newOrder in reorder(newOrder) }
@@ -348,19 +348,24 @@ private struct ListViewBody: View {
     /// Pre-edit row comes from this view's `@Query`-backed `items` array,
     /// which is already user-scoped — no need for a separate store fetch
     /// (those public read methods were removed in Wave B).
-    private func schedule(_ id: String, dueDate: Date?, precision: DueDatePrecision) {
+    private func schedule(_ id: String, dueDate: Date?, precision: DueDatePrecision, tonight: Bool) {
         guard let item = items.first(where: { $0.id == id }) else { return }
         HapticManager.medium()
         let newPrecision: Any? = dueDate == nil ? nil : precision.rawValue
+        // Clearing the date also clears tonight — no evening hint without
+        // a due date.
+        let newTonight: Bool = dueDate == nil ? false : tonight
         itemStore.update(
             id: id,
             changes: [
                 "dueDate": dueDate as Any? ?? NSNull(),
                 "dueDatePrecision": newPrecision ?? NSNull(),
+                "tonight": newTonight,
             ],
             previousValues: [
                 "dueDate": item.dueDate as Any? ?? NSNull(),
                 "dueDatePrecision": item.dueDatePrecision as Any? ?? NSNull(),
+                "tonight": item.tonight,
             ],
             userId: userId
         )

--- a/apps/ios/Brett/Views/Settings/CalendarSettingsView.swift
+++ b/apps/ios/Brett/Views/Settings/CalendarSettingsView.swift
@@ -21,20 +21,28 @@ import AuthenticationServices
 ///   renders a page that calls `window.close()`, which the auth session
 ///   also interprets as completion.
 struct CalendarSettingsView: View {
+    /// Shared between the Google + Granola sections so we make a single
+    /// `/things/broken-connections` request when the view appears. Both
+    /// sections render warning chrome from the same source of truth.
+    @State private var brokenConnections = BrokenConnectionsStore()
+
     var body: some View {
         BrettSettingsScroll {
-            GoogleCalendarSection()
-            GranolaIntegrationSection()
+            GoogleCalendarSection(brokenConnections: brokenConnections)
+            GranolaIntegrationSection(brokenConnections: brokenConnections)
         }
         .navigationTitle("Calendar")
         .navigationBarTitleDisplayMode(.large)
         .toolbarBackground(.hidden, for: .navigationBar)
+        .task { await brokenConnections.refresh() }
     }
 }
 
 // MARK: - Google Calendar section
 
 private struct GoogleCalendarSection: View {
+    let brokenConnections: BrokenConnectionsStore
+
     @State private var store = CalendarAccountsStore()
     @State private var isConnecting = false
     @State private var errorMessage: String?
@@ -81,7 +89,15 @@ private struct GoogleCalendarSection: View {
             }
 
             ForEach(store.accounts) { account in
+                let broken = brokenConnections.brokenDetail(
+                    type: "google-calendar",
+                    accountId: account.id
+                )
                 BrettSettingsSection(account.googleEmail) {
+                    if let broken {
+                        AccountWarningRow(detail: broken)
+                        BrettSettingsDivider()
+                    }
                     accountHeaderRow(account)
 
                     BrettSettingsDivider()
@@ -339,6 +355,8 @@ private struct GoogleCalendarSection: View {
 // MARK: - Granola integration section
 
 private struct GranolaIntegrationSection: View {
+    let brokenConnections: BrokenConnectionsStore
+
     @State private var granolaStatus: GranolaAuthStatus?
     @State private var isGranolaLoading = false
     @State private var isConnectingGranola = false
@@ -471,6 +489,15 @@ private struct GranolaIntegrationSection: View {
     @ViewBuilder
     private func granolaAccountRows(_ account: GranolaAccount) -> some View {
         let isDisconnecting = disconnectingAccountId == account.id
+        let broken = brokenConnections.brokenDetail(
+            type: "granola",
+            accountId: account.id
+        )
+
+        if let broken {
+            AccountWarningRow(detail: broken)
+            BrettSettingsDivider()
+        }
 
         // Row 1 — identity + last sync.
         // No per-card Reconnect button: it would open generic OAuth without a
@@ -708,6 +735,43 @@ private struct GranolaIntegrationSection: View {
             granolaStatus = GranolaAuthStatus(connected: true, accounts: previousAccounts)
             granolaErrorMessage = "Couldn't update preference. Please try again."
         }
+    }
+}
+
+// MARK: - Account warning row
+
+/// Inline warning chrome rendered at the top of a Settings account card
+/// when the server has an active re-link task for that specific account.
+///
+/// Matches the row padding (14h / 12v) of every other row inside a
+/// `BrettSettingsCard` so it sits flush with the divider above the
+/// existing identity row. Uses system orange + SF Symbols to stay native
+/// on iOS — desktop uses amber for the same role; both clients carry the
+/// same content (title + reason).
+private struct AccountWarningRow: View {
+    let detail: APIClient.BrokenConnectionDetail
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.system(size: 14, weight: .semibold))
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Needs reconnection")
+                    .font(BrettTypography.taskTitle)
+                    .foregroundStyle(.orange)
+                if let reason = detail.reason, !reason.isEmpty {
+                    Text(reason)
+                        .font(BrettTypography.taskMeta)
+                        .foregroundStyle(.orange.opacity(0.75))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
     }
 }
 

--- a/apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
+++ b/apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
@@ -14,6 +14,7 @@ import SwiftUI
 /// don't have desktop equivalents and don't need parity.
 enum QuickScheduleOption: String, CaseIterable, Identifiable {
     case today
+    case tonight
     case tomorrow
     case thisWeekend
     case thisWeek
@@ -28,6 +29,7 @@ enum QuickScheduleOption: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .today: return "Today"
+        case .tonight: return "Tonight"
         case .tomorrow: return "Tomorrow"
         case .thisWeekend: return "This Weekend"
         case .thisWeek: return "This Week"
@@ -42,6 +44,7 @@ enum QuickScheduleOption: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .today: return "sun.max.fill"
+        case .tonight: return "moon.stars.fill"
         case .tomorrow: return "sunrise.fill"
         case .thisWeekend: return "calendar"
         case .thisWeek: return "calendar.badge.clock"
@@ -51,6 +54,12 @@ enum QuickScheduleOption: String, CaseIterable, Identifiable {
         case .someday: return "moon.stars.fill"
         case .pickDate: return "calendar.badge.plus"
         }
+    }
+
+    /// True if picking this option should set `tonight=true` on the item.
+    /// Every other option implicitly clears the flag — see `handle(_:)`.
+    var setsTonight: Bool {
+        self == .tonight
     }
 
     /// True if this option should render with the muted (non-gold) tint.
@@ -85,6 +94,12 @@ enum QuickScheduleOption: String, CaseIterable, Identifiable {
 
         switch self {
         case .today:
+            return anchorAt(0)
+        case .tonight:
+            // Same calendar day as today — `tonight` is a presentation hint
+            // (Tonight section, 6pm auto-expand on desktop). The dueDate
+            // matches `today` exactly so existing date-based logic (urgency,
+            // bucketing) continues to behave correctly.
             return anchorAt(0)
         case .tomorrow:
             return anchorAt(1)
@@ -141,7 +156,12 @@ struct QuickScheduleSheet: View {
     /// Both `date` and `precision` are required so the caller can persist
     /// the picker's intent exactly. Week-precision presets stored as
     /// `.day` silently bucketize into the weekend.
-    let onConfirm: (_ date: Date?, _ precision: DueDatePrecision) -> Void
+    ///
+    /// `tonight` is `true` only when the user picked the Tonight chip.
+    /// Every other commit path (other presets, raw calendar pick, Someday)
+    /// passes `false`, which is the correct behavior — it clears any
+    /// previously set tonight flag when the user retriages the item.
+    let onConfirm: (_ date: Date?, _ precision: DueDatePrecision, _ tonight: Bool) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var showsDatePicker: Bool = false
@@ -151,7 +171,7 @@ struct QuickScheduleSheet: View {
     /// the desktop chip picker exactly so the two clients feel like the
     /// same product. iOS-only options come last.
     private static let presets: [QuickScheduleOption] = [
-        .today, .tomorrow, .thisWeekend, .thisWeek, .nextWeek, .nextMonth,
+        .today, .tonight, .tomorrow, .thisWeekend, .thisWeek, .nextWeek, .nextMonth,
         .inAMonth, .someday, .pickDate,
     ]
 
@@ -199,7 +219,10 @@ struct QuickScheduleSheet: View {
                                 // of the user's local date — see the storage
                                 // convention in `DateHelpers.utcMidnightOfLocalDate`.
                                 let stored = DateHelpers.utcMidnightOfLocalDate(pickedDate, in: .current)
-                                onConfirm(stored, .day)
+                                // Raw calendar picks always clear tonight — the
+                                // chip is the only Tonight entry point. Re-triaging
+                                // via the calendar drops the evening hint.
+                                onConfirm(stored, .day, false)
                                 dismiss()
                             } label: {
                                 Text("Confirm")
@@ -245,7 +268,7 @@ struct QuickScheduleSheet: View {
             return
         }
         HapticManager.medium()
-        onConfirm(option.resolvedDate(), option.precision)
+        onConfirm(option.resolvedDate(), option.precision, option.setsTonight)
         dismiss()
     }
 

--- a/apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
+++ b/apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
@@ -51,7 +51,7 @@ enum QuickScheduleOption: String, CaseIterable, Identifiable {
         case .nextWeek: return "forward.fill"
         case .nextMonth: return "calendar"
         case .inAMonth: return "calendar.badge.clock"
-        case .someday: return "moon.stars.fill"
+        case .someday: return "moon.zzz.fill"
         case .pickDate: return "calendar.badge.plus"
         }
     }

--- a/apps/ios/Brett/Views/Shared/TaskRow.swift
+++ b/apps/ios/Brett/Views/Shared/TaskRow.swift
@@ -38,7 +38,7 @@ struct TaskRow: View {
     /// is `.day` for Today/Tomorrow/This Weekend/Next Month/raw calendar
     /// picks and `.week` for This Week / Next Week — pass it through to
     /// the mutation so week-precision picks don't bucketize as weekend.
-    private let onSchedule: (_ dueDate: Date?, _ precision: DueDatePrecision) -> Void
+    private let onSchedule: (_ dueDate: Date?, _ precision: DueDatePrecision, _ tonight: Bool) -> Void
     private let onArchive: () -> Void
     private let onDelete: () -> Void
 
@@ -65,7 +65,7 @@ struct TaskRow: View {
         dragIDs: [String] = [],
         onToggle: @escaping () -> Void,
         onSelect: @escaping () -> Void,
-        onSchedule: @escaping (_ dueDate: Date?, _ precision: DueDatePrecision) -> Void = { _, _ in },
+        onSchedule: @escaping (_ dueDate: Date?, _ precision: DueDatePrecision, _ tonight: Bool) -> Void = { _, _, _ in },
         onArchive: @escaping () -> Void = {},
         onDelete: @escaping () -> Void = {},
         onReorder: @escaping (_ newOrder: [String]) -> Void = { _ in }
@@ -116,14 +116,16 @@ struct TaskRow: View {
             .applyIf(allowSwipeRight) { view in
                 view.swipeActions(edge: .leading, allowsFullSwipe: true) {
                     Button {
-                        apply(dueDate: QuickScheduleOption.today.resolvedDate(), precision: .day)
+                        // Swipe-right "Today" clears any prior tonight flag,
+                        // matching every other non-Tonight commit path.
+                        apply(dueDate: QuickScheduleOption.today.resolvedDate(), precision: .day, tonight: false)
                     } label: {
                         Label("Today", systemImage: "sun.max.fill")
                     }
                     .tint(BrettColors.gold)
 
                     Button {
-                        apply(dueDate: QuickScheduleOption.tomorrow.resolvedDate(), precision: .day)
+                        apply(dueDate: QuickScheduleOption.tomorrow.resolvedDate(), precision: .day, tonight: false)
                     } label: {
                         Label("Tomorrow", systemImage: "sunrise.fill")
                     }
@@ -164,8 +166,8 @@ struct TaskRow: View {
                 )
             }
             .sheet(isPresented: $showsScheduleSheet) {
-                QuickScheduleSheet { date, precision in
-                    apply(dueDate: date, precision: precision)
+                QuickScheduleSheet { date, precision, tonight in
+                    apply(dueDate: date, precision: precision, tonight: tonight)
                 }
             }
     }
@@ -370,10 +372,10 @@ struct TaskRow: View {
     /// trigger the gold pulse, and dispatch to the caller. `precision` is
     /// always supplied — week-precision picks (This Week / Next Week)
     /// must round-trip as `.week` or they bucketize as the weekend.
-    private func apply(dueDate: Date?, precision: DueDatePrecision) {
+    private func apply(dueDate: Date?, precision: DueDatePrecision, tonight: Bool) {
         HapticManager.medium()
         pulseTrigger &+= 1
-        onSchedule(dueDate, precision)
+        onSchedule(dueDate, precision, tonight)
     }
 
     /// VoiceOver label — built from the `ViewModel` so the announced whisper

--- a/apps/ios/Brett/Views/Today/TaskSection.swift
+++ b/apps/ios/Brett/Views/Today/TaskSection.swift
@@ -16,7 +16,7 @@ struct TaskSection: View {
     // Swipe handlers — default no-ops so existing callers keep working.
     // Today page wires these to ItemStore so swipe-to-schedule/archive/delete
     // actually persist through the sync engine.
-    var onSchedule: ((String, Date?, DueDatePrecision) -> Void)? = nil
+    var onSchedule: ((String, Date?, DueDatePrecision, Bool) -> Void)? = nil
     var onArchive: ((String) -> Void)? = nil
     var onDelete: ((String) -> Void)? = nil
     // Drag-to-reorder inputs. When absent, drag is disabled on rows in this
@@ -184,7 +184,7 @@ struct TaskSection: View {
             dragIDs: reorderIDs,
             onToggle: { onToggle(item.id) },
             onSelect: { onSelect?(item.id) },
-            onSchedule: { dueDate, precision in onSchedule?(item.id, dueDate, precision) },
+            onSchedule: { dueDate, precision, tonight in onSchedule?(item.id, dueDate, precision, tonight) },
             onArchive: { onArchive?(item.id) },
             onDelete: { onDelete?(item.id) },
             onReorder: { newOrder in onReorder?(newOrder) }

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -386,6 +386,25 @@ private struct TodayPageBody: View {
             onDelete: delete
         )
 
+        // Tonight: today-day items the user flagged via the Tonight chip.
+        // Hidden entirely when empty (no "Tonight (0)" header). Always
+        // expanded on iOS — the spec's 6pm auto-expand is desktop-only
+        // because iOS sections don't support a collapsed state today.
+        if !s.tonight.isEmpty {
+            TaskSection(
+                label: "Tonight",
+                icon: "moon.stars",
+                items: s.tonight,
+                labelColor: .white,
+                listNameProvider: nameProvider,
+                onToggle: toggle,
+                onSelect: select,
+                onSchedule: schedule,
+                onArchive: archive,
+                onDelete: delete
+            )
+        }
+
         // Chronological ordering: weekend first on Sat/Sun, week first on
         // Mon-Fri. Mirrors the same rule on desktop's ThingsList +
         // TodayView. The two TaskSection calls are identical aside from

--- a/apps/ios/Brett/Views/Today/TodayPage.swift
+++ b/apps/ios/Brett/Views/Today/TodayPage.swift
@@ -581,22 +581,28 @@ private struct TodayPageBody: View {
     /// The pre-edit row comes from this view's `@Query`-backed `items`
     /// array, which is already user-scoped — no need for a separate store
     /// fetch (those public read methods were removed in Wave B).
-    private func schedule(_ id: String, dueDate: Date?, precision: DueDatePrecision) {
+    private func schedule(_ id: String, dueDate: Date?, precision: DueDatePrecision, tonight: Bool) {
         guard let item = items.first(where: { $0.id == id }) else { return }
         HapticManager.medium()
-        // Persist both dueDate and dueDatePrecision in a single mutation so
-        // a week-precision pick (This Week / Next Week) doesn't get bucketed
-        // as the weekend by the day-precision branch of computeUrgency.
+        // Persist dueDate + dueDatePrecision + tonight in a single mutation
+        // so a week-precision pick (This Week / Next Week) doesn't get
+        // bucketed as the weekend by the day-precision branch of
+        // computeUrgency, and so re-triaging clears any prior tonight flag.
         let newPrecision: Any? = dueDate == nil ? nil : precision.rawValue
+        // Clearing the date also clears tonight (no evening hint without a
+        // due date). Otherwise pass through whatever the picker reported.
+        let newTonight: Bool = dueDate == nil ? false : tonight
         itemStore.update(
             id: id,
             changes: [
                 "dueDate": dueDate as Any? ?? NSNull(),
                 "dueDatePrecision": newPrecision ?? NSNull(),
+                "tonight": newTonight,
             ],
             previousValues: [
                 "dueDate": item.dueDate as Any? ?? NSNull(),
                 "dueDatePrecision": item.dueDatePrecision as Any? ?? NSNull(),
+                "tonight": item.tonight,
             ],
             userId: userId
         )

--- a/apps/ios/Brett/Views/Today/TodaySections.swift
+++ b/apps/ios/Brett/Views/Today/TodaySections.swift
@@ -27,28 +27,24 @@ struct TodaySections {
 
     /// Count shown on the iOS home-screen badge and the macOS dock badge.
     ///
-    /// Inclusion rules (must stay in lockstep with desktop's `App.tsx`
-    /// `badgeCount`):
-    ///   - Always: overdue + today + thisWeek
-    ///   - On Sat/Sun: + thisWeekend (the weekend has arrived)
+    /// Inclusion rules (kept narrow on purpose — must stay in lockstep
+    /// with desktop's `apps/desktop/src/lib/badgeCount.ts`):
+    ///   - overdue + today only
+    ///   - Tonight items count as today (they live in the today bucket
+    ///     via dueDate = today; the `tonight` flag only affects
+    ///     sectioning, not counting)
     ///
-    /// Weekend items deliberately stay out of the badge on weekdays —
-    /// a Saturday task shouldn't nag the user on Tuesday — but roll in
-    /// once the weekend itself arrives.
+    /// History: before 2026-05-18 this also added `thisWeek` (and, on
+    /// Sat/Sun, `thisWeekend`). That made the badge noisy during the
+    /// workweek and conflated "due today" with "due eventually". Spec:
+    /// docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md.
     static func badgeCount(
         items: [Item],
         now: Date = Date(),
         localCalendar: Calendar = .current
     ) -> Int {
         let s = bucket(items: items, reflowKey: 0, now: now, localCalendar: localCalendar)
-        // "Weekend now" is decided from the user's LOCAL day-of-week, not
-        // UTC's. Friday 9:43 PM MT is still Friday for the badge.
-        let weekday = localCalendar.component(.weekday, from: now) // Sun=1..Sat=7
-        let isWeekend = weekday == 1 || weekday == 7
-        return s.overdue.count
-            + s.today.count
-            + s.thisWeek.count
-            + (isWeekend ? s.thisWeekend.count : 0)
+        return s.overdue.count + s.today.count
     }
 
     /// UTC calendar — used for reading calendar-date components of stored

--- a/apps/ios/Brett/Views/Today/TodaySections.swift
+++ b/apps/ios/Brett/Views/Today/TodaySections.swift
@@ -12,13 +12,17 @@ import Foundation
 struct TodaySections {
     let overdue: [Item]
     let today: [Item]
+    /// Subset of today-day items where `tonight == true`. Split out for
+    /// presentation only — they remain "today" tasks semantically, just
+    /// rendered under a separate header in the Today view.
+    let tonight: [Item]
     let thisWeek: [Item]
     let thisWeekend: [Item]
     let nextWeek: [Item]
     let doneToday: [Item]
 
     var activeCount: Int {
-        overdue.count + today.count + thisWeek.count + thisWeekend.count + nextWeek.count
+        overdue.count + today.count + tonight.count + thisWeek.count + thisWeekend.count + nextWeek.count
     }
 
     var hasDoneToday: Bool { !doneToday.isEmpty }
@@ -44,7 +48,9 @@ struct TodaySections {
         localCalendar: Calendar = .current
     ) -> Int {
         let s = bucket(items: items, reflowKey: 0, now: now, localCalendar: localCalendar)
-        return s.overdue.count + s.today.count
+        // Tonight items are today-day items split out for presentation;
+        // they still count as "today" for the badge.
+        return s.overdue.count + s.today.count + s.tonight.count
     }
 
     /// UTC calendar — used for reading calendar-date components of stored
@@ -114,6 +120,7 @@ struct TodaySections {
 
         var overdue: [Item] = []
         var today: [Item] = []
+        var tonight: [Item] = []
         var thisWeek: [Item] = []
         var thisWeekend: [Item] = []
         var nextWeek: [Item] = []
@@ -142,7 +149,14 @@ struct TodaySections {
 
             let diff = DateHelpers.utcCalendar.dateComponents([.day], from: startOfToday, to: due).day ?? 0
             if diff == 0 {
-                today.append(item)
+                // Split today-day items: tonight==true items render under the
+                // Tonight header instead of Today, but still count as a "today"
+                // task everywhere else (badge, urgency math, etc.).
+                if item.tonight {
+                    tonight.append(item)
+                } else {
+                    today.append(item)
+                }
                 continue
             }
             let dueWeekday = DateHelpers.utcCalendar.component(.weekday, from: due)
@@ -172,6 +186,7 @@ struct TodaySections {
         return TodaySections(
             overdue: overdue.sorted(by: activeSort),
             today: today.sorted(by: activeSort),
+            tonight: tonight.sorted(by: activeSort),
             thisWeek: thisWeek.sorted(by: activeSort),
             thisWeekend: thisWeekend.sorted(by: activeSort),
             nextWeek: nextWeek.sorted(by: activeSort),
@@ -257,6 +272,10 @@ final class TodaySectionsCache {
             hasher.combine(item.status)
             hasher.combine(item.dueDate)
             hasher.combine(item.completedAt)
+            // Tonight flag flips an item between the Today and Tonight buckets
+            // without changing its dueDate — must participate in the cache key
+            // or toggling tonight on a today-day item won't reflow.
+            hasher.combine(item.tonight)
         }
         return hasher.finalize()
     }

--- a/apps/ios/BrettTests/Views/QuickScheduleTests.swift
+++ b/apps/ios/BrettTests/Views/QuickScheduleTests.swift
@@ -52,6 +52,33 @@ struct QuickScheduleTests {
         #expect(comps.hour == 0 && comps.minute == 0 && comps.second == 0)
     }
 
+    // MARK: - Tonight
+
+    @Test("Tonight resolves to the same date as Today")
+    func tonightIsSameDayAsToday() {
+        let now = tuesdayAnchor()
+        let today = QuickScheduleOption.today.resolvedDate(now: now, calendar: calendar)!
+        let tonight = QuickScheduleOption.tonight.resolvedDate(now: now, calendar: calendar)!
+        // Tonight is a presentation hint, not a different day — selecting it
+        // must store the same dueDate as Today so urgency math, badges, and
+        // bucketing all keep treating it as a today-day task.
+        #expect(tonight == today)
+    }
+
+    @Test("Only the Tonight chip sets the tonight flag; every other preset clears it")
+    func tonightFlagIsExclusive() {
+        // Spot-check: only `tonight` should advertise setsTonight=true.
+        // Every other preset must report false so re-triaging a Tonight item
+        // through any other chip drops the flag.
+        for option in QuickScheduleOption.allCases {
+            if option == .tonight {
+                #expect(option.setsTonight, "Tonight option should set tonight=true")
+            } else {
+                #expect(!option.setsTonight, "\(option.rawValue) must not set tonight=true")
+            }
+        }
+    }
+
     // MARK: - Tomorrow
 
     @Test("Tomorrow is now + 1 day, at start of day")

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -5,10 +5,15 @@ import Testing
 /// Tests for `TodaySections.badgeCount(items:now:)` — the number that
 /// drives the iOS home-screen badge.
 ///
-/// Rules under test:
-///   - Always: overdue + today + thisWeek
-///   - On Sat/Sun only: + thisWeekend (weekend items roll in once it IS
-///     the weekend)
+/// Rules under test (2026-05-18 tuning spec — must stay in lockstep with
+/// desktop's `apps/desktop/src/lib/badgeCount.ts`):
+///   - Always: overdue + today only
+///   - Tonight items count as today (they have dueDate = today; the
+///     `tonight` flag only affects sectioning, not counting)
+///
+/// History: before 2026-05-18 the badge also included `thisWeek` (and, on
+/// weekends, `thisWeekend`). The `excludesThisWeek*` / `excludesWeekend*`
+/// tests guard against regressing back to that.
 ///
 /// Anchored on fixed dates (Wednesday + Saturday) to make assertions
 /// time-independent. Calendar is forced to UTC so date arithmetic agrees
@@ -66,21 +71,21 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 1)
     }
 
-    @Test func countsThisWeekOnWeekday() {
-        // Thu/Fri from Wed → thisWeek bucket → counted.
+    @Test func excludesThisWeekOnWeekday() {
+        // Regression guard: before 2026-05-18 the badge included thisWeek
+        // items. The spec narrowed it to overdue + today only.
         let thursday = days(1, from: Self.wednesdayNow)
         let friday = days(2, from: Self.wednesdayNow)
         let items = [
             TestFixtures.makeItem(status: .active, dueDate: thursday),
             TestFixtures.makeItem(status: .active, dueDate: friday),
         ]
-        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 2)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
     @Test func excludesThisWeekendOnWeekday() {
-        // The key new rule: Saturday and Sunday do NOT count toward the
-        // badge while today is a weekday. Sat/Sun from Wed land in
-        // `thisWeekend`, which is excluded until the weekend arrives.
+        // Sat/Sun from Wed land in `thisWeekend`, which is now excluded
+        // from the badge unconditionally.
         let saturday = days(3, from: Self.wednesdayNow)
         let sunday = days(4, from: Self.wednesdayNow)
         let items = [
@@ -90,15 +95,17 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
-    @Test func includesThisWeekendOnSaturday() {
-        // Same Sat/Sun items, now evaluated on Saturday — they should
-        // count toward the badge ("until it IS the weekend").
+    @Test func excludesThisWeekendEvenOnSaturday() {
+        // Critical regression guard: before 2026-05-18, weekend items DID
+        // count once Saturday arrived. The new spec drops that — weekend
+        // items only count once they're overdue or today. Sunday-from-
+        // Saturday lands in `thisWeekend`, not `today`, so it stays out.
         let sunday = days(1, from: Self.saturdayNow)
         let items = [
-            TestFixtures.makeItem(status: .active, dueDate: Self.saturdayNow), // today urgency
-            TestFixtures.makeItem(status: .active, dueDate: sunday),            // thisWeekend
+            TestFixtures.makeItem(status: .active, dueDate: Self.saturdayNow), // today ✓
+            TestFixtures.makeItem(status: .active, dueDate: sunday),            // thisWeekend ✗
         ]
-        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow, localCalendar: calendar) == 2)
+        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow, localCalendar: calendar) == 1)
     }
 
     @Test func excludesNextWeek() {
@@ -151,13 +158,13 @@ struct TodaySectionsBadgeTests {
         let items = [
             TestFixtures.makeItem(status: .active,  dueDate: yesterday),         // overdue ✓
             TestFixtures.makeItem(status: .active,  dueDate: Self.wednesdayNow), // today ✓
-            TestFixtures.makeItem(status: .active,  dueDate: thursday),          // thisWeek ✓
-            TestFixtures.makeItem(status: .active,  dueDate: saturday),          // thisWeekend ✗ (weekday)
+            TestFixtures.makeItem(status: .active,  dueDate: thursday),          // thisWeek ✗
+            TestFixtures.makeItem(status: .active,  dueDate: saturday),          // thisWeekend ✗
             TestFixtures.makeItem(status: .active,  dueDate: nextThursday),      // nextWeek ✗
             TestFixtures.makeItem(status: .done,    dueDate: Self.wednesdayNow), // ✗
             TestFixtures.makeItem(status: .snoozed, dueDate: yesterday),         // ✗
             TestFixtures.makeItem(status: .active,  dueDate: nil),               // ✗
         ]
-        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 3)
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 2)
     }
 }

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -150,20 +150,17 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
-    // MARK: - Spec-named regression guards (2026-05-18 brett-tuning plan, Task A2)
+    // MARK: - Spec-named regression guards (2026-05-18 brett-tuning plan)
     //
     // These tests intentionally duplicate behavior already covered above. The
-    // 2026-05-18 plan named three regression guards by exact identifier
-    // (`narrowsToTodayOnly`, `excludesWeekendOnWeekend`, `countsTonight`) so
-    // future reviewers grepping the plan can find them without trawling the
-    // broader suite. Don't fold them back in — the explicit names are the
-    // point.
+    // plan named these regression guards by exact identifier so future
+    // reviewers grepping the plan can find them without trawling the broader
+    // suite. Don't fold them back in — the explicit names are the point.
 
     @Test func narrowsToTodayOnly() {
-        // The badge counts overdue + today and NOTHING ELSE. Plan §A2 spec:
-        // "overdue + today only". This is the canonical assertion — if you
-        // add a new bucket to TodaySections, this test must keep passing
-        // unchanged.
+        // The badge counts overdue + today (+ tonight, which is a today-day
+        // item with a presentation hint) and NOTHING ELSE. If you add a new
+        // bucket to TodaySections, this test must keep passing unchanged.
         let yesterday = days(-1, from: Self.wednesdayNow)
         let thursday = days(1, from: Self.wednesdayNow)         // thisWeek
         let saturday = days(3, from: Self.wednesdayNow)         // thisWeekend
@@ -189,21 +186,13 @@ struct TodaySectionsBadgeTests {
     }
 
     @Test func countsTonight() {
-        // Forward-looking stub for Phase B. "Tonight" items are items dated
-        // for today's end (dueDate = today). They live in the `today` bucket
-        // via dueDate; the `tonight` flag only affects sectioning, not
-        // counting. This branch doesn't yet have the `tonight` field on
-        // Item — when Phase B merges, replace the dueDate-only setup with
-        // a real tonight=true item and confirm the count is unchanged.
-        let today = Self.wednesdayNow
-        // Simulate the "tonight" shape we'll get post-Phase B: a today-dated
-        // item with no other distinguishing field. Adds to the badge today.
-        let items = [
-            TestFixtures.makeItem(status: .active, dueDate: today),
-        ]
-        // TODO(phase-b): once Item.tonight exists, set tonight=true here and
-        // re-confirm the count == 1 (tonight-flag must not change counting).
-        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 1)
+        // Tonight items are today-day tasks with a presentation hint. They
+        // render in their own section but must still count toward the badge —
+        // an evening task created mid-afternoon must not silently fall off
+        // the home-screen indicator.
+        let item = TestFixtures.makeItem(status: .active, dueDate: Self.wednesdayNow)
+        item.tonight = true
+        #expect(TodaySections.badgeCount(items: [item], now: Self.wednesdayNow, localCalendar: calendar) == 1)
     }
 
     @Test func sumsBucketsTogetherOnWeekday() {

--- a/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsBadgeTests.swift
@@ -150,6 +150,62 @@ struct TodaySectionsBadgeTests {
         #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 0)
     }
 
+    // MARK: - Spec-named regression guards (2026-05-18 brett-tuning plan, Task A2)
+    //
+    // These tests intentionally duplicate behavior already covered above. The
+    // 2026-05-18 plan named three regression guards by exact identifier
+    // (`narrowsToTodayOnly`, `excludesWeekendOnWeekend`, `countsTonight`) so
+    // future reviewers grepping the plan can find them without trawling the
+    // broader suite. Don't fold them back in — the explicit names are the
+    // point.
+
+    @Test func narrowsToTodayOnly() {
+        // The badge counts overdue + today and NOTHING ELSE. Plan §A2 spec:
+        // "overdue + today only". This is the canonical assertion — if you
+        // add a new bucket to TodaySections, this test must keep passing
+        // unchanged.
+        let yesterday = days(-1, from: Self.wednesdayNow)
+        let thursday = days(1, from: Self.wednesdayNow)         // thisWeek
+        let saturday = days(3, from: Self.wednesdayNow)         // thisWeekend
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: yesterday),         // overdue ✓
+            TestFixtures.makeItem(status: .active, dueDate: Self.wednesdayNow), // today ✓
+            TestFixtures.makeItem(status: .active, dueDate: thursday),          // ✗
+            TestFixtures.makeItem(status: .active, dueDate: saturday),          // ✗
+        ]
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 2)
+    }
+
+    @Test func excludesWeekendOnWeekend() {
+        // On Saturday, the upcoming Sunday is in the `thisWeekend` bucket and
+        // MUST NOT count toward the badge. Before 2026-05-18, the badge added
+        // `thisWeekend` on weekends — drop that, or the badge stays noisy
+        // through the weekend.
+        let sunday = days(1, from: Self.saturdayNow) // thisWeekend on Saturday
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: sunday),
+        ]
+        #expect(TodaySections.badgeCount(items: items, now: Self.saturdayNow, localCalendar: calendar) == 0)
+    }
+
+    @Test func countsTonight() {
+        // Forward-looking stub for Phase B. "Tonight" items are items dated
+        // for today's end (dueDate = today). They live in the `today` bucket
+        // via dueDate; the `tonight` flag only affects sectioning, not
+        // counting. This branch doesn't yet have the `tonight` field on
+        // Item — when Phase B merges, replace the dueDate-only setup with
+        // a real tonight=true item and confirm the count is unchanged.
+        let today = Self.wednesdayNow
+        // Simulate the "tonight" shape we'll get post-Phase B: a today-dated
+        // item with no other distinguishing field. Adds to the badge today.
+        let items = [
+            TestFixtures.makeItem(status: .active, dueDate: today),
+        ]
+        // TODO(phase-b): once Item.tonight exists, set tonight=true here and
+        // re-confirm the count == 1 (tonight-flag must not change counting).
+        #expect(TodaySections.badgeCount(items: items, now: Self.wednesdayNow, localCalendar: calendar) == 1)
+    }
+
     @Test func sumsBucketsTogetherOnWeekday() {
         let yesterday = days(-1, from: Self.wednesdayNow)
         let thursday = days(1, from: Self.wednesdayNow)

--- a/apps/ios/BrettTests/Views/TodaySectionsTests.swift
+++ b/apps/ios/BrettTests/Views/TodaySectionsTests.swift
@@ -58,6 +58,24 @@ struct TodaySectionsTests {
         #expect(sections.overdue.isEmpty)
     }
 
+    @Test func todayItemWithTonightFlagGoesToTonightBucket() throws {
+        // A today-day item with `tonight=true` must leave the Today bucket
+        // and land in the Tonight bucket. Splitting is presentation-only;
+        // both buckets together still feed the badge (covered separately
+        // in TodaySectionsBadgeTests). If this regresses, Tonight items
+        // appear twice or get hidden under Today's header.
+        let ctx = try makeContext()
+        let today = utcCalendar.startOfDay(for: Date()).addingTimeInterval(3600)
+        let item = itemDue(today)
+        item.tonight = true
+        ctx.insert(item)
+
+        let sections = TodaySections.bucket(items: [item], reflowKey: 0, localCalendar: utcCalendar)
+
+        #expect(sections.tonight.map(\.id) == [item.id])
+        #expect(sections.today.isEmpty)
+    }
+
     @Test func itemCompletedTodayGoesToDoneToday() throws {
         let ctx = try makeContext()
         let now = Date()

--- a/docs/superpowers/plans/2026-05-18-brett-tuning-may.md
+++ b/docs/superpowers/plans/2026-05-18-brett-tuning-may.md
@@ -1,0 +1,2034 @@
+# Brett Tuning May 2026 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship five focused tweaks across Today view, Tonight concept, and connection-health visibility — desktop + iOS where applicable.
+
+**Architecture:** Three independent PRs that can be built in parallel after PR B's schema migration deploys to API first.
+
+**Tech Stack:** TypeScript (Hono API, Vite/React desktop, shared packages), Swift/SwiftUI/SwiftData (iOS), Prisma (Postgres), Vitest + Swift Testing.
+
+**Spec:** [`docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md`](../specs/2026-05-18-brett-tuning-may-design.md).
+
+---
+
+## Survey results (from Explore agents)
+
+Critical findings the plan accommodates:
+
+- **Item 4 (granola second account) is likely a stale-client issue, not a code bug.** Multi-granola code is on `release` (commits `8f8511d`, `26c9c47`, `4cecd76`, `c153c75`, `7321937`). Desktop manifest dated 2026-05-19 confirms shipped. No code change planned — Phase C task 1 is a verification step.
+- **Item 5 has two halves.** Per-account scoped re-link resolution is already shipped (`resolveRelinkTaskForAccount` in `apps/api/src/lib/connection-health.ts`, regression-tested in `granola-auth.test.ts:122-180`). What is NOT shipped: per-account warning chrome inside Settings cards with the failure reason. Phase C builds that UI.
+- **No accordion primitive exists.** Phase A task 5 builds a small `CollapsibleSection` wrapper using `@radix-ui/react-collapsible` (or hand-rolled if dep absent — check first).
+- **No localStorage UI-state precedent.** Phase A task 4 introduces `useLocalStorageBoolean` in `apps/desktop/src/lib/` using the existing `userScopedStorage` helper at `apps/desktop/src/lib/userScopedStorage.ts`.
+
+---
+
+## File-structure overview
+
+### New files
+- `packages/ui/src/CollapsibleSection.tsx` — reusable accordion for Today sections.
+- `apps/desktop/src/lib/useLocalStorageBoolean.ts` — small hook for per-section collapse state.
+- `apps/desktop/src/lib/useTonightAutoExpand.ts` — 6pm auto-expand logic.
+- `apps/api/prisma/migrations/<timestamp>_add_item_tonight/migration.sql` — adds `tonight` column.
+
+### Modified files (high-traffic, by phase)
+- **Phase A:** `apps/desktop/src/App.tsx`, `apps/ios/Brett/Views/Today/TodaySections.swift`, `apps/desktop/src/views/TodayView.tsx`, `docs/superpowers/specs/2026-04-24-today-count-badge-design.md`.
+- **Phase B:** `apps/api/prisma/schema.prisma`, `apps/api/src/routes/sync.ts`, `packages/types/src/index.ts`, `packages/business/src/index.ts`, `packages/business/src/index.ts` (TriageDatePreset), `packages/ui/src/quickPicker/letters.ts`, `packages/ui/src/quickPicker/QuickDatePicker.tsx`, `apps/ios/Brett/Models/Item.swift`, `apps/ios/Brett/Models/Item+Fields.swift`, `apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift`, `apps/ios/Brett/Views/Today/TodaySections.swift`, `apps/ios/Brett/Views/Today/TodayPage.swift`, `apps/desktop/src/views/TodayView.tsx`.
+- **Phase C:** `apps/api/src/lib/connection-health.ts` (extend `BrokenConnectionsResponse`), `apps/api/src/routes/things.ts`, `apps/desktop/src/api/connection-health.ts`, `apps/desktop/src/settings/CalendarSection.tsx`, `apps/desktop/src/settings/AIProvidersSection.tsx` (if scope), `apps/ios/Brett/Views/Settings/CalendarSettingsView.swift`.
+
+---
+
+# PHASE A — Today view tuning (Items 1 + 2)
+
+**Single PR.** Touches desktop + iOS (badge only on iOS, no UI). Low risk; UI-only.
+
+## Task A1: Narrow desktop badge filter to overdue + today (drop "this week" and weekend logic)
+
+**Files:**
+- Modify: `apps/desktop/src/App.tsx:501-590`
+- Test: `apps/desktop/src/__tests__/badgeCount.test.ts` (new — check if any sibling tests exist; if not, create test directory)
+
+- [ ] **Step 1: Inspect current code at App.tsx:497-590**
+
+Read the surrounding area to see imports of `getEndOfWeekUTC` and the `useActiveThings` hook signature. Look for `getEndOfTodayUTC` — if it doesn't exist, we'll add it next to `getEndOfWeekUTC` (search for the file that defines `getEndOfWeekUTC`).
+
+- [ ] **Step 2: Add `getEndOfTodayUTC` helper if missing**
+
+```bash
+grep -rn "getEndOfWeekUTC" apps/desktop/src packages/ | head -10
+```
+
+Open the file where `getEndOfWeekUTC` is defined. Add (mirroring the existing helper signature exactly):
+
+```typescript
+export function getEndOfTodayUTC(now: Date): Date {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59, 999));
+  return d;
+}
+```
+
+If `getEndOfWeekUTC` uses a different time computation (local vs UTC midnight), match THAT pattern; do not invent a new one.
+
+- [ ] **Step 3: Write failing test for narrowed badge**
+
+If the project has no badge-count unit test on desktop, add one. Otherwise extend the existing one.
+
+```typescript
+// apps/desktop/src/__tests__/badgeCount.test.ts
+import { describe, it, expect } from "vitest";
+
+// Replicate the filter logic in a pure helper so we can test it. If the App.tsx
+// uses an inline filter, extract to a helper first (see Step 4).
+import { computeBadgeCount } from "../lib/badgeCount";
+
+const today = new Date("2026-05-18T12:00:00Z");
+
+describe("computeBadgeCount", () => {
+  it("counts overdue items", () => {
+    const items = [{ dueDate: "2026-05-17T12:00:00Z", isCompleted: false, urgency: "overdue" }];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("counts today items", () => {
+    const items = [{ dueDate: "2026-05-18T18:00:00Z", isCompleted: false, urgency: "today" }];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("counts tonight items as today", () => {
+    const items = [{ dueDate: "2026-05-18T23:00:00Z", isCompleted: false, urgency: "today", tonight: true }];
+    expect(computeBadgeCount(items, today)).toBe(1);
+  });
+
+  it("excludes this_week items", () => {
+    const items = [{ dueDate: "2026-05-20T12:00:00Z", isCompleted: false, urgency: "this_week" }];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+
+  it("excludes this_weekend items even on a weekend", () => {
+    const items = [{ dueDate: "2026-05-23T12:00:00Z", isCompleted: false, urgency: "this_weekend" }];
+    // Note: today=2026-05-23 if we want to test weekend; just make sure weekend items don't count
+    const saturday = new Date("2026-05-23T12:00:00Z");
+    const weekendItem = [{ dueDate: "2026-05-24T12:00:00Z", isCompleted: false, urgency: "this_weekend" }];
+    expect(computeBadgeCount(weekendItem, saturday)).toBe(0);
+  });
+
+  it("excludes completed items", () => {
+    const items = [{ dueDate: "2026-05-18T18:00:00Z", isCompleted: true, urgency: "today" }];
+    expect(computeBadgeCount(items, today)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 4: Run test (should fail because helper does not exist yet)**
+
+```bash
+cd /Users/brentbarkman/code/brett && pnpm --filter @brett/desktop test badgeCount
+```
+
+Expected: FAIL (`computeBadgeCount` not exported / `../lib/badgeCount` not found).
+
+- [ ] **Step 5: Extract `computeBadgeCount` helper from App.tsx**
+
+Create `apps/desktop/src/lib/badgeCount.ts`:
+
+```typescript
+type BadgeInputThing = {
+  dueDate?: string | Date | null;
+  isCompleted?: boolean;
+  urgency?: string;
+};
+
+export function computeBadgeCount(things: BadgeInputThing[], now: Date = new Date()): number {
+  const endOfToday = new Date(Date.UTC(
+    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59, 999
+  ));
+  return things.filter((t) => {
+    if (t.isCompleted) return false;
+    if (!t.dueDate) return false;
+    return new Date(t.dueDate) <= endOfToday;
+  }).length;
+}
+```
+
+- [ ] **Step 6: Run test (should pass)**
+
+```bash
+cd /Users/brentbarkman/code/brett && pnpm --filter @brett/desktop test badgeCount
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Replace inline logic in App.tsx with the helper**
+
+In `apps/desktop/src/App.tsx`:
+
+Replace lines 522–528:
+```typescript
+const badgeCount = useMemo(() => {
+  if (!badgeUserId) return 0;
+  return computeBadgeCount(activeThingsForCount);
+}, [badgeUserId, activeThingsForCount]);
+```
+
+Add at top of file: `import { computeBadgeCount } from "./lib/badgeCount";`
+
+Remove the now-unused `isWeekendNow` variable and its dependencies if nothing else uses it (lines 518–521 area — verify with grep before deleting).
+
+`useActiveThings(endOfWeekISO)` still fetches a week's worth so the rest of the Today view has data; the badge just filters it down. Do NOT narrow the fetch itself.
+
+- [ ] **Step 8: Typecheck + test**
+
+```bash
+cd /Users/brentbarkman/code/brett && pnpm --filter @brett/desktop typecheck && pnpm --filter @brett/desktop test
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/App.tsx apps/desktop/src/lib/badgeCount.ts apps/desktop/src/__tests__/badgeCount.test.ts
+git commit -m "feat(desktop): narrow Today badge to overdue + today only
+
+Drops 'this week' and weekend logic from the dock + sidebar badge per the
+2026-05-18 tuning spec. Today + Overdue stay; Tonight is captured via dueDate
+filter. Extracts the filter into apps/desktop/src/lib/badgeCount.ts with unit
+tests."
+```
+
+---
+
+## Task A2: Narrow iOS badge filter to overdue + today
+
+**Files:**
+- Modify: `apps/ios/Brett/Views/Today/TodaySections.swift:38-52`
+- Test: `apps/ios/BrettTests/TodaySectionsTests.swift` (look for existing test file first; extend if present, create if not)
+
+- [ ] **Step 1: Locate existing TodaySections tests**
+
+```bash
+find apps/ios -name "*TodaySections*Tests.swift" -o -name "TodaySectionsTests*.swift"
+```
+
+If none exists, create `apps/ios/BrettTests/TodaySectionsTests.swift` with imports matching sibling test files in `apps/ios/BrettTests/`.
+
+- [ ] **Step 2: Write failing test**
+
+```swift
+import Testing
+@testable import Brett
+import Foundation
+
+@Suite("TodaySections.badgeCount")
+struct TodaySectionsBadgeTests {
+    func makeItem(dueDate: Date?, status: String = "active", tonight: Bool = false) -> Item {
+        let item = Item(
+            id: UUID().uuidString,
+            userId: "u1",
+            type: "task",
+            status: status,
+            title: "t",
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        item.dueDate = dueDate
+        // item.tonight = tonight  // uncomment once tonight property added in PR B
+        return item
+    }
+
+    @Test("counts overdue + today, excludes thisWeek and thisWeekend")
+    func narrowsToTodayOnly() throws {
+        let now = ISO8601DateFormatter().date(from: "2026-05-18T12:00:00Z")!
+        let cal = Calendar(identifier: .gregorian)
+        let overdueDate = cal.date(byAdding: .day, value: -1, to: now)!
+        let todayDate = now
+        let thisWeekDate = cal.date(byAdding: .day, value: 3, to: now)!
+        let items = [
+            makeItem(dueDate: overdueDate),
+            makeItem(dueDate: todayDate),
+            makeItem(dueDate: thisWeekDate),
+        ]
+        let count = TodaySections.badgeCount(items: items, now: now, localCalendar: cal)
+        #expect(count == 2)
+    }
+
+    @Test("excludes thisWeekend even on a weekend")
+    func excludesWeekendOnWeekend() throws {
+        let saturday = ISO8601DateFormatter().date(from: "2026-05-23T12:00:00Z")!
+        let cal = Calendar(identifier: .gregorian)
+        let weekendItem = makeItem(dueDate: cal.date(byAdding: .day, value: 1, to: saturday)!)
+        let count = TodaySections.badgeCount(items: [weekendItem], now: saturday, localCalendar: cal)
+        #expect(count == 0)
+    }
+}
+```
+
+- [ ] **Step 3: Run test (should fail)**
+
+In Xcode or via xcodebuild. The existing `badgeCount` adds weekend items on Sat/Sun → second test fails.
+
+```bash
+cd apps/ios && xcodebuild test -scheme Brett -destination "platform=iOS Simulator,name=iPhone 15" -only-testing:BrettTests/TodaySectionsBadgeTests 2>&1 | tail -30
+```
+
+- [ ] **Step 4: Narrow badgeCount in TodaySections.swift**
+
+Replace lines 38–52:
+
+```swift
+/// Inclusion rules (must stay in lockstep with desktop's badgeCount):
+/// Always: overdue + today.
+/// Tonight tasks are counted via the today bucket (they have dueDate = today).
+static func badgeCount(
+    items: [Item],
+    now: Date = Date(),
+    localCalendar: Calendar = .current
+) -> Int {
+    let s = bucket(items: items, reflowKey: 0, now: now, localCalendar: localCalendar)
+    return s.overdue.count + s.today.count
+}
+```
+
+- [ ] **Step 5: Run test (should pass)**
+
+Same xcodebuild command. Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ios/Brett/Views/Today/TodaySections.swift apps/ios/BrettTests/TodaySectionsTests.swift
+git commit -m "feat(ios): narrow Today badge to overdue + today only
+
+Mirrors desktop change in lockstep. Tonight items still count (they're in the
+today bucket via dueDate = today)."
+```
+
+---
+
+## Task A3: Update the badge spec doc to match new definition
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-24-today-count-badge-design.md`
+
+- [ ] **Step 1: Update the Count definition section**
+
+Edit the "## Count definition" section. Change `**overdue + due today + due this week**` to `**overdue + due today**` and update the desktop bullet (drop the weekend logic mention) and the iOS bullet (drop `+ s.thisWeek.count + (isWeekend ? s.thisWeekend.count : 0)`).
+
+Add a sentence: `Tonight items are counted as today (they have dueDate = today; the tonight flag only affects sectioning, not counting).`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-24-today-count-badge-design.md
+git commit -m "docs: update badge spec — narrow to overdue + today only
+
+Supersedes the original 'overdue + today + thisWeek + weekend (if weekend)'
+definition per the 2026-05-18 tuning spec."
+```
+
+---
+
+## Task A4: Build `useLocalStorageBoolean` hook (UI state persistence)
+
+**Files:**
+- Create: `apps/desktop/src/lib/useLocalStorageBoolean.ts`
+- Test: `apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts`
+
+- [ ] **Step 1: Look at existing userScopedStorage helper**
+
+Read `apps/desktop/src/lib/userScopedStorage.ts` to see the `scopedKey(base)` pattern and reuse it so UI state is per-user.
+
+- [ ] **Step 2: Write failing test**
+
+```typescript
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
+
+beforeEach(() => localStorage.clear());
+
+describe("useLocalStorageBoolean", () => {
+  it("returns default value when no key in storage", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("persists toggled value to localStorage", () => {
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+    expect(localStorage.getItem("brett:test.key")).toBe("true");
+  });
+
+  it("reads existing value on mount", () => {
+    localStorage.setItem("brett:test.key", "true");
+    const { result } = renderHook(() => useLocalStorageBoolean("test.key", false));
+    expect(result.current[0]).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run test (should fail — module not found)**
+
+```bash
+pnpm --filter @brett/desktop test useLocalStorageBoolean
+```
+
+- [ ] **Step 4: Implement the hook**
+
+```typescript
+// apps/desktop/src/lib/useLocalStorageBoolean.ts
+import { useCallback, useEffect, useState } from "react";
+
+const PREFIX = "brett:";
+
+function read(key: string, fallback: boolean): boolean {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(PREFIX + key);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useLocalStorageBoolean(
+  key: string,
+  fallback: boolean,
+): [boolean, (next: boolean) => void] {
+  const [value, setValue] = useState<boolean>(() => read(key, fallback));
+
+  useEffect(() => {
+    // Re-sync from storage if key changes (rare, but defensive).
+    setValue(read(key, fallback));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const update = useCallback((next: boolean) => {
+    setValue(next);
+    try {
+      window.localStorage.setItem(PREFIX + key, next ? "true" : "false");
+    } catch {
+      // localStorage unavailable — in-memory state still works.
+    }
+  }, [key]);
+
+  return [value, update];
+}
+```
+
+- [ ] **Step 5: Run test (should pass)**
+
+```bash
+pnpm --filter @brett/desktop test useLocalStorageBoolean
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/lib/useLocalStorageBoolean.ts apps/desktop/src/__tests__/useLocalStorageBoolean.test.ts
+git commit -m "feat(desktop): add useLocalStorageBoolean hook
+
+Small utility for per-feature UI state persistence (collapsed section
+state, etc.). Uses the brett: prefix consistent with existing localStorage
+usage in lib/backgroundLuminance.ts."
+```
+
+---
+
+## Task A5: Build `CollapsibleSection` UI component
+
+**Files:**
+- Create: `packages/ui/src/CollapsibleSection.tsx`
+
+- [ ] **Step 1: Check if @radix-ui/react-collapsible is already a dep**
+
+```bash
+grep -A1 "@radix-ui/react-collapsible" packages/ui/package.json apps/desktop/package.json
+```
+
+If absent, add it: `pnpm --filter @brett/ui add @radix-ui/react-collapsible`. (Many Radix primitives are already pulled via shadcn dependencies — likely present.)
+
+- [ ] **Step 2: Implement the component**
+
+```typescript
+// packages/ui/src/CollapsibleSection.tsx
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { ChevronDown } from "lucide-react";
+import { ReactNode } from "react";
+import { cn } from "./lib/utils";
+
+interface CollapsibleSectionProps {
+  title: string;
+  count?: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+  headerExtras?: ReactNode;
+  className?: string;
+}
+
+export function CollapsibleSection({
+  title,
+  count,
+  open,
+  onOpenChange,
+  children,
+  headerExtras,
+  className,
+}: CollapsibleSectionProps) {
+  return (
+    <Collapsible.Root open={open} onOpenChange={onOpenChange} className={className}>
+      <Collapsible.Trigger asChild>
+        <button
+          type="button"
+          className="group flex w-full items-center gap-2 py-2 text-left text-xs font-medium uppercase tracking-wider text-white/40 hover:text-white/60 transition-colors"
+          data-testid={`collapsible-${title.toLowerCase().replace(/\s+/g, "-")}`}
+        >
+          <ChevronDown
+            className={cn(
+              "h-3 w-3 transition-transform duration-200",
+              open ? "rotate-0" : "-rotate-90",
+            )}
+          />
+          <span>{title}</span>
+          {typeof count === "number" && count > 0 && (
+            <span className="ml-1 text-white/30">{count}</span>
+          )}
+          {headerExtras && <span className="ml-auto">{headerExtras}</span>}
+        </button>
+      </Collapsible.Trigger>
+      <Collapsible.Content
+        className={cn(
+          "overflow-hidden",
+          "data-[state=open]:animate-collapsible-down",
+          "data-[state=closed]:animate-collapsible-up",
+        )}
+      >
+        {children}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
+```
+
+Verify `cn` is exported from `packages/ui/src/lib/utils.ts` — otherwise inline the className concatenation. Look at `packages/ui/src/index.ts` to confirm the export pattern used by sibling components, then add `export * from "./CollapsibleSection";` if that's how the package exports.
+
+Check `tailwind.config.js` or equivalent for the animation classes `animate-collapsible-down`/`animate-collapsible-up`. If absent, either add them or omit the className entirely (the component will work without animation; not ideal but unblocked).
+
+- [ ] **Step 3: Verify chevron + header style matches existing section headers**
+
+Open `apps/desktop/src/views/TodayView.tsx` line 403 area where `SectionHeader` lives. The text color, weight, tracking should match. If different, update the CollapsibleSection styles to mirror it exactly so the visual treatment is consistent for collapsible vs non-collapsible sections.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/CollapsibleSection.tsx packages/ui/src/index.ts
+git commit -m "feat(ui): add CollapsibleSection accordion primitive
+
+Wraps Radix Collapsible with the Today view's section-header styling and a
+chevron. Used for default-collapsed sections like This Week / This Weekend /
+Done Today."
+```
+
+---
+
+## Task A6: Wire collapsible sections into TodayView
+
+**Files:**
+- Modify: `apps/desktop/src/views/TodayView.tsx`
+
+- [ ] **Step 1: Identify the JSX that renders each section**
+
+Read TodayView.tsx around the `sections.map(...)` JSX. The current pattern renders `<SectionHeader ... />` followed by the items list.
+
+- [ ] **Step 2: Define which sections collapse**
+
+At the top of TodayView (or in `sections` building loop), add:
+
+```typescript
+const COLLAPSIBLE_SECTION_KEYS = new Set(["this-week", "this-weekend", "done-today"]);
+```
+
+- [ ] **Step 3: Wire `useLocalStorageBoolean` per collapsible section**
+
+```typescript
+const [thisWeekOpen, setThisWeekOpen] = useLocalStorageBoolean("today.section.this-week.open", false);
+const [thisWeekendOpen, setThisWeekendOpen] = useLocalStorageBoolean("today.section.this-weekend.open", false);
+const [doneTodayOpen, setDoneTodayOpen] = useLocalStorageBoolean("today.section.done-today.open", false);
+
+const openMap: Record<string, { open: boolean; set: (v: boolean) => void }> = {
+  "this-week": { open: thisWeekOpen, set: setThisWeekOpen },
+  "this-weekend": { open: thisWeekendOpen, set: setThisWeekendOpen },
+  "done-today": { open: doneTodayOpen, set: setDoneTodayOpen },
+};
+```
+
+Import the hook: `import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";`
+
+- [ ] **Step 4: Render collapsible vs static sections**
+
+In the sections render loop:
+
+```typescript
+{sections.map((section) => {
+  if (COLLAPSIBLE_SECTION_KEYS.has(section.key)) {
+    const state = openMap[section.key];
+    return (
+      <CollapsibleSection
+        key={section.key}
+        title={section.title}
+        count={section.count}
+        open={state.open}
+        onOpenChange={state.set}
+      >
+        {/* existing items render for this section */}
+      </CollapsibleSection>
+    );
+  }
+  return (
+    <div key={section.key}>
+      <SectionHeader title={section.title} count={section.count} />
+      {/* existing items render for this section */}
+    </div>
+  );
+})}
+```
+
+Refactor the actual section-content rendering into a helper so it's not duplicated. Example:
+
+```typescript
+const renderSectionItems = (key: string) => {
+  switch (key) {
+    case "overdue": return grouped.overdue.map(renderItem);
+    case "today": return grouped.today.map(renderItem);
+    case "this-week": return grouped.thisWeek.map(renderItem);
+    case "this-weekend": return grouped.thisWeekend.map(renderItem);
+    case "done-today": return grouped.done.map(renderItem);
+    default: return null;
+  }
+};
+```
+
+- [ ] **Step 5: Manual verification with preview tools**
+
+```bash
+# Start dev server if not running, then via preview_*:
+# 1. Load Today view with mixed sections
+# 2. Verify This Week / This Weekend / Done are collapsed by default
+# 3. Click to expand This Week → reload page → still expanded
+# 4. Verify count chip visible in collapsed state
+```
+
+Use the verification workflow from preview_tools instructions.
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+pnpm --filter @brett/desktop typecheck
+git add apps/desktop/src/views/TodayView.tsx
+git commit -m "feat(desktop): collapsible This Week / This Weekend / Done sections
+
+Default collapsed, state per-section in localStorage. Today and Overdue stay
+always-expanded. Count chip visible in collapsed state."
+```
+
+---
+
+## Task A7: Open Phase A PR
+
+- [ ] **Step 1: Push branch + open PR**
+
+```bash
+# Assuming worktree branch is already created by subagent-driven-development
+git push -u origin <branch-name>
+gh pr create --base main --title "feat: today view tuning — narrow badge + collapsible sections" --body "$(cat <<'EOF'
+## Summary
+- Narrow Today badge count to overdue + today only (drops This Week + weekend logic on both desktop + iOS)
+- Collapsible This Week / This Weekend / Done Today sections on desktop (default collapsed, localStorage per-section)
+
+Spec: docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md (items 1, 2)
+
+## Test plan
+- [ ] `pnpm --filter @brett/desktop typecheck`
+- [ ] `pnpm --filter @brett/desktop test`
+- [ ] `xcodebuild test -scheme Brett -only-testing:BrettTests/TodaySectionsBadgeTests`
+- [ ] Manual: collapse a section, reload, still collapsed
+- [ ] Manual: badge count drops by amount of This Week items
+EOF
+)"
+```
+
+---
+
+# PHASE B — Tonight (Item 3)
+
+**Single PR.** Schema migration, sync engine update, both platforms. Release order: API first (migration), then desktop + iOS clients.
+
+## Task B1: Add `tonight` field to Prisma schema + migration
+
+**Files:**
+- Modify: `apps/api/prisma/schema.prisma:146-195`
+- Create: `apps/api/prisma/migrations/<TIMESTAMP>_add_item_tonight/migration.sql`
+
+- [ ] **Step 1: Edit schema**
+
+In the `Item` model (line 146-195), add after `recurrenceRule String?`:
+
+```prisma
+  tonight          Boolean   @default(false)
+```
+
+- [ ] **Step 2: Create migration**
+
+```bash
+cd apps/api && pnpm prisma migrate dev --name add_item_tonight --create-only
+```
+
+Open the generated `migration.sql` and verify it contains exactly:
+
+```sql
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN "tonight" BOOLEAN NOT NULL DEFAULT false;
+```
+
+If Prisma generates additional cascading changes (it shouldn't — we only added one nullable-with-default column), fix the migration to be just the single ALTER.
+
+- [ ] **Step 3: Apply migration locally**
+
+```bash
+cd apps/api && pnpm prisma migrate dev
+```
+
+Should complete without prompting.
+
+- [ ] **Step 4: Verify Prisma client regenerates with `tonight` field**
+
+```bash
+cd apps/api && pnpm prisma generate
+# Then in a TS file:
+grep -rn "tonight" apps/api/node_modules/.prisma/client/index.d.ts | head -3
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/prisma/schema.prisma apps/api/prisma/migrations/
+git commit -m "feat(api): add Item.tonight boolean (default false)
+
+Additive non-null column with default. Single ALTER, no data movement. Older
+clients ignore the unknown field on pull; they cannot set it (which is correct
+fallback)."
+```
+
+---
+
+## Task B2: Add `tonight` to sync engine field whitelists
+
+**Files:**
+- Modify: `apps/api/src/routes/sync.ts:38-63`
+
+- [ ] **Step 1: Update MUTABLE_FIELDS and CREATABLE_FIELDS**
+
+In `apps/api/src/routes/sync.ts`:
+
+```typescript
+const MUTABLE_FIELDS: Record<PushableEntityType, readonly string[]> = {
+  item: ["title", "description", "notes", "status", "dueDate", "dueDatePrecision",
+         "completedAt", "snoozedUntil", "reminder", "recurrence", "recurrenceRule",
+         "listId", "brettObservation", "contentType", "contentStatus", "tonight"],
+  // ...
+};
+
+const CREATABLE_FIELDS: Record<PushableEntityType, readonly string[]> = {
+  item: [
+    "type", "source", "sourceId", "sourceUrl",
+    "title", "description", "notes",
+    "status", "dueDate", "dueDatePrecision", "completedAt", "snoozedUntil",
+    "reminder", "recurrence", "recurrenceRule",
+    "listId", "brettObservation",
+    "contentType", "contentStatus", "tonight",
+  ],
+  // ...
+};
+```
+
+- [ ] **Step 2: Write API test for tonight sync round-trip**
+
+Look for an existing `sync.test.ts` in `apps/api/src/__tests__/`. Extend it (or create new) with:
+
+```typescript
+import { describe, it, expect } from "vitest";
+// Import the test helpers used by sibling sync tests (createTestUser, callPush, callPull).
+
+describe("sync — tonight field", () => {
+  it("accepts tonight=true on item CREATE and returns it on pull", async () => {
+    const user = await createTestUser();
+    const push = await callPush(user, {
+      mutations: [{
+        id: "m1", entityType: "item", entityId: "i1", action: "create",
+        payload: { id: "i1", type: "task", title: "Pick up groceries", status: "active",
+                   dueDate: new Date().toISOString(), dueDatePrecision: "day", tonight: true },
+      }],
+    });
+    expect(push.results[0].status).toBe("ok");
+    const pull = await callPull(user, {});
+    const itemRow = pull.tables.item.upserted.find((r: any) => r.id === "i1");
+    expect(itemRow.tonight).toBe(true);
+  });
+
+  it("accepts tonight=true on item UPDATE with previousValues", async () => {
+    // (after CREATE) push UPDATE with changedFields=["tonight"], previousValues={tonight: false}
+    // expect ok + pull returns tonight=true
+  });
+
+  it("defaults tonight=false on existing rows pulled by older clients", async () => {
+    // create item without tonight — pull — expect tonight === false (not undefined)
+  });
+});
+```
+
+Mirror the exact helper/fixture patterns from existing sync tests rather than inventing new ones — check the imports + setup pattern of an existing sync test file before writing this.
+
+- [ ] **Step 3: Run test (should fail until step 1 ships if you ordered things differently — should pass now)**
+
+```bash
+cd apps/api && pnpm test -- sync
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/routes/sync.ts apps/api/src/__tests__/<sync test file>
+git commit -m "feat(api): allow Item.tonight in sync push/pull
+
+Adds tonight to MUTABLE_FIELDS + CREATABLE_FIELDS for item entity. Tests
+verify round-trip and default value for older clients."
+```
+
+---
+
+## Task B3: Add `tonight` to ItemRecord type
+
+**Files:**
+- Modify: `packages/types/src/index.ts:60-93`
+
+- [ ] **Step 1: Add field**
+
+In `ItemRecord` interface (lines 60-93), add after `recurrenceRule?: string | null;`:
+
+```typescript
+  tonight?: boolean;
+```
+
+Optional because older API responses may omit it; defaults to `false` semantically.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm --filter @brett/types typecheck
+pnpm typecheck  # full repo, since this type is shared
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/types/src/index.ts
+git commit -m "feat(types): add tonight?: boolean to ItemRecord"
+```
+
+---
+
+## Task B4: Update `itemToThing` to include tonight
+
+**Files:**
+- Modify: `packages/business/src/index.ts:305-352`
+
+- [ ] **Step 1: Find Thing interface in packages/types/src/index.ts:123 area, add `tonight?: boolean`**
+
+```typescript
+// in Thing interface (find via: grep -n "interface Thing" packages/types/src/index.ts)
+  tonight?: boolean;
+```
+
+- [ ] **Step 2: Add to itemToThing return**
+
+In `packages/business/src/index.ts`, find `itemToThing` and add `tonight: item.tonight ?? false` to the returned object.
+
+- [ ] **Step 3: Add TriageDatePreset entry**
+
+Find `TriageDatePreset` type (search `grep -n "TriageDatePreset" packages/business/src/index.ts`). Add `"tonight"` to the union.
+
+Add to `computeTriageResult` (also in packages/business): when preset is `"tonight"`, return `{ dueDate: <end of today UTC>, precision: "day", tonight: true }`. Verify the return type allows a `tonight` field — if not, extend the result type.
+
+```typescript
+// Existing pattern (illustrative, match actual code):
+case "today":
+  return { dueDate: endOfTodayISO(now), precision: "day", tonight: false };
+case "tonight":
+  return { dueDate: endOfTodayISO(now), precision: "day", tonight: true };
+case "tomorrow":
+  return { dueDate: endOfTomorrowISO(now), precision: "day", tonight: false };
+```
+
+Critical: every existing case must explicitly set `tonight: false` so that picking "Today" or "Tomorrow" CLEARS a previously-set tonight flag.
+
+- [ ] **Step 4: Update existing tests for computeTriageResult**
+
+`grep -rn "computeTriageResult" packages/business/src/__tests__ packages/business/src/` — extend tests to cover `tonight: true` behavior + clearing on other presets.
+
+- [ ] **Step 5: Run tests + commit**
+
+```bash
+pnpm --filter @brett/business test
+pnpm --filter @brett/business typecheck
+git add packages/types/src/index.ts packages/business/src/
+git commit -m "feat(business): add tonight to Thing + TriageDatePreset
+
+Selecting 'Tonight' sets dueDate=endOfToday + tonight=true. All other presets
+explicitly clear tonight=false."
+```
+
+---
+
+## Task B5: Add "Tonight" to desktop date picker
+
+**Files:**
+- Modify: `packages/ui/src/quickPicker/letters.ts:12-28`
+- Modify: `packages/ui/src/quickPicker/QuickDatePicker.tsx` (icon rendering, if needed)
+
+- [ ] **Step 1: Update DATE_PRESET_ORDER and labels**
+
+In `packages/ui/src/quickPicker/letters.ts`:
+
+```typescript
+export const DATE_PRESET_ORDER: TriageDatePreset[] = [
+  "today",
+  "tonight",
+  "tomorrow",
+  "this_weekend",
+  "this_week",
+  "next_week",
+  "next_month",
+];
+
+export const DATE_PRESET_LABELS: Record<TriageDatePreset, string> = {
+  today: "Today",
+  tonight: "Tonight",
+  tomorrow: "Tomorrow",
+  this_weekend: "This Weekend",
+  this_week: "This Week",
+  next_week: "Next Week",
+  next_month: "Next Month",
+};
+```
+
+Also check `DATE_LETTER_TO_PRESET` and `DATE_PRESET_TO_LETTER` maps — if they exist and use single-letter shortcuts, assign one for tonight. Suggested letter: `N` (T conflicts with Today/Tomorrow; M for "midnight" is taken if someone uses it).
+
+```typescript
+export const DATE_LETTER_TO_PRESET: Record<string, TriageDatePreset> = {
+  T: "today",
+  N: "tonight",  // 'N' for "night"
+  // ...
+};
+```
+
+- [ ] **Step 2: Verify chip renders correctly**
+
+Run desktop dev server, open the date picker (Omnibar or task detail), confirm "Tonight" chip appears between Today and Tomorrow.
+
+- [ ] **Step 3: Manual test**
+
+Use preview_* tools:
+1. Open Omnibar
+2. Type a task title
+3. Open date picker → click Tonight
+4. Verify task gets created with dueDate=today end + tonight flag
+
+(Confirming the flag stored requires looking at network panel for POST /sync/push payload.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/quickPicker/
+git commit -m "feat(ui): add Tonight chip to QuickDatePicker
+
+Slotted between Today and Tomorrow. Single-letter shortcut 'N' (for night).
+Selecting Tonight sets dueDate=today + tonight=true via computeTriageResult."
+```
+
+---
+
+## Task B6: Add `tonight` to iOS Item SwiftData model + Codable
+
+**Files:**
+- Modify: `apps/ios/Brett/Models/Item.swift:8-238`
+
+- [ ] **Step 1: Add property**
+
+After `var brettObservation: String?` (around line 29):
+
+```swift
+var tonight: Bool = false
+```
+
+- [ ] **Step 2: Add CodingKey**
+
+In `enum CodingKeys: String, CodingKey` (around line 102), add:
+
+```swift
+case tonight
+```
+
+- [ ] **Step 3: Add decode**
+
+In `init(from decoder: Decoder)` (line 143), add (before sync metadata section):
+
+```swift
+self.tonight = try container.decodeIfPresent(Bool.self, forKey: .tonight) ?? false
+```
+
+- [ ] **Step 4: Add encode**
+
+In `func encode(to encoder: Encoder)` (line 197), add:
+
+```swift
+try container.encode(tonight, forKey: .tonight)
+```
+
+- [ ] **Step 5: Build to confirm**
+
+```bash
+cd apps/ios && xcodebuild -scheme Brett -destination "platform=iOS Simulator,name=iPhone 15" build 2>&1 | tail -10
+```
+
+Should compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/ios/Brett/Models/Item.swift
+git commit -m "feat(ios): add tonight Bool to Item model + Codable"
+```
+
+---
+
+## Task B7: Add `tonight` to iOS Item+Fields
+
+**Files:**
+- Modify: `apps/ios/Brett/Models/Item+Fields.swift:15-98`
+
+- [ ] **Step 1: Add Field enum case**
+
+In `enum Field: String, CaseIterable` (lines 15-38), add:
+
+```swift
+case tonight
+```
+
+- [ ] **Step 2: Add to value(for:)**
+
+```swift
+case .tonight: return tonight
+```
+
+- [ ] **Step 3: Add to set(_:for:)**
+
+```swift
+case .tonight:
+    if let v = value as? Bool {
+        self.tonight = v
+    } else if value is NSNull {
+        self.tonight = false
+    }
+```
+
+- [ ] **Step 4: Build + commit**
+
+```bash
+xcodebuild -scheme Brett -destination "platform=iOS Simulator,name=iPhone 15" build 2>&1 | tail -5
+git add apps/ios/Brett/Models/Item+Fields.swift
+git commit -m "feat(ios): expose tonight via Item+Fields for mutation queue"
+```
+
+---
+
+## Task B8: Add Tonight bucket to iOS TodaySections
+
+**Files:**
+- Modify: `apps/ios/Brett/Views/Today/TodaySections.swift`
+
+- [ ] **Step 1: Add `tonight` to struct**
+
+```swift
+struct TodaySections {
+    let overdue: [Item]
+    let today: [Item]
+    let tonight: [Item]   // NEW — items with tonight==true && sameDay(dueDate, today) && status != done
+    let thisWeek: [Item]
+    let thisWeekend: [Item]
+    let nextWeek: [Item]
+    let doneToday: [Item]
+}
+```
+
+- [ ] **Step 2: Bucket tonight items**
+
+In `bucket(items:reflowKey:now:localCalendar:)`, split today items into today vs tonight:
+
+```swift
+// After existing 'today' bucketing, split:
+let tonightBucket = today.filter { $0.tonight }
+let todayBucket = today.filter { !$0.tonight }
+return TodaySections(
+    overdue: overdue,
+    today: todayBucket,
+    tonight: tonightBucket,
+    thisWeek: thisWeek,
+    thisWeekend: thisWeekend,
+    nextWeek: nextWeek,
+    doneToday: doneToday,
+)
+```
+
+Read the existing `bucket(...)` body first; the actual variable names will differ. The point is: tonight is a subset of today that's split out for display only — it still counts in the badge via `today.count + tonight.count` (see Step 3).
+
+- [ ] **Step 3: Update badgeCount to include tonight**
+
+```swift
+static func badgeCount(
+    items: [Item],
+    now: Date = Date(),
+    localCalendar: Calendar = .current
+) -> Int {
+    let s = bucket(items: items, reflowKey: 0, now: now, localCalendar: localCalendar)
+    return s.overdue.count + s.today.count + s.tonight.count
+}
+```
+
+Note: this restores tonight to the badge count after Phase A narrowed it. The narrowing dropped thisWeek + weekend; tonight is back because it's a today-day task with an evening hint.
+
+- [ ] **Step 4: Update badge tests**
+
+Add a test case:
+
+```swift
+@Test("counts tonight items in badge")
+func countsTonight() throws {
+    let now = ISO8601DateFormatter().date(from: "2026-05-18T12:00:00Z")!
+    let cal = Calendar(identifier: .gregorian)
+    let item = makeItem(dueDate: now)
+    item.tonight = true
+    let count = TodaySections.badgeCount(items: [item], now: now, localCalendar: cal)
+    #expect(count == 1)
+}
+```
+
+Also add a bucket test verifying tonight items leave the today bucket and land in tonight bucket.
+
+- [ ] **Step 5: Test + commit**
+
+```bash
+xcodebuild test -scheme Brett -destination "platform=iOS Simulator,name=iPhone 15" -only-testing:BrettTests/TodaySectionsBadgeTests 2>&1 | tail -10
+git add apps/ios/Brett/Views/Today/TodaySections.swift apps/ios/BrettTests/TodaySectionsTests.swift
+git commit -m "feat(ios): split today bucket into today + tonight
+
+Tonight items have tonight==true. Badge counts both. Tonight bucket renders as
+a separate section in TodayPage (next task)."
+```
+
+---
+
+## Task B9: Render Tonight section on iOS TodayPage
+
+**Files:**
+- Modify: `apps/ios/Brett/Views/Today/TodayPage.swift`
+
+- [ ] **Step 1: Add the section between Today and This Week**
+
+Read the existing section layout — find where the Today section header is rendered. Add Tonight section immediately after, with:
+
+```swift
+if !sections.tonight.isEmpty {
+    TaskSection(
+        title: "Tonight",
+        icon: "moon.stars",
+        items: sections.tonight,
+        // ... matching the other sections' init signature
+    )
+}
+```
+
+Hide entirely when empty (no "Tonight (0)" header).
+
+- [ ] **Step 2: Add 6pm auto-expand state**
+
+Use @AppStorage scoped by date for per-day user-toggle:
+
+```swift
+@AppStorage("today.tonight.userToggled.\(todayKey)") private var userToggledTonight: Bool = false
+@AppStorage("today.tonight.openState.\(todayKey)") private var userTonightOpenState: Bool = false
+
+private var todayKey: String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.string(from: Date())
+}
+
+private var tonightIsOpen: Bool {
+    if userToggledTonight { return userTonightOpenState }
+    let hour = Calendar.current.component(.hour, from: Date())
+    return hour >= 18
+}
+```
+
+Note: @AppStorage keys cannot be dynamic at the property-wrapper level (they're compile-time). The actual implementation uses `UserDefaults.standard` with the dated key, exposed via a small `TonightExpansionStore` (`apps/ios/Brett/Services/TonightExpansionStore.swift`). Build that helper:
+
+```swift
+// apps/ios/Brett/Services/TonightExpansionStore.swift
+import Foundation
+
+@Observable
+final class TonightExpansionStore {
+    static let shared = TonightExpansionStore()
+
+    private func dateKey() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    func isOpen() -> Bool {
+        let key = dateKey()
+        let toggledKey = "today.tonight.userToggled.\(key)"
+        let openKey = "today.tonight.openState.\(key)"
+        if UserDefaults.standard.bool(forKey: toggledKey) {
+            return UserDefaults.standard.bool(forKey: openKey)
+        }
+        let hour = Calendar.current.component(.hour, from: Date())
+        return hour >= 18
+    }
+
+    func setOpen(_ open: Bool) {
+        let key = dateKey()
+        UserDefaults.standard.set(true, forKey: "today.tonight.userToggled.\(key)")
+        UserDefaults.standard.set(open, forKey: "today.tonight.openState.\(key)")
+    }
+}
+```
+
+If `TaskSection` doesn't support a collapsed state, leave Tonight always-expanded on iOS (per the spec, iOS skipped collapse for non-Tonight sections). The 6pm auto-expand only matters if the user can collapse. **Decision:** iOS Tonight section is always expanded; iOS users see it appear at the right slot but cannot collapse it. The 6pm behavior is desktop-only. Skip the TonightExpansionStore entirely.
+
+Reasoning: spec says collapse is desktop-only. Tonight section being visible is fine since it's hidden when empty anyway.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/ios/Brett/Views/Today/TodayPage.swift
+git commit -m "feat(ios): render Tonight section after Today
+
+Hidden when empty. Always-expanded on iOS per spec (collapse is desktop-only).
+Section position: immediately after Today, before This Week."
+```
+
+---
+
+## Task B10: Add "Tonight" to iOS date picker
+
+**Files:**
+- Modify: `apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift:15-156`
+
+- [ ] **Step 1: Add enum case**
+
+```swift
+enum QuickScheduleOption: String, CaseIterable, Identifiable {
+    case today
+    case tonight     // NEW
+    case tomorrow
+    case thisWeekend
+    case thisWeek
+    case nextWeek
+    case nextMonth
+    case inAMonth
+    case someday
+    case pickDate
+    // ...
+}
+```
+
+- [ ] **Step 2: Add label + icon**
+
+```swift
+var label: String {
+    switch self {
+    case .today: return "Today"
+    case .tonight: return "Tonight"
+    case .tomorrow: return "Tomorrow"
+    // ...
+    }
+}
+
+var icon: String {
+    switch self {
+    case .today: return "sun.max"
+    case .tonight: return "moon.stars"
+    case .tomorrow: return "sunrise"
+    // ...
+    }
+}
+```
+
+(Match exact icon names from the existing cases — these are illustrative.)
+
+- [ ] **Step 3: Add resolvedDate logic**
+
+```swift
+func resolvedDate() -> Date? {
+    let calendar = Calendar.current
+    let now = Date()
+    switch self {
+    case .today: return calendar.endOfDay(for: now)
+    case .tonight: return calendar.endOfDay(for: now)
+    // ...
+    }
+}
+```
+
+- [ ] **Step 4: Add `var setsTonight: Bool` helper**
+
+```swift
+var setsTonight: Bool {
+    if case .tonight = self { return true }
+    return false
+}
+```
+
+- [ ] **Step 5: Wire setsTonight into the confirm action**
+
+In `handle(_:)`:
+
+```swift
+case .tonight:
+    onConfirm(option.resolvedDate(), option.precision, tonight: true)
+default:
+    onConfirm(option.resolvedDate(), option.precision, tonight: false)
+```
+
+Update the `onConfirm` closure signature throughout the iOS app to accept `tonight: Bool` (likely a callback type alias — grep for `onConfirm` callers). Every existing site passes `false`.
+
+- [ ] **Step 6: Update all callers to write `item.tonight`**
+
+Find callers of `onConfirm` that mutate Item. They must now also set `item.tonight = tonight`.
+
+- [ ] **Step 7: Build + commit**
+
+```bash
+xcodebuild -scheme Brett build 2>&1 | tail -5
+git add apps/ios/Brett/Views/Shared/QuickScheduleSheet.swift
+git commit -m "feat(ios): add Tonight chip to QuickScheduleSheet
+
+Slotted between Today and Tomorrow. Selecting Tonight sets tonight=true on
+the Item via expanded onConfirm callback. Other presets explicitly set
+tonight=false to clear the flag."
+```
+
+---
+
+## Task B11: Render Tonight section on desktop TodayView (with 6pm auto-expand)
+
+**Files:**
+- Modify: `apps/desktop/src/views/TodayView.tsx`
+- Create: `apps/desktop/src/lib/useTonightAutoExpand.ts`
+
+- [ ] **Step 1: Build auto-expand hook**
+
+```typescript
+// apps/desktop/src/lib/useTonightAutoExpand.ts
+import { useEffect, useState } from "react";
+
+const TOUCHED_KEY_PREFIX = "brett:today.tonight.userToggled.";
+const STATE_KEY_PREFIX = "brett:today.tonight.openState.";
+const EVENING_HOUR = 18;
+
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function computeDefault(): boolean {
+  return new Date().getHours() >= EVENING_HOUR;
+}
+
+export function useTonightExpansion(): [boolean, (open: boolean) => void] {
+  const [open, setOpenState] = useState<boolean>(() => {
+    const k = todayKey();
+    try {
+      if (window.localStorage.getItem(TOUCHED_KEY_PREFIX + k) === "true") {
+        return window.localStorage.getItem(STATE_KEY_PREFIX + k) === "true";
+      }
+    } catch {}
+    return computeDefault();
+  });
+
+  // Re-evaluate every minute so 6pm "tips over" without page reload.
+  useEffect(() => {
+    const id = setInterval(() => {
+      const k = todayKey();
+      try {
+        if (window.localStorage.getItem(TOUCHED_KEY_PREFIX + k) === "true") return; // user-controlled, leave alone
+      } catch {}
+      setOpenState(computeDefault());
+    }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const setOpen = (next: boolean) => {
+    const k = todayKey();
+    setOpenState(next);
+    try {
+      window.localStorage.setItem(TOUCHED_KEY_PREFIX + k, "true");
+      window.localStorage.setItem(STATE_KEY_PREFIX + k, next ? "true" : "false");
+    } catch {}
+  };
+
+  return [open, setOpen];
+}
+```
+
+- [ ] **Step 2: Write unit test for the hook**
+
+```typescript
+// apps/desktop/src/__tests__/useTonightAutoExpand.test.ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTonightExpansion } from "../lib/useTonightAutoExpand";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+describe("useTonightExpansion", () => {
+  it("defaults to closed before 6pm if untouched", () => {
+    vi.setSystemTime(new Date("2026-05-18T17:30:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("defaults to open at 6pm or later if untouched", () => {
+    vi.setSystemTime(new Date("2026-05-18T18:00:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("respects user collapse after 6pm", () => {
+    vi.setSystemTime(new Date("2026-05-18T20:00:00"));
+    const { result } = renderHook(() => useTonightExpansion());
+    expect(result.current[0]).toBe(true);
+    act(() => result.current[1](false));
+    expect(result.current[0]).toBe(false);
+    // Re-mount — should still be false
+    const { result: result2 } = renderHook(() => useTonightExpansion());
+    expect(result2.current[0]).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+pnpm --filter @brett/desktop test tonight
+```
+
+- [ ] **Step 4: Bucket tonight items in TodayView grouping**
+
+In TodayView.tsx, update `grouped`:
+
+```typescript
+const grouped = useMemo(() => {
+  const uncompleted = filteredThings.filter((t) => !t.isCompleted);
+  const done = filteredThings.filter((t) => t.isCompleted);
+  const todayAll = uncompleted.filter((t) => t.urgency === "today");
+  return {
+    overdue: uncompleted.filter((t) => t.urgency === "overdue"),
+    today: todayAll.filter((t) => !t.tonight),
+    tonight: todayAll.filter((t) => t.tonight),
+    thisWeek: uncompleted.filter((t) => t.urgency === "this_week"),
+    thisWeekend: uncompleted.filter((t) => t.urgency === "this_weekend"),
+    done,
+  };
+}, [filteredThings]);
+```
+
+- [ ] **Step 5: Add Tonight to sections list**
+
+In the sections useMemo:
+
+```typescript
+if (grouped.today.length > 0) list.push({ key: "today", title: "Today", count: grouped.today.length });
+if (grouped.tonight.length > 0) list.push({ key: "tonight", title: "Tonight", count: grouped.tonight.length });
+```
+
+Add Tonight to render switch in `renderSectionItems`:
+```typescript
+case "tonight": return grouped.tonight.map(renderItem);
+```
+
+- [ ] **Step 6: Make Tonight section collapsible via the hook**
+
+```typescript
+const [tonightOpen, setTonightOpen] = useTonightExpansion();
+
+// In the render loop:
+if (section.key === "tonight") {
+  return (
+    <CollapsibleSection
+      key={section.key}
+      title="Tonight"
+      count={section.count}
+      open={tonightOpen}
+      onOpenChange={setTonightOpen}
+    >
+      {renderSectionItems("tonight")}
+    </CollapsibleSection>
+  );
+}
+```
+
+Use a moon icon if `CollapsibleSection` supports a leading icon (extend the component if not — small change, add `icon?: ReactNode` prop).
+
+- [ ] **Step 7: Update badge to include tonight**
+
+In `apps/desktop/src/lib/badgeCount.ts`:
+
+```typescript
+type BadgeInputThing = {
+  dueDate?: string | Date | null;
+  isCompleted?: boolean;
+  urgency?: string;
+  tonight?: boolean;  // NEW — for documentation; logic doesn't depend on it
+};
+
+export function computeBadgeCount(things: BadgeInputThing[], now: Date = new Date()): number {
+  // ... unchanged — Tonight items have dueDate=today and naturally satisfy the filter
+}
+```
+
+No logic change needed — the filter already captures Tonight via dueDate. Update the type for clarity.
+
+Update unit test to verify Tonight items count:
+
+```typescript
+it("counts tonight items as today", () => {
+  const items = [{ dueDate: "2026-05-18T23:00:00Z", isCompleted: false, urgency: "today", tonight: true }];
+  expect(computeBadgeCount(items, new Date("2026-05-18T12:00:00Z"))).toBe(1);
+});
+```
+
+- [ ] **Step 8: Manual verification with preview tools**
+
+1. Create a task → set Tonight via chip → verify it appears in Tonight section.
+2. Before 6pm: section collapsed by default.
+3. Set system clock past 6pm (or mock): section auto-expands.
+4. Collapse manually after 6pm: stays collapsed.
+5. Badge count includes the tonight task.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/views/TodayView.tsx apps/desktop/src/lib/useTonightAutoExpand.ts apps/desktop/src/lib/badgeCount.ts apps/desktop/src/__tests__/
+git commit -m "feat(desktop): render Tonight section with 6pm auto-expand
+
+Tonight section appears between Today and This Week. Default-collapsed
+before 6pm local, auto-expands at 6pm. User collapse after 6pm sticks for
+the rest of the day via per-date localStorage key."
+```
+
+---
+
+## Task B12: Open Phase B PR
+
+- [ ] **Step 1: Push + open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --base main --title "feat: Tonight concept across desktop + iOS" --body "$(cat <<'EOF'
+## Summary
+- New Item.tonight boolean field — additive migration
+- Tonight chip in date pickers (desktop + iOS) — slotted between Today and Tomorrow
+- Tonight section in Today view — desktop has 6pm auto-expand, iOS shows when non-empty
+- Tonight items count in badge (they're today items with an evening hint)
+
+Spec: docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md (item 3)
+
+## Release notes
+- API must deploy first (migration) before desktop/iOS release. Older clients ignore the unknown field harmlessly.
+
+## Test plan
+- [ ] API: pnpm --filter @brett/api test (new sync round-trip tests)
+- [ ] pnpm typecheck (full repo)
+- [ ] xcodebuild test for TodaySections tests
+- [ ] Manual: create Tonight task on desktop, see it on iOS after pull, and vice versa
+- [ ] Manual: 6pm auto-expand on desktop (use system clock override)
+- [ ] Manual: badge count includes Tonight task
+EOF
+)"
+```
+
+---
+
+# PHASE C — Connection health visibility (Items 4 + 5)
+
+**Single PR.** Bulk of work is per-account warning chrome in Settings cards (5a). Item 4 + 5b are verification only.
+
+## Task C1: Verify multi-granola is live on user's clients
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Check release branch + manifest date**
+
+```bash
+git log release --oneline -- apps/desktop/src/settings/CalendarSection.tsx | head -3
+curl -sI https://api.brett.brentbarkman.com/releases/latest-mac.yml | grep -i last-modified
+```
+
+Multi-granola desktop commit (`4cecd76` 2026-05-16) should be on release. Manifest Last-Modified should be ≥ 2026-05-16. If both true, this is a stale-client issue.
+
+- [ ] **Step 2: Ask user to verify their desktop version**
+
+Add a note in the PR description: "Please check Settings → Updates → Current version. Should be 0.1.1537 or higher. If lower, autoupdate to latest and retry connecting a second Granola account."
+
+- [ ] **Step 3: If verified live and bug persists, escalate**
+
+If the user confirms latest version and still sees only one account, add an additional debugging task (out of scope of this plan). Likely API response is fine — render bug? Open Chrome DevTools, inspect `GET /granola/auth` response shape.
+
+---
+
+## Task C2: Backend — extend broken-connections endpoint with per-account details
+
+**Files:**
+- Modify: `apps/api/src/routes/things.ts:279-292`
+- Modify: `apps/api/src/lib/connection-health.ts` (if reason text isn't already captured)
+- Test: `apps/api/src/__tests__/connection-health.test.ts`
+
+- [ ] **Step 1: Inspect current endpoint shape**
+
+```bash
+sed -n '270,300p' apps/api/src/routes/things.ts
+```
+
+Currently returns `{ count, types }`. We need it to also return per-account details so the frontend can render reason text inside cards.
+
+- [ ] **Step 2: Define expanded response shape**
+
+In `apps/api/src/lib/connection-health.ts`, add:
+
+```typescript
+export interface BrokenConnectionDetail {
+  type: ConnectionType;            // "granola" | "google-calendar" | "ai"
+  accountId: string | null;        // null for AI providers (no per-account model yet)
+  reason: string | null;           // user-facing one-liner from the re-link task body
+  brokenSince: string;             // ISO timestamp of when the re-link task was created
+}
+
+export interface BrokenConnectionsResponse {
+  count: number;
+  types: string[];                 // backwards-compatible (existing UI consumes this)
+  details: BrokenConnectionDetail[];   // NEW
+}
+```
+
+- [ ] **Step 3: Implement aggregation**
+
+In `apps/api/src/lib/connection-health.ts`, add a function `getBrokenConnections(userId): Promise<BrokenConnectionsResponse>` that queries:
+
+```typescript
+const items = await prisma.item.findMany({
+  where: {
+    userId,
+    source: "system",
+    sourceId: { startsWith: "relink:" },
+    status: { in: ["active", "snoozed"] },
+  },
+  select: { sourceId: true, body: true, createdAt: true, description: true },
+});
+
+const details: BrokenConnectionDetail[] = items.map((item) => {
+  const parts = (item.sourceId ?? "").split(":");
+  // sourceId format: "relink:<type>" or "relink:<type>:<accountId>"
+  const type = (parts[1] ?? "") as ConnectionType;
+  const accountId = parts[2] ?? null;
+  // Reason: stored in body (preferred) or description fallback
+  const reason = item.body ?? item.description ?? null;
+  return {
+    type,
+    accountId,
+    reason,
+    brokenSince: item.createdAt.toISOString(),
+  };
+});
+
+const types = Array.from(new Set(details.map((d) => d.type)));
+return { count: details.length, types, details };
+```
+
+Note: `Item.body` does not exist in the schema (verified). Use `description` instead, OR add a new `Item.body` field — but that's out of scope. Use `description` for the reason text; the spec's "store in body" was a placeholder for "store in a human-readable field." `description` is the right field.
+
+- [ ] **Step 4: Write reason text when creating re-link tasks**
+
+Find where `createRelinkTask` is called (search: `grep -rn "createRelinkTask" apps/api/src`). The current call signature must already accept a reason — verify. If not, add a `reason` parameter and write it to `Item.description`.
+
+```typescript
+// example pattern in connection-health.ts
+export async function createRelinkTask(
+  userId: string,
+  type: ConnectionType,
+  accountId: string | null,
+  reason: string,   // NEW or already-existing parameter
+): Promise<void> {
+  const sourceId = accountId ? `relink:${type}:${accountId}` : `relink:${type}`;
+  await prisma.item.upsert({
+    where: { /* dedupe by source + sourceId + userId */ },
+    create: {
+      // ...
+      title: relinkTaskTitle(type, accountId),
+      description: reason,
+    },
+    update: { description: reason },  // refresh reason on each detection
+  });
+}
+```
+
+Wherever the function is called from (granola sync errors, calendar token-refresh errors), update the call site to pass a meaningful reason string:
+
+```typescript
+await createRelinkTask(userId, "granola", account.id,
+  `Authorization revoked — please reconnect ${account.email}`);
+```
+
+- [ ] **Step 5: Update the route handler**
+
+In `apps/api/src/routes/things.ts:279-292`:
+
+```typescript
+things.get("/broken-connections", async (c) => {
+  const user = c.get("user");
+  const result = await getBrokenConnections(user.id);
+  return c.json(result);
+});
+```
+
+- [ ] **Step 6: Update tests**
+
+In `apps/api/src/__tests__/connection-health.test.ts`, add tests:
+
+```typescript
+it("returns details with per-account reason and brokenSince", async () => {
+  const user = await createTestUser();
+  await createRelinkTask(user.id, "granola", "acc-1", "Token expired");
+  const res = await api.get(`/things/broken-connections`).set(auth(user));
+  expect(res.body.details).toEqual([
+    expect.objectContaining({
+      type: "granola",
+      accountId: "acc-1",
+      reason: "Token expired",
+      brokenSince: expect.any(String),
+    }),
+  ]);
+});
+```
+
+- [ ] **Step 7: Run tests + commit**
+
+```bash
+pnpm --filter @brett/api test connection-health
+git add apps/api/src/routes/things.ts apps/api/src/lib/connection-health.ts apps/api/src/__tests__/connection-health.test.ts
+git commit -m "feat(api): expose per-account details in /things/broken-connections
+
+Adds 'details' array to the response with per-account reason + brokenSince.
+Backward-compatible — existing 'count' and 'types' fields preserved. Reason
+text comes from Item.description (set by createRelinkTask call sites)."
+```
+
+---
+
+## Task C3: Desktop — per-account warning chrome in Settings cards
+
+**Files:**
+- Modify: `apps/desktop/src/api/connection-health.ts`
+- Modify: `apps/desktop/src/settings/CalendarSection.tsx`
+
+- [ ] **Step 1: Extend useBrokenConnections hook to return details**
+
+In `apps/desktop/src/api/connection-health.ts`:
+
+```typescript
+export interface BrokenConnectionDetail {
+  type: "granola" | "google-calendar" | "ai";
+  accountId: string | null;
+  reason: string | null;
+  brokenSince: string;
+}
+
+export interface BrokenConnectionsData {
+  count: number;
+  types: string[];
+  details: BrokenConnectionDetail[];
+}
+
+export function useBrokenConnections() {
+  return useQuery<BrokenConnectionsData>({
+    queryKey: ["broken-connections"],
+    queryFn: async () => {
+      const res = await api.get("/things/broken-connections");
+      return res.data;
+    },
+    refetchInterval: 60_000,
+  });
+}
+```
+
+(Match the existing hook style precisely — check the file before editing.)
+
+- [ ] **Step 2: Add helper for looking up a specific account's status**
+
+```typescript
+export function findBrokenDetailForAccount(
+  data: BrokenConnectionsData | undefined,
+  type: "granola" | "google-calendar",
+  accountId: string,
+): BrokenConnectionDetail | null {
+  if (!data) return null;
+  return data.details.find((d) => d.type === type && d.accountId === accountId) ?? null;
+}
+```
+
+- [ ] **Step 3: Add warning row inside Granola account cards**
+
+In `apps/desktop/src/settings/CalendarSection.tsx`, where each Granola account card renders (line ~362 area per the survey):
+
+```typescript
+const { data: brokenConnections } = useBrokenConnections();
+
+// inside the .map() that renders each account:
+{granolaData.accounts.map((account) => {
+  const broken = findBrokenDetailForAccount(brokenConnections, "granola", account.id);
+  return (
+    <div
+      key={account.id}
+      className={cn(
+        "rounded-lg border bg-white/5 p-4",
+        broken ? "border-amber-400/40 bg-amber-500/5" : "border-white/10",
+      )}
+    >
+      {broken && (
+        <div className="mb-3 flex items-start gap-2 text-xs text-amber-300/90">
+          <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <div>
+            <div className="font-medium">Needs reconnection</div>
+            {broken.reason && <div className="text-amber-300/70">{broken.reason}</div>}
+          </div>
+        </div>
+      )}
+      {/* existing card body: email, last sync, toggles, disconnect */}
+    </div>
+  );
+})}
+```
+
+Use the exact card chrome currently in the file — only add the warning header row + conditional border tint. Don't rewrite the card.
+
+- [ ] **Step 4: Same treatment for Google Calendar cards**
+
+Within `CalendarSection.tsx` (same file — Google Calendar accounts also render here), apply the identical warning row to Google account cards. Use `findBrokenDetailForAccount(data, "google-calendar", account.id)`.
+
+- [ ] **Step 5: Manual verification with preview tools**
+
+1. Manually create a broken re-link task in the DB (or use a granola revoke flow).
+2. Open Settings → Calendar.
+3. Verify warning row appears on the specific broken account with reason text.
+4. Verify other accounts (same provider, different account) DO NOT show the warning.
+5. Reconnect the broken account → warning disappears within 60s (poll interval) or immediately if mutation invalidates the query.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/api/connection-health.ts apps/desktop/src/settings/CalendarSection.tsx
+git commit -m "feat(desktop): per-account warning chrome in Settings cards
+
+Shows amber warning row + tint on the specific Granola or Google Calendar
+account that needs reconnection, with reason text. Other accounts of the same
+provider stay clean."
+```
+
+---
+
+## Task C4: iOS — per-account warning chrome in Settings
+
+**Files:**
+- Modify: `apps/ios/Brett/Views/Settings/CalendarSettingsView.swift`
+- Modify: `apps/ios/Brett/Services/ConnectionHealthService.swift` (if exists) or wherever iOS fetches broken connections
+
+- [ ] **Step 1: Add Decodable for new response shape**
+
+```swift
+struct BrokenConnectionDetail: Decodable, Hashable {
+    let type: String
+    let accountId: String?
+    let reason: String?
+    let brokenSince: String
+}
+
+struct BrokenConnectionsResponse: Decodable {
+    let count: Int
+    let types: [String]
+    let details: [BrokenConnectionDetail]
+}
+```
+
+- [ ] **Step 2: Update iOS fetcher**
+
+Find the existing iOS broken-connections fetch (grep `broken-connections` in `apps/ios`). Update it to decode the new shape. If iOS doesn't currently fetch this endpoint at all (just renders local data), add a small `BrokenConnectionsStore` that fetches it on view appear + every 60s.
+
+- [ ] **Step 3: Add warning view inside each Granola account row**
+
+In `CalendarSettingsView.swift` around `granolaAccountsList()` (lines 425-469 per the survey):
+
+```swift
+// helper:
+private func brokenDetail(for accountId: String, type: String, details: [BrokenConnectionDetail]) -> BrokenConnectionDetail? {
+    details.first(where: { $0.type == type && $0.accountId == accountId })
+}
+
+// in the per-account row:
+VStack(alignment: .leading, spacing: 8) {
+    if let broken = brokenDetail(for: account.id, type: "granola", details: brokenConnections.details) {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Needs reconnection")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.orange)
+                if let reason = broken.reason {
+                    Text(reason)
+                        .font(.caption2)
+                        .foregroundStyle(.orange.opacity(0.7))
+                }
+            }
+        }
+    }
+    // existing row content
+}
+.padding(.horizontal, broken != nil ? 12 : 0)   // breathing room for warning state
+.background(broken != nil ? Color.orange.opacity(0.08) : Color.clear)
+.overlay(
+    RoundedRectangle(cornerRadius: 12)
+        .stroke(broken != nil ? Color.orange.opacity(0.3) : Color.clear, lineWidth: 1)
+)
+```
+
+Match the existing card chrome (corner radius, padding) exactly.
+
+- [ ] **Step 4: Manual verification on simulator**
+
+Build + run, manually trigger a broken state (or temporarily seed local SwiftData with a re-link task). Verify warning row appears on the correct account.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ios/Brett/Views/Settings/CalendarSettingsView.swift apps/ios/Brett/Services/
+git commit -m "feat(ios): per-account warning row in Settings cards
+
+Mirrors desktop: amber warning + reason text inside the specific account
+card. Matches iOS design language (SF Symbols, system orange)."
+```
+
+---
+
+## Task C5: Backend regression test — confirm scoped resolution still works
+
+**Files:**
+- Modify: `apps/api/src/__tests__/connection-health.test.ts`
+
+- [ ] **Step 1: Add explicit regression test**
+
+The Explore agent found a test at `connection-health.test.ts:122-180` for granola. Add a parallel test for the new response shape end-to-end:
+
+```typescript
+it("regression: reconnecting account B does not clear account A's re-link task", async () => {
+  const user = await createTestUser();
+  await createRelinkTask(user.id, "granola", "acc-A", "Token expired for A");
+  await createRelinkTask(user.id, "granola", "acc-B", "Token expired for B");
+
+  // Simulate reconnect of acc-B by calling the resolver
+  await resolveRelinkTaskForAccount(user.id, "granola", "acc-B");
+
+  const res = await api.get("/things/broken-connections").set(auth(user));
+  expect(res.body.details).toHaveLength(1);
+  expect(res.body.details[0].accountId).toBe("acc-A");
+});
+```
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+pnpm --filter @brett/api test connection-health
+git add apps/api/src/__tests__/connection-health.test.ts
+git commit -m "test(api): regression test for per-account re-link resolution scope"
+```
+
+---
+
+## Task C6: Open Phase C PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --base main --title "feat: per-account connection health visibility" --body "$(cat <<'EOF'
+## Summary
+- /things/broken-connections now returns per-account details (type, accountId, reason, brokenSince)
+- Settings cards show inline warning chrome + reason text on the specific broken account
+- Regression test confirms re-link resolution stays scoped to the correct accountId
+- Multi-granola spec verified shipped — item 4 in the design spec was a stale-client issue, no code change needed there
+
+Spec: docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md (items 4, 5)
+
+## Test plan
+- [ ] pnpm --filter @brett/api test connection-health
+- [ ] Manual: trigger a broken state on one account, verify warning on that card only
+- [ ] Manual: reconnect that account, verify warning clears within 60s
+- [ ] iOS: same end-to-end on simulator
+EOF
+)"
+```
+
+---
+
+# Self-Review
+
+**Spec coverage:**
+- Item 1 (badge narrow): Phase A tasks A1, A2, A3 ✅
+- Item 2 (collapsible sections): Phase A tasks A4, A5, A6 ✅
+- Item 3 (Tonight): Phase B tasks B1-B11 ✅
+- Item 4 (granola second MCP): Phase C task C1 (verification only — already shipped) ✅
+- Item 5a (per-account warning UI): Phase C tasks C2, C3, C4 ✅
+- Item 5b (scoped resolution): Phase C task C5 (regression test — already shipped) ✅
+
+**Placeholder scan:** No "TBD" / "TODO" / "fill in details". All code blocks contain real code. A few "verify with grep before deleting" / "look at existing helper first" instructions are intentional anchors for things that the survey couldn't perfectly nail down — they instruct the implementer to confirm exact import paths and call signatures from the actual code.
+
+**Type consistency:**
+- `tonight: boolean` — used consistently across Prisma schema, TypeScript types, Swift property, and the field whitelists.
+- `BrokenConnectionDetail` — same shape in API + desktop hook + iOS Decodable.
+- `computeBadgeCount` — same signature throughout Phase A.
+
+**Risk callouts not in the original spec:**
+
+1. Phase B Task B10 expands the iOS `onConfirm` callback signature to include `tonight: Bool`. Every existing call site must be updated. The agent must grep all callers and not miss any.
+2. Phase A Task A1 mentions removing `isWeekendNow` from App.tsx. Must verify with grep that nothing else uses it (the dock badge IPC effect only depends on `badgeCount` per the survey).
+3. Phase C Task C2 changes `Item.description` to carry user-facing reason text. If `description` is already used for something else on re-link tasks, this could collide. Re-link tasks are system-created and unlikely to have a meaningful pre-existing description, but agent should verify with a quick `findFirst({ where: { source: "system", sourceId: { startsWith: "relink:" } } })` and review what's currently stored.

--- a/docs/superpowers/specs/2026-04-24-today-count-badge-design.md
+++ b/docs/superpowers/specs/2026-04-24-today-count-badge-design.md
@@ -16,15 +16,23 @@ outstanding items for the Today view.
 
 ## Count definition
 
-**`overdue + due today + due this week`**, excluding Next Week and completed
-items. Matches the existing in-app sidebar badge on desktop.
+**`overdue + due today`**, excluding This Week, This Weekend, Next Week, and
+completed items. The badge is intentionally narrow — it answers "what needs my
+attention right now," not "what's coming up."
 
-- Desktop: `activeThingsForCount.length` from `apps/desktop/src/App.tsx`
-  (active items whose `dueDate ≤ endOfWeekUTC`) is already exactly this number
-  — reuse it.
-- iOS: a new `TodaySections.badgeCount` computed property returns
-  `overdue.count + today.count + thisWeek.count`. Keeps the bucket math in one
-  place, so desktop and iOS agree on what "Today" means.
+Tonight items are counted as today (they have `dueDate = today`; the `tonight`
+flag only affects sectioning, not counting).
+
+- Desktop: `computeBadgeCount(activeThingsForCount)` from
+  `apps/desktop/src/lib/badgeCount.ts` — filters the week-long fetch down to
+  items whose `dueDate ≤ end of today UTC`, dropping completed.
+- iOS: `TodaySections.badgeCount(items:)` returns
+  `overdue.count + today.count`. Keeps the bucket math in one place, so
+  desktop and iOS agree on what "Today" means.
+
+History: between 2026-04-24 and 2026-05-18 the badge included This Week (and,
+on Sat/Sun, This Weekend). The 2026-05-18 tuning spec narrowed it to overdue
++ today — see `docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md`.
 
 ## Desktop — macOS dock badge
 

--- a/docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md
+++ b/docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md
@@ -1,0 +1,330 @@
+# Brett Tuning — May 2026
+
+**Date:** 2026-05-18
+**Status:** Design approved — ready for implementation planning
+**Scope:** Five focused tweaks across Today view (desktop + iOS), MCP settings, and connection health UX.
+
+## Summary
+
+Five small but high-signal changes to make daily use feel calmer and more honest:
+
+1. **Badge count narrows** to overdue + today + tonight (drops "this week").
+2. **Collapsible "This Week" / "This Weekend" / "Done"** sections on Electron — default collapsed, count chip visible. iOS unchanged.
+3. **New "Tonight" concept** — due-date shortcut, dedicated section, auto-expands at 6pm local.
+4. **Fix:** second Granola MCP account not appearing in Settings list.
+5. **Per-account connection health visibility** — show *which* account is broken and *why*, and stop letting one account's reconnect clear another account's issue.
+
+Items 1–3 are evergreen Today-view polish. Items 4–5 are bugfixes/UX fills against the existing multi-granola + connection-health work.
+
+Updates two prior specs:
+- [`2026-04-24-today-count-badge-design.md`](2026-04-24-today-count-badge-design.md) — count definition narrows.
+- [`2026-04-04-connection-health-ux-design.md`](2026-04-04-connection-health-ux-design.md) — extends per-account visibility into settings UI.
+
+---
+
+## 1. Badge count: overdue + today + tonight only
+
+### Change
+
+Drop "this week" from the count. New definition:
+
+```
+badgeCount = count(items where status != done AND (
+  dueDate < startOfToday        -- overdue
+  OR sameDay(dueDate, today)    -- today (includes tonight)
+))
+```
+
+**Tonight always counts in the badge** regardless of clock time — it's still a today item, the evening tag only affects sectioning.
+
+### Files affected
+
+**Desktop** (`apps/desktop/src/App.tsx`):
+- `activeThingsForCount` currently includes items where `dueDate ≤ endOfWeekUTC`. Narrow to `dueDate ≤ endOfTodayUTC`. The variable serves two callers: the in-app sidebar Today badge and the new dock badge. Both should now show the narrower count — the existing sidebar badge will go down for most users, which is the intended outcome.
+
+**iOS** (`apps/ios/Brett/Views/Today/TodayPage.swift`):
+- `TodaySections.badgeCount(items:)` currently returns `overdue.count + today.count + thisWeek.count`. Change to `overdue.count + today.count`. The `today` bucket already includes Tonight tasks (they have `dueDate = today`), so the badge picks them up automatically.
+
+**Spec sync:** update `2026-04-24-today-count-badge-design.md` Count definition section to match.
+
+### Risk
+
+- Some users' badge count will drop noticeably. That's the goal. Not a regression.
+- Make sure the sidebar Today nav count and the dock/app icon badge stay in lockstep — both read from the same `activeThingsForCount` source on desktop and the same `TodaySections.badgeCount` on iOS. Don't fork them.
+
+---
+
+## 2. Collapsible sections on Electron (Today view only)
+
+### Change
+
+In the Today view on desktop, the following sections become collapsible accordions:
+
+- This Week — default **collapsed**
+- This Weekend — default **collapsed**
+- Done — default **collapsed**
+
+Stay non-collapsible (always expanded):
+- Overdue, Today, Tonight (when present)
+
+Section header always shows:
+- Section title
+- Item count chip (regardless of expanded state)
+- Disclosure chevron (rotates on expand)
+
+### Persistence
+
+Per-section expand state stored in `localStorage`, keyed `today.section.<name>.expanded`. Persists across reloads. Defaults to `false` (collapsed) if absent.
+
+Why localStorage and not the DB: this is a UI affordance, not user data. No need to sync across devices, and the user will rarely tweak it.
+
+### Scope
+
+**Only the Today view** (`apps/desktop/src/pages/Today.tsx` / wherever `ThingsList`'s Today-mode lives). NOT applied to:
+- Custom lists — they don't have sub-sections.
+- Inbox — single bucket.
+- Upcoming view — sectioning there is by week, not by urgency.
+
+### iOS — skipped intentionally
+
+iOS scrolls naturally, and the calm-hero pattern already prioritizes Today + Tonight at the top. Adding a tap-to-expand interaction on iOS would fight the existing sticky-header design. **Acceptable parity exception** per CLAUDE.md — the desktop user is staring at a fixed window and benefits from squeezing the view; the iOS user already gets the same visual hierarchy by virtue of scrolling.
+
+If we later add iOS parity, it should reuse the same default-collapsed convention and likely use SwiftUI's `DisclosureGroup` within sections — but not now.
+
+### Animation
+
+Reuse whatever accordion / disclosure pattern is already in use in the app (likely Radix `Collapsible` via shadcn, given the stack). 200ms ease-out matches existing motion language.
+
+---
+
+## 3. Tonight
+
+### Concept
+
+"Tonight" is a due-date hint, not a separate due date. A Tonight task is a Today task with a flag saying *"don't surface me during the workday — surface me after 6pm."*
+
+After today passes, an incomplete Tonight task becomes overdue like any other Today task. The `tonight` flag stays on the row as data but stops affecting UI.
+
+### Data model
+
+**Schema** (`apps/api/prisma/schema.prisma`):
+
+```prisma
+model Item {
+  // ...existing fields...
+  tonight Boolean @default(false)
+}
+```
+
+Boolean flag rather than a `dueWindow` enum. We don't yet need "morning" / "afternoon" / "evening" — only the evening case is real. YAGNI.
+
+**Migration:** additive non-null boolean with default false. Single statement, safe.
+
+**Sync engine:**
+- Add `tonight` to the iOS `Item` SwiftData model.
+- Add `tonight` to the field-level merge map in `apps/api/src/services/sync.ts` (treat as standard scalar — last-write-wins via `previousValues`).
+- Add to the API request/response Zod schemas for `/sync/push` and `/sync/pull`.
+
+**Older clients:**
+- Existing iOS or desktop builds without the field: API serves the field, they ignore unknown JSON keys → no error.
+- They cannot **set** `tonight` — that's fine, they fall back to "Today" semantics, which is correct behavior for clients that don't know about the concept.
+
+### Setting Tonight
+
+**Entry point:** Quick-pick chip in the due-date selector, both Omnibar and task detail panel. Natural-language parsing ("tonight", "this evening") is deferred — chip first.
+
+**Chip order in the picker:**
+`Today` → `Tonight` → `Tomorrow` → `This Weekend` → `This Week` → `Next Week` → `Pick date…`
+
+**Visual:** Same chip chrome as the others, with a small moon icon (or evening-toned dot) to differentiate. Match the existing chip style in [`packages/ui/src/DatePicker.tsx`](packages/ui/src/DatePicker.tsx) (or wherever the current chip set lives — Explore agent to confirm).
+
+**Behavior:** Selecting Tonight sets `dueDate = today` (end of day, same as Today picker) AND `tonight = true`. Selecting any other chip clears `tonight = false`.
+
+### Tonight section in Today view
+
+**Position:** Between Today and This Week (or between Today and This Weekend if This Weekend appears first — Tonight is always immediately after Today).
+
+**Header:**
+- Title: "Tonight"
+- Moon icon (24px, neutral-warm — same palette as the chip)
+- Count chip
+
+**Collapse behavior:**
+- Before 6pm local → default **collapsed**
+- At 6pm local → auto-expand
+- After auto-expand, **user collapse wins** — if the user manually collapses it after 6pm, it stays collapsed for the rest of the day
+- Next day → state resets to default-collapsed before 6pm
+
+**Implementation note:** the auto-expand at 6pm is a passive "default state" change, not an active animation. The component reads `now()` on render and on a minute-tick timer; if the current time is ≥ 6pm and the user hasn't touched the section today, it renders expanded. If they've touched it (recorded in `localStorage` with today's date as part of the key), their choice sticks.
+
+localStorage key: `today.tonight.userToggledOn.<YYYY-MM-DD>` → boolean (presence = user touched it; value = their chosen state).
+
+### Empty state
+
+If a user has no Tonight tasks, the section does not render at all. We don't want a permanent "Tonight (0)" header in the Today view.
+
+### iOS parity
+
+Tonight ships on iOS too. Same model:
+- New "Tonight" chip in the iOS due-date picker (`apps/ios/Brett/Views/Date/DatePickerView.swift` or equivalent).
+- New Tonight section in `TodayPage`, slotted between Today and This Week.
+- `TodaySections` gets a new bucket: `tonight` (items with `tonight == true && sameDay(dueDate, today) && status != done`).
+- Section is hidden when empty.
+- Auto-expand at 6pm. Same localStorage-equivalent via `@AppStorage`, keyed by date.
+
+### Brett (AI) Tonight routing — out of scope
+
+Whether Brett's AI task creation should ever choose Tonight is deferred. Initial rollout: Tonight is human-driven only. If we later want Brett to route certain content there (e.g., evening reading, errand reminders), we can add it.
+
+---
+
+## 4. Granola second MCP not appearing in Settings
+
+### Symptom
+
+User connected a second Granola account. The Settings → Calendar page only shows one. Multi-granola spec ([`2026-05-16-multi-granola-design.md`](2026-05-16-multi-granola-design.md)) says all connected accounts should render as separate cards.
+
+### Investigation hypothesis
+
+Most likely culprits (Explore agent to confirm):
+
+1. **API still returns `account: GranolaAccount | null` instead of `accounts: GranolaAccount[]`** — spec change might not have shipped. Check `apps/api/src/routes/granola-auth.ts` for the `GET /granola/auth` response shape.
+
+2. **Desktop hook still reads `.account` instead of `.accounts`** — even if API was updated, `apps/desktop/src/api/granola.ts` might still use the old singular hook. Check whether `useGranolaAccount` was renamed to `useGranolaAccounts`.
+
+3. **CalendarSection.tsx renders a single card** — even if hook returns array, the JSX might be `accounts[0]` instead of `.map(...)`.
+
+4. **OAuth callback still upserts on `userId` instead of `(userId, email)`** — would mean the second OAuth attempt overwrites the first row instead of creating a new one. Check the upsert call in the callback handler. Symptom would be: first account's email gets replaced by second account's email, not a "missing" account.
+
+5. **DB schema still has `userId @unique`** — would mean the second `INSERT` would fail at the DB level, but might be silently caught. Check `apps/api/prisma/schema.prisma` and the latest migrations folder.
+
+### Fix
+
+Whichever of 1–5 is the gap, close it. The spec already specifies the correct end state; this is plumbing through whatever didn't make it.
+
+**Acceptance:** With two Granola accounts connected for the same user, `GET /granola/auth` returns both, the Settings Calendar tab renders two cards, and `INSERT`-ing the second account does not collide with the first.
+
+---
+
+## 5. Per-account connection health visibility
+
+### Problems
+
+Both observed by the user; both real:
+
+**5a. Settings shows badge but not which account / why.** Today the left-nav badge tells you "something's broken" but Settings itself doesn't explain *which* account or *why* once you're there. The re-link task in Today says "reconnect granola" but doesn't survive in the UI long enough to be useful.
+
+**5b. Reconnecting any account clears all accounts' tasks.** User had account A broken. They connected (or reconnected) account B. The re-link task for account A disappeared even though A is still broken.
+
+### Fix 5a — Show the state per account in Settings
+
+**On every connected-account card** (Granola, Google Calendar, etc.), render a status row inside the card:
+
+- **Healthy state:** small green dot + "Connected" (or just absence of warning).
+- **Broken state:** small amber dot + "Needs reconnection" + reason line below in muted text. Example reasons:
+  - "Token expired — last successful sync 3 days ago"
+  - "Authorization revoked"
+  - "Authentication failed (401)"
+
+The reason text is derived from existing failure logging on the backend. Where the current backend doesn't already write a reason string, add one to the `Item` (re-link task) when it's created — store as a sentence in a new `Item.systemReason` field, or piggyback on `Item.body`. **Spec to choose:** use existing `body` (no schema change), with the format `"Token expired — last successful sync 3 days ago"`. Frontend reads `body` for broken-state reason.
+
+**Card chrome:** warning state adds a 1px amber left-border on the card and a subtle amber wash background. Matches the existing alert chrome pattern in the app (verify in Explore — likely the connection-health task card already has the right treatment to copy).
+
+### Fix 5b — Re-link tasks must be scoped per account
+
+The bug: the `resolveRelinkTask` backend logic (probably) clears any re-link task matching the connection type, not the specific account. So reconnecting account B clears account A's task.
+
+**Fix:**
+
+1. **Verify the task's `sourceId` already encodes accountId.** The connection-health spec says `sourceId = relink:<type>:<accountId>`. Confirm this is actually how the tasks are being created today, for every connection type (Granola, Google Calendar, AI).
+2. **Update auto-resolution to require accountId match.** When OAuth completes for account `X` (e.g., `granolaAccountId = X`), only auto-complete re-link tasks whose `sourceId == relink:granola:X`. Other accounts' tasks stay open.
+3. **Update the health check loop** that creates re-link tasks: tasks must be uniquely scoped by `(userId, sourceId)` so two broken accounts produce two distinct tasks, not a single deduped one.
+
+**Acceptance test:**
+- User has Granola account A broken, B healthy.
+- Today view shows one re-link task scoped to A.
+- User connects a *new* account C → A's task remains.
+- User reconnects A → A's task auto-completes.
+- B's settings card never showed a warning throughout.
+
+### Files affected (preliminary)
+
+| Area | File | Change |
+|---|---|---|
+| API | `src/services/connection-health.ts` (or wherever re-link tasks are created/resolved) | scope resolution by `sourceId == relink:<type>:<accountId>` |
+| API | `src/routes/granola-auth.ts` callback, `src/routes/calendar-accounts.ts` callback | on success, only resolve tasks matching the **specific** account just connected |
+| API | re-link task creation | ensure reason string written to `Item.body` |
+| Desktop | `apps/desktop/src/settings/CalendarSection.tsx` + sibling sections | per-account status row + warning chrome |
+| iOS | `apps/ios/Brett/Views/Settings/CalendarSettingsView.swift` + sibling settings views | per-account status row + warning chrome |
+
+---
+
+## Testing
+
+### Item 1 (badge)
+
+- Unit test `TodaySections.badgeCount(items:)` (iOS) — overdue + today, excludes thisWeek and nextWeek.
+- Unit/integration test `activeThingsForCount` on desktop — same cases.
+- Verify Tonight tasks count in badge regardless of clock time.
+
+### Item 2 (collapsible sections)
+
+- Manual: collapse "This Week" → reload → still collapsed. Expand → reload → still expanded.
+- Manual: collapse state for "This Week" does not affect "Done" or other sections.
+- Visual regression / screenshot — confirm count chip visible in collapsed state.
+
+### Item 3 (Tonight)
+
+- Unit: Tonight chip in date picker sets `tonight = true` and `dueDate = today`. Switching to any other chip clears `tonight`.
+- Unit: `TodaySections.tonight` bucket includes only `tonight && today && !done` items.
+- Unit: empty Tonight bucket → section hidden.
+- Manual: at 5:59pm section collapsed, at 6:00pm expanded (use device time override or fake clock).
+- Manual: after auto-expand, collapse → stays collapsed.
+- Sync test: create Tonight task on desktop → appears as Tonight on iOS after pull. And vice versa.
+- Schema migration test against prod-shaped data.
+
+### Item 4 (multi-granola visibility)
+
+- API integration test: user with 2 GranolaAccount rows → `GET /granola/auth` returns array of length 2.
+- Desktop manual: connect two Granola accounts, both appear in Calendar settings.
+- iOS manual: same.
+
+### Item 5 (per-account connection health)
+
+- Backend test: re-link task created with `sourceId = relink:granola:<accountId>`. Reconnecting a different `accountId` does NOT resolve the existing task.
+- Backend test: reconnecting the SAME `accountId` auto-resolves its task.
+- UI: warning chrome on broken account card with reason text.
+- Cross-platform manual: same scenarios on desktop and iOS.
+
+---
+
+## Out of scope
+
+- Brett AI auto-routing tasks to Tonight (revisit if signal emerges).
+- iOS collapsible sections (parity exception).
+- Surface "Tonight" as a separate dock/app-icon badge color or grouping — it counts the same as Today.
+- Natural-language Tonight parsing in the Omnibar (chip-only for now).
+- Reconnect-broken-account inline buttons on iOS Settings cards — covered separately by the existing connection-health UX spec; assumed shipped.
+- Showing health status for non-Granola/Calendar integrations (e.g., AI providers) in this change. Same pattern, but defer to keep scope tight.
+
+---
+
+## Implementation phasing
+
+These five items are independent enough to dispatch in parallel:
+
+| Item | Surface area | Risk | Notes |
+|---|---|---|---|
+| 1. Badge narrow | Desktop + iOS | Low | One-line filter change each side |
+| 2. Collapsible sections | Desktop only | Low | UI-only, localStorage |
+| 3. Tonight | Schema, API, desktop, iOS | Medium | Migration + sync coordination |
+| 4. Multi-granola bug | API + desktop + iOS | Low–Med | Bug investigation first |
+| 5. Per-account health | API + desktop + iOS | Medium | Backend resolution logic + UI |
+
+**Suggested PR slicing:**
+
+- **PR A** — Items 1 + 2 (Today view tuning, desktop-leaning).
+- **PR B** — Item 3 (Tonight — schema, sync, both platforms).
+- **PR C** — Items 4 + 5 (connection visibility — backend + both platforms).
+
+Item 3 needs the API to deploy first (per release process) so older clients ignore `tonight: true` from the start. Items 4 + 5 are server-fix-driven; clients consume gracefully.

--- a/packages/business/src/__tests__/business.test.ts
+++ b/packages/business/src/__tests__/business.test.ts
@@ -10,6 +10,7 @@ import {
   validateBulkUpdate,
   computeTriageResult,
   groupUpcomingThings,
+  type TriageDatePreset,
 } from "../index";
 import type { ItemRecord, Urgency, DueDatePrecision, Thing } from "@brett/types";
 
@@ -348,6 +349,35 @@ describe("computeTriageResult", () => {
 
     it("this_weekend on Wednesday → upcoming Saturday March 14", () => {
       expect(computeTriageResult("this_weekend", WEDNESDAY).dueDate).toBe("2026-03-14T00:00:00.000Z");
+    });
+  });
+
+  describe("tonight flag", () => {
+    it("tonight → same dueDate as today + tonight=true", () => {
+      const today = computeTriageResult("today", NOW);
+      const tonight = computeTriageResult("tonight", NOW);
+      // Calendar day must match — `tonight` is a display/expand hint, not a
+      // different stored due date. Older clients that ignore the flag still
+      // see the task in their Today bucket.
+      expect(tonight.dueDate).toBe(today.dueDate);
+      expect(tonight.dueDatePrecision).toBe("day");
+      expect(tonight.tonight).toBe(true);
+    });
+
+    it("every non-tonight preset clears tonight=false", () => {
+      // Picking any other preset must explicitly produce tonight=false so
+      // re-triaging a previously-Tonight task to e.g. Tomorrow drops the flag.
+      const presets: TriageDatePreset[] = [
+        "today",
+        "tomorrow",
+        "this_weekend",
+        "this_week",
+        "next_week",
+        "next_month",
+      ];
+      for (const preset of presets) {
+        expect(computeTriageResult(preset, NOW).tonight).toBe(false);
+      }
     });
   });
 });

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -500,6 +500,13 @@ export function validateUpdateItem(
     }
   }
 
+  if (obj.tonight !== undefined) {
+    if (typeof obj.tonight !== "boolean") {
+      return { ok: false, error: "tonight must be a boolean" };
+    }
+    data.tonight = obj.tonight;
+  }
+
   if (obj.snoozedUntil !== undefined) {
     if (obj.snoozedUntil !== null) {
       if (typeof obj.snoozedUntil !== "string" || isNaN(Date.parse(obj.snoozedUntil))) {
@@ -676,6 +683,10 @@ export function validateBulkUpdate(
     }
   }
 
+  if (updates.tonight !== undefined && typeof updates.tonight !== "boolean") {
+    return { ok: false, error: "updates.tonight must be a boolean" };
+  }
+
   return {
     ok: true,
     data: {
@@ -684,6 +695,7 @@ export function validateBulkUpdate(
         listId: updates.listId as string | null | undefined,
         dueDate: updates.dueDate as string | null | undefined,
         dueDatePrecision: updates.dueDatePrecision as DueDatePrecision | null | undefined,
+        tonight: updates.tonight as boolean | undefined,
         status: updates.status as ItemStatus | undefined,
       },
     },

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -323,6 +323,7 @@ export function itemToThing(
     dueDateLabel: computeDueDateLabel(item.dueDate, now, timezone),
     isCompleted: item.completedAt !== null,
     completedAt: item.completedAt?.toISOString(),
+    tonight: item.tonight ?? false,
     brettObservation: item.brettObservation ?? undefined,
     description: item.description ?? undefined,
     stalenessDays: computeStalenessDays(item.updatedAt, now),
@@ -689,11 +690,18 @@ export function validateBulkUpdate(
   };
 }
 
-export type TriageDatePreset = "today" | "tomorrow" | "this_weekend" | "this_week" | "next_week" | "next_month";
+export type TriageDatePreset = "today" | "tonight" | "tomorrow" | "this_weekend" | "this_week" | "next_week" | "next_month";
 
 export interface TriageResult {
   dueDate: string; // ISO string
   dueDatePrecision: DueDatePrecision;
+  /**
+   * Whether selecting this preset sets the `tonight` flag on the item. Only
+   * `"tonight"` produces `true`; every other preset explicitly produces
+   * `false` so that picking e.g. "Today" or "Tomorrow" clears a previously
+   * set tonight flag.
+   */
+  tonight: boolean;
 }
 
 /**
@@ -719,10 +727,16 @@ export function computeTriageResult(
 
   switch (preset) {
     case "today":
-      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: false };
+    case "tonight":
+      // Same calendar day as "today" — `tonight` is just a presentation hint
+      // ("expand after 6pm", "show in the Tonight section"). The dueDate is
+      // identical to "today" so existing date-based logic (badges, urgency)
+      // keeps working unchanged.
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: true };
     case "tomorrow":
       d.setUTCDate(d.getUTCDate() + 1);
-      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: false };
     case "this_weekend": {
       // If today is Saturday (6) or Sunday (0), we ARE in the weekend — use today.
       // Otherwise jump to the next upcoming Saturday.
@@ -730,23 +744,23 @@ export function computeTriageResult(
       if (dayOfWeek !== 6 && dayOfWeek !== 0) {
         d.setUTCDate(d.getUTCDate() + (6 - dayOfWeek));
       }
-      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: false };
     }
     case "this_week": {
       // Friday of the current workweek (today if today IS Friday).
       // On Sat-Sun, jump to next Friday since the current workweek has ended.
       d.setUTCDate(d.getUTCDate() + daysUntilUpcomingFriday(d.getUTCDay()));
-      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: false };
     }
     case "next_week": {
       // The Friday after "this_week"'s Friday — i.e., the end of next
       // workweek. Stays in lockstep with `this_week` by construction.
       d.setUTCDate(d.getUTCDate() + daysUntilUpcomingFriday(d.getUTCDay()) + 7);
-      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: false };
     }
     case "next_month":
       d.setUTCMonth(d.getUTCMonth() + 1, 1);
-      return { dueDate: d.toISOString(), dueDatePrecision: "day" };
+      return { dueDate: d.toISOString(), dueDatePrecision: "day", tonight: false };
   }
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -190,6 +190,7 @@ export interface UpdateItemInput {
   sourceUrl?: string | null;
   dueDate?: string | null; // ISO string
   dueDatePrecision?: DueDatePrecision | null;
+  tonight?: boolean;
   brettObservation?: string | null;
   listId?: string | null;
   status?: ItemStatus;
@@ -225,6 +226,7 @@ export interface BulkUpdateInput {
     listId?: string | null;
     dueDate?: string | null;
     dueDatePrecision?: DueDatePrecision | null;
+    tonight?: boolean;
     status?: ItemStatus;
   };
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -74,6 +74,7 @@ export interface ItemRecord {
   reminder: string | null;
   recurrence: string | null;
   recurrenceRule: string | null;
+  tonight?: boolean;
   brettTakeGeneratedAt: Date | null;
   contentType: string | null;
   contentStatus: string | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -109,6 +109,7 @@ export interface Thing {
   dueDateLabel?: string;
   isCompleted: boolean;
   completedAt?: string; // ISO string
+  tonight?: boolean;
   brettObservation?: string;
   description?: string;
   stalenessDays?: number;

--- a/packages/types/src/sync.ts
+++ b/packages/types/src/sync.ts
@@ -80,7 +80,7 @@ export type PushableEntityType = (typeof PUSHABLE_ENTITY_TYPES)[number];
 export const MUTABLE_FIELDS: Record<PushableEntityType, readonly string[]> = {
   item: ["title", "description", "notes", "status", "dueDate", "dueDatePrecision",
          "completedAt", "snoozedUntil", "reminder", "recurrence", "recurrenceRule",
-         "listId", "brettObservation", "contentType", "contentStatus"],
+         "listId", "brettObservation", "contentType", "contentStatus", "tonight"],
   list: ["name", "colorClass", "sortOrder", "archivedAt"],
   calendar_event_note: ["content"],
 };

--- a/packages/ui/src/CollapsibleSection.tsx
+++ b/packages/ui/src/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 /**
@@ -7,14 +7,27 @@ import { ChevronRight } from "lucide-react";
  * collapsed section sits next to a static one without a chrome jump.
  *
  * Hand-rolled rather than wrapping Radix Collapsible — the behavior here is
- * trivial (toggle a boolean, conditionally render children) and pulling in
+ * trivial (toggle a boolean, animate height + opacity) and pulling in
  * `@radix-ui/react-collapsible` for one component would add ~7KB and a new
- * dep without buying us animation or a11y the spec demands.
+ * dep without buying us anything the spec demands.
  *
  * a11y: the header is a real `<button>` with `aria-expanded`. Screen readers
- * announce "Collapsed/Expanded" on toggle. Children mount/unmount with `open`
- * — collapsed sections also drop from the DOM, which matters for the
- * always-rendered Today view where every extra card is a paint cost.
+ * announce "Collapsed/Expanded" on toggle. The collapsed body is marked
+ * `aria-hidden` and removed from tab order.
+ *
+ * Animation: 220ms height + opacity transition on the `cubic-bezier(0.16, 1,
+ * 0.3, 1)` curve the DESIGN_GUIDE designates for "section enters, toggles,
+ * cross-fades" (matches ConfirmDialog, CrossFade, calendar/feedback modals,
+ * LeftNav stroke transitions). Implemented via `grid-template-rows: 0fr/1fr`
+ * — the modern technique that animates to unknown content height without a
+ * JS `ResizeObserver` or a hardcoded `max-height` ceiling that would clip
+ * tall sections (Done Today can grow to 50+ rows). The inner grid child is
+ * `overflow: hidden` so the row clip looks like a shutter, not a scrollbar.
+ *
+ * Children mount on open and unmount AFTER the close transition completes
+ * (transitionEnd-driven, with a setTimeout fallback in case the event drops).
+ * For the always-rendered Today view this keeps the original perf property:
+ * collapsed sections add zero ThingCard paint cost once the animation ends.
  */
 interface CollapsibleSectionProps {
   title: string;
@@ -27,6 +40,8 @@ interface CollapsibleSectionProps {
   className?: string;
 }
 
+const ANIMATION_MS = 220;
+
 export function CollapsibleSection({
   title,
   count,
@@ -36,6 +51,43 @@ export function CollapsibleSection({
   headerExtras,
   className,
 }: CollapsibleSectionProps) {
+  // `bodyMounted` lags `open` on close: stays true through the close
+  // transition so the children have something to animate FROM, then flips
+  // false once the height collapse finishes — restoring the original
+  // "collapsed sections don't pay paint cost" property of the unanimated
+  // version.
+  const [bodyMounted, setBodyMounted] = useState<boolean>(open);
+  const closeTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      // Cancel any pending unmount + mount immediately so the open
+      // transition starts on the same frame the user clicked.
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+      setBodyMounted(true);
+      return;
+    }
+    // Close: keep mounted until the height transition finishes, then drop.
+    // +30ms cushion absorbs jitter in transitionend timing (browsers
+    // occasionally drop the event under load); setTimeout is the floor.
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+    }
+    closeTimerRef.current = window.setTimeout(() => {
+      setBodyMounted(false);
+      closeTimerRef.current = null;
+    }, ANIMATION_MS + 30);
+    return () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    };
+  }, [open]);
+
   return (
     <div className={className}>
       <button
@@ -49,10 +101,13 @@ export function CollapsibleSection({
       >
         <ChevronRight
           size={10}
-          className={
-            "flex-shrink-0 text-white/40 transition-transform duration-150 " +
-            (open ? "rotate-90" : "rotate-0")
-          }
+          // Chevron rotation rides the same curve + duration as the height
+          // transition below so the gesture reads as one motion, not two.
+          className="flex-shrink-0 text-white/40"
+          style={{
+            transform: open ? "rotate(90deg)" : "rotate(0deg)",
+            transition: `transform ${ANIMATION_MS}ms cubic-bezier(0.16, 1, 0.3, 1)`,
+          }}
         />
         <h3 className="text-[10px] uppercase tracking-[0.15em] font-semibold text-white/40 flex-shrink-0 group-hover:text-white/60 transition-colors">
           {title}
@@ -65,7 +120,24 @@ export function CollapsibleSection({
         )}
         {headerExtras && <span className="flex-shrink-0">{headerExtras}</span>}
       </button>
-      {open && <div>{children}</div>}
+      <div
+        // grid-template-rows: 0fr ↔ 1fr is the modern animatable-to-auto
+        // pattern. The inner wrapper is overflow:hidden so the grid clip
+        // looks like a shutter rather than revealing a scrollbar.
+        style={{
+          display: "grid",
+          gridTemplateRows: open ? "1fr" : "0fr",
+          opacity: open ? 1 : 0,
+          transition:
+            `grid-template-rows ${ANIMATION_MS}ms cubic-bezier(0.16, 1, 0.3, 1), ` +
+            `opacity ${ANIMATION_MS - 40}ms cubic-bezier(0.16, 1, 0.3, 1)`,
+        }}
+        aria-hidden={!open}
+      >
+        <div style={{ overflow: "hidden", minHeight: 0 }}>
+          {bodyMounted ? children : null}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/CollapsibleSection.tsx
+++ b/packages/ui/src/CollapsibleSection.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { ChevronRight } from "lucide-react";
+
+/**
+ * Collapsible Today-view section. Visually matches `SectionHeader` exactly
+ * (same 10px uppercase title, same divider line, same count chip) so a
+ * collapsed section sits next to a static one without a chrome jump.
+ *
+ * Hand-rolled rather than wrapping Radix Collapsible — the behavior here is
+ * trivial (toggle a boolean, conditionally render children) and pulling in
+ * `@radix-ui/react-collapsible` for one component would add ~7KB and a new
+ * dep without buying us animation or a11y the spec demands.
+ *
+ * a11y: the header is a real `<button>` with `aria-expanded`. Screen readers
+ * announce "Collapsed/Expanded" on toggle. Children mount/unmount with `open`
+ * — collapsed sections also drop from the DOM, which matters for the
+ * always-rendered Today view where every extra card is a paint cost.
+ */
+interface CollapsibleSectionProps {
+  title: string;
+  count?: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+  /** Optional element rendered to the far right of the header (e.g. an action). */
+  headerExtras?: React.ReactNode;
+  className?: string;
+}
+
+export function CollapsibleSection({
+  title,
+  count,
+  open,
+  onOpenChange,
+  children,
+  headerExtras,
+  className,
+}: CollapsibleSectionProps) {
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        // Mirror SectionHeader's chrome: 10px uppercase tracked label,
+        // divider line, optional count chip. Add a chevron up front.
+        className="group flex w-full items-center gap-3 mb-2 text-left"
+        data-testid={`collapsible-${title.toLowerCase().replace(/\s+/g, "-")}`}
+      >
+        <ChevronRight
+          size={10}
+          className={
+            "flex-shrink-0 text-white/40 transition-transform duration-150 " +
+            (open ? "rotate-90" : "rotate-0")
+          }
+        />
+        <h3 className="text-[10px] uppercase tracking-[0.15em] font-semibold text-white/40 flex-shrink-0 group-hover:text-white/60 transition-colors">
+          {title}
+        </h3>
+        <div className="h-px bg-white/10 flex-1" />
+        {typeof count === "number" && count > 0 && (
+          <span className="text-[10px] tabular-nums text-white/40 flex-shrink-0">
+            {count}
+          </span>
+        )}
+        {headerExtras && <span className="flex-shrink-0">{headerExtras}</span>}
+      </button>
+      {open && <div>{children}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/ContentDetailPanel.tsx
+++ b/packages/ui/src/ContentDetailPanel.tsx
@@ -32,7 +32,7 @@ interface ContentDetailPanelProps {
   lists?: NavList[];
   onSetList?: (id: string, anchorEl: HTMLElement) => void;
   // Schedule callbacks
-  onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision) => void;
+  onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision, tonight: boolean) => void;
   onUpdateReminder?: (reminder: ReminderType | null) => void;
   onUpdateRecurrence?: (recurrence: RecurrenceType | null) => void;
   // Notes

--- a/packages/ui/src/DetailPanel.tsx
+++ b/packages/ui/src/DetailPanel.tsx
@@ -31,7 +31,7 @@ interface DetailPanelProps {
   lists?: NavList[];
   onSetList?: (id: string, anchorEl: HTMLElement) => void;
   // Schedule
-  onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision) => void;
+  onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision, tonight: boolean) => void;
   onUpdateReminder?: (reminder: ReminderType | null) => void;
   onUpdateRecurrence?: (recurrence: RecurrenceType | null) => void;
   // Notes

--- a/packages/ui/src/ScheduleRow.tsx
+++ b/packages/ui/src/ScheduleRow.tsx
@@ -10,7 +10,7 @@ interface ScheduleRowProps {
   dueDatePrecision?: DueDatePrecision;
   reminder?: ReminderType;
   recurrence?: RecurrenceType;
-  onUpdateDueDate: (dueDate: string | null, precision: DueDatePrecision) => void;
+  onUpdateDueDate: (dueDate: string | null, precision: DueDatePrecision, tonight: boolean) => void;
   onUpdateReminder: (reminder: ReminderType | null) => void;
   onUpdateRecurrence: (recurrence: RecurrenceType | null) => void;
 }
@@ -125,8 +125,8 @@ export function ScheduleRow({
             <QuickDatePicker
               anchorEl={anchorEl}
               initialDate={dueDate ? new Date(dueDate) : null}
-              onCommit={(date, precision) => {
-                onUpdateDueDate(date ? date.toISOString() : null, precision);
+              onCommit={(date, precision, tonight) => {
+                onUpdateDueDate(date ? date.toISOString() : null, precision, tonight);
                 close();
               }}
               onCancel={close}

--- a/packages/ui/src/TaskDetailPanel.tsx
+++ b/packages/ui/src/TaskDetailPanel.tsx
@@ -32,7 +32,7 @@ interface TaskDetailPanelProps {
   lists?: NavList[];
   onSetList?: (id: string, anchorEl: HTMLElement) => void;
   // Schedule callbacks
-  onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision) => void;
+  onUpdateDueDate?: (dueDate: string | null, precision: DueDatePrecision, tonight: boolean) => void;
   onUpdateReminder?: (reminder: ReminderType | null) => void;
   onUpdateRecurrence?: (recurrence: RecurrenceType | null) => void;
   // Notes

--- a/packages/ui/src/ThingsList.tsx
+++ b/packages/ui/src/ThingsList.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from "react";
 import type { Thing, NavList } from "@brett/types";
 import { ThingCard } from "./ThingCard";
 import { SectionHeader } from "./SectionHeader";
+import { CollapsibleSection } from "./CollapsibleSection";
 import { QuickAddInput, type QuickAddInputHandle } from "./QuickAddInput";
 import { useListKeyboardNav } from "./useListKeyboardNav";
 import { useDeferredToggle } from "./useDeferredToggle";
@@ -33,9 +34,16 @@ interface ThingsListProps {
    * `visibility: hidden` so it still occupies layout space but doesn't
    * duplicate the chrome active-section header above the inner scroll. */
   hiddenHeaderKey?: string | null;
+  /** Controlled open-state map for sections that should be collapsible.
+   * Keys are section keys (e.g. "this-week", "this-weekend", "done-today");
+   * absent keys = section is always-expanded (Overdue, Today). When the
+   * parent owns this map (persisting state per-user via
+   * useLocalStorageBoolean), a section with `false` hides its items and
+   * shows a chevron header. */
+  collapsibleSections?: Record<string, { open: boolean; onOpenChange: (open: boolean) => void }>;
 }
 
-export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddContent, onTriageOpen, onFocusChange, header, activeFilter, bare, onReconnect, reconnectPendingSourceId, onInstallUpdate, hiddenHeaderKey }: ThingsListProps) {
+export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddContent, onTriageOpen, onFocusChange, header, activeFilter, bare, onReconnect, reconnectPendingSourceId, onInstallUpdate, hiddenHeaderKey, collapsibleSections }: ThingsListProps) {
   // Shared across ThingsList, InboxView, and UpcomingView — see CLAUDE.md
   // list-consistency rule.
   const handleToggleWithFreeze = useDeferredToggle(onToggle);
@@ -124,27 +132,27 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
           {header && <div>{header}</div>}
 
           {grouped.overdue.length > 0 && (
-            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} />
+            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} collapse={collapsibleSections?.["overdue"]} />
           )}
           {grouped.today.length > 0 && (
-            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} />
+            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} />
           )}
           {isWeekendNow ? (
             <>
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
               )}
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
               )}
             </>
           ) : (
             <>
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
               )}
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
               )}
             </>
           )}
@@ -155,7 +163,7 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
 
           {done.length > 0 && (
             <div>
-              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} />
+              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} collapse={collapsibleSections?.["done-today"]} />
             </div>
           )}
         </div>
@@ -196,6 +204,7 @@ function Section({
   onInstallUpdate,
   cardEls,
   hideHeader,
+  collapse,
 }: {
   /** Stable identifier matched against TodayView's section list to drive the
    * chrome active-section header. The chrome header pins at the top of the
@@ -218,7 +227,53 @@ function Section({
    * duplicate. Layout space is preserved so the chrome→in-flow handoff during
    * scroll doesn't jump. */
   hideHeader?: boolean;
+  /** When provided, renders a CollapsibleSection header. Items render only
+   * when `open` is true. The chrome active-section header in TodayView
+   * already skips collapsed sections because there are no items to scroll
+   * past. */
+  collapse?: { open: boolean; onOpenChange: (open: boolean) => void };
 }) {
+  const items = (
+    <div className="flex flex-col">
+      {things.map((item, i) => (
+        <ThingCard
+          key={item.id}
+          thing={item}
+          onClick={() => onItemClick(item)}
+          onToggle={onToggle}
+          isFocused={focusedIndex === indexOffset + i}
+          onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
+            ? () => onReconnect(item.sourceId!)
+            : undefined}
+          reconnectPending={item.sourceId === reconnectPendingSourceId}
+          onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
+          onElementRef={(el) => {
+            if (el) cardEls.current.set(item.id, el);
+            else cardEls.current.delete(item.id);
+          }}
+        />
+      ))}
+    </div>
+  );
+
+  // Collapsible variant: header is a chevron button, items render only when
+  // open. `hideHeader` doesn't apply — the chrome active-section header in
+  // TodayView never tracks collapsed sections.
+  if (collapse) {
+    return (
+      <div data-section-key={sectionKey}>
+        <CollapsibleSection
+          title={title}
+          count={things.length}
+          open={collapse.open}
+          onOpenChange={collapse.onOpenChange}
+        >
+          {items}
+        </CollapsibleSection>
+      </div>
+    );
+  }
+
   return (
     <div data-section-key={sectionKey}>
       {/* For non-active sections the in-flow header is a visible divider.
@@ -232,26 +287,7 @@ function Section({
       {!hideHeader && (
         <SectionHeader title={title} count={things.length} />
       )}
-      <div className="flex flex-col">
-        {things.map((item, i) => (
-          <ThingCard
-            key={item.id}
-            thing={item}
-            onClick={() => onItemClick(item)}
-            onToggle={onToggle}
-            isFocused={focusedIndex === indexOffset + i}
-            onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
-              ? () => onReconnect(item.sourceId!)
-              : undefined}
-            reconnectPending={item.sourceId === reconnectPendingSourceId}
-            onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
-            onElementRef={(el) => {
-              if (el) cardEls.current.set(item.id, el);
-              else cardEls.current.delete(item.id);
-            }}
-          />
-        ))}
-      </div>
+      {items}
     </div>
   );
 }

--- a/packages/ui/src/ThingsList.tsx
+++ b/packages/ui/src/ThingsList.tsx
@@ -35,11 +35,10 @@ interface ThingsListProps {
    * duplicate the chrome active-section header above the inner scroll. */
   hiddenHeaderKey?: string | null;
   /** Controlled open-state map for sections that should be collapsible.
-   * Keys are section keys (e.g. "this-week", "this-weekend", "done-today");
-   * absent keys = section is always-expanded (Overdue, Today). When the
-   * parent owns this map (persisting state per-user via
-   * useLocalStorageBoolean), a section with `false` hides its items and
-   * shows a chevron header. */
+   * Keys are section keys (e.g. "tonight", "this-week", "this-weekend",
+   * "done-today"); absent keys = section is always-expanded (Overdue,
+   * Today). When the parent owns this map, a section with `false` hides
+   * its items and shows the on-brand animated chevron header. */
   collapsibleSections?: Record<string, { open: boolean; onOpenChange: (open: boolean) => void }>;
 }
 
@@ -59,16 +58,21 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
   const { uncompleted, done, grouped, allItems } = (() => {
     const uncompleted = things.filter((t) => !t.isCompleted);
     const done = things.filter((t) => t.isCompleted);
+    const todayAll = uncompleted.filter((t) => t.urgency === "today");
     const grouped = {
       overdue: uncompleted.filter((t) => t.urgency === "overdue"),
-      today: uncompleted.filter((t) => t.urgency === "today"),
+      // Today-day items where `tonight` is true render under a separate
+      // "Tonight" header. Splitting is presentation-only — they still
+      // contribute to keyboard nav and the all-items focus chain.
+      today: todayAll.filter((t) => !t.tonight),
+      tonight: todayAll.filter((t) => t.tonight),
       this_week: uncompleted.filter((t) => t.urgency === "this_week"),
       this_weekend: uncompleted.filter((t) => t.urgency === "this_weekend"),
     };
     const weekChunks = isWeekendNow
       ? [...grouped.this_weekend, ...grouped.this_week]
       : [...grouped.this_week, ...grouped.this_weekend];
-    const allItems = [...grouped.overdue, ...grouped.today, ...weekChunks, ...done];
+    const allItems = [...grouped.overdue, ...grouped.today, ...grouped.tonight, ...weekChunks, ...done];
     return { uncompleted, done, grouped, allItems };
   })();
   const quickAddRef = useRef<QuickAddInputHandle>(null);
@@ -107,13 +111,16 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
   const hasUncompleted = uncompleted.length > 0;
 
   // Compute running offset so Section knows which indices are "focused".
-  // The order here MUST match the `allItems` concat above — weekend comes
-  // before week on Sat/Sun, otherwise after.
+  // The order here MUST match the `allItems` concat above — Tonight slots
+  // right after Today; weekend comes before week on Sat/Sun, otherwise
+  // after.
   let offset = 0;
   const overdueOffset = offset;
   offset += grouped.overdue.length;
   const todayOffset = offset;
   offset += grouped.today.length;
+  const tonightOffset = offset;
+  offset += grouped.tonight.length;
   const firstWeekChunkOffset = offset;
   const firstWeekChunkLength = isWeekendNow ? grouped.this_weekend.length : grouped.this_week.length;
   offset += firstWeekChunkLength;
@@ -136,6 +143,9 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
           )}
           {grouped.today.length > 0 && (
             <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} />
+          )}
+          {grouped.tonight.length > 0 && (
+            <Section sectionKey="tonight" title="Tonight" things={grouped.tonight} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={tonightOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "tonight"} collapse={collapsibleSections?.["tonight"]} />
           )}
           {isWeekendNow ? (
             <>
@@ -284,9 +294,7 @@ function Section({
        *  data-section-key — the chrome already shows the name. TodayView
        *  compensates scrollTop on transitions so the layout shift doesn't
        *  pop the viewport. */}
-      {!hideHeader && (
-        <SectionHeader title={title} count={things.length} />
-      )}
+      {!hideHeader && <SectionHeader title={title} count={things.length} />}
       {items}
     </div>
   );

--- a/packages/ui/src/__tests__/quickPicker/QuickDatePicker.test.tsx
+++ b/packages/ui/src/__tests__/quickPicker/QuickDatePicker.test.tsx
@@ -45,10 +45,13 @@ function renderPicker(
 }
 
 describe("QuickDatePicker", () => {
-  it("renders the six preset chips with letters and resolved dates", () => {
+  it("renders the seven preset chips with letters and resolved dates", () => {
     renderPicker();
     expect(screen.getByTestId("chip-today")).toHaveTextContent("Today");
     expect(screen.getByTestId("chip-today")).toHaveTextContent("Thu · May 7");
+    expect(screen.getByTestId("chip-tonight")).toHaveTextContent("Tonight");
+    // Tonight resolves to the same calendar day as Today.
+    expect(screen.getByTestId("chip-tonight")).toHaveTextContent("Thu · May 7");
     expect(screen.getByTestId("chip-tomorrow")).toHaveTextContent("Tomorrow");
     expect(screen.getByTestId("chip-this_weekend")).toHaveTextContent("This Weekend");
     expect(screen.getByTestId("chip-this_weekend")).toHaveTextContent("Sat · May 9");
@@ -57,11 +60,28 @@ describe("QuickDatePicker", () => {
     expect(screen.getByTestId("chip-next_month")).toHaveTextContent("Next Month");
 
     expect(screen.getByTestId("chip-today")).toHaveTextContent("T");
+    expect(screen.getByTestId("chip-tonight")).toHaveTextContent("E");
     expect(screen.getByTestId("chip-tomorrow")).toHaveTextContent("M");
     expect(screen.getByTestId("chip-this_weekend")).toHaveTextContent("S");
     expect(screen.getByTestId("chip-this_week")).toHaveTextContent("W");
     expect(screen.getByTestId("chip-next_week")).toHaveTextContent("N");
     expect(screen.getByTestId("chip-next_month")).toHaveTextContent("X");
+  });
+
+  it("commits tonight=true when the Tonight chip is picked, tonight=false for every other preset", () => {
+    const { onCommit } = renderPicker();
+    fireEvent.keyDown(window, { key: "e" });
+    expect(onCommit).toHaveBeenLastCalledWith(expect.any(Date), "day", true);
+
+    onCommit.mockClear();
+    fireEvent.keyDown(window, { key: "t" });
+    // Today (and every non-Tonight chip) must explicitly pass tonight=false
+    // so re-triaging a Tonight task into another bucket clears the flag.
+    expect(onCommit).toHaveBeenLastCalledWith(expect.any(Date), "day", false);
+
+    onCommit.mockClear();
+    fireEvent.keyDown(window, { key: "m" });
+    expect(onCommit).toHaveBeenLastCalledWith(expect.any(Date), "day", false);
   });
 
   it("commits today when 't' is pressed", () => {
@@ -91,11 +111,13 @@ describe("QuickDatePicker", () => {
   it("clears the date on Backspace and Delete", () => {
     const { onCommit } = renderPicker({ initialDate: MAY_7 });
     fireEvent.keyDown(window, { key: "Backspace" });
-    expect(onCommit).toHaveBeenLastCalledWith(null, "day");
+    // Clearing the date also clears any tonight flag — clears are never
+    // partial. The third arg is `false`, not `undefined`.
+    expect(onCommit).toHaveBeenLastCalledWith(null, "day", false);
 
     onCommit.mockClear();
     fireEvent.keyDown(window, { key: "Delete" });
-    expect(onCommit).toHaveBeenLastCalledWith(null, "day");
+    expect(onCommit).toHaveBeenLastCalledWith(null, "day", false);
   });
 
   it("calls onCancel on Escape and does not commit", () => {

--- a/packages/ui/src/__tests__/quickPicker/letters.test.ts
+++ b/packages/ui/src/__tests__/quickPicker/letters.test.ts
@@ -9,6 +9,7 @@ describe("date picker letter map", () => {
   it("maps letters to presets in the spec'd order", () => {
     expect(DATE_LETTER_TO_PRESET).toEqual({
       t: "today",
+      e: "tonight",
       m: "tomorrow",
       s: "this_weekend",
       w: "this_week",
@@ -20,6 +21,7 @@ describe("date picker letter map", () => {
   it("exposes preset order matching chip layout (top to bottom)", () => {
     expect(DATE_PRESET_ORDER).toEqual([
       "today",
+      "tonight",
       "tomorrow",
       "this_weekend",
       "this_week",
@@ -30,6 +32,7 @@ describe("date picker letter map", () => {
 
   it("provides display labels for every preset", () => {
     expect(DATE_PRESET_LABELS.today).toBe("Today");
+    expect(DATE_PRESET_LABELS.tonight).toBe("Tonight");
     expect(DATE_PRESET_LABELS.tomorrow).toBe("Tomorrow");
     expect(DATE_PRESET_LABELS.this_weekend).toBe("This Weekend");
     expect(DATE_PRESET_LABELS.this_week).toBe("This Week");

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,6 +50,7 @@ export { useListKeyboardNav } from "./useListKeyboardNav";
 export { useDeferredToggle } from "./useDeferredToggle";
 export { ItemListShell } from "./ItemListShell";
 export { SectionHeader } from "./SectionHeader";
+export { CollapsibleSection } from "./CollapsibleSection";
 export { useClickOutside } from "./useClickOutside";
 export { TaskDetailPanel } from "./TaskDetailPanel";
 export { OverflowMenu } from "./OverflowMenu";

--- a/packages/ui/src/quickPicker/QuickDatePicker.tsx
+++ b/packages/ui/src/quickPicker/QuickDatePicker.tsx
@@ -21,8 +21,13 @@ export interface QuickDatePickerProps {
    * picks. Callers that previously hard-coded `"day"` should pass `precision`
    * through verbatim — otherwise week-precision picks silently corrupt into
    * weekend-bucketed day-precision items.
+   *
+   * `tonight` is `true` only when the user picked the Tonight chip. Every
+   * other commit path — other chips, raw calendar dates, clearing the date —
+   * passes `false`, which intentionally clears any previously set tonight
+   * flag on the item.
    */
-  onCommit: (date: Date | null, precision: DueDatePrecision) => void;
+  onCommit: (date: Date | null, precision: DueDatePrecision, tonight: boolean) => void;
   onCancel: () => void;
   placement?: "bottom-end" | "bottom-start" | "top-end" | "top-start";
   now?: Date;
@@ -81,7 +86,7 @@ export function QuickDatePicker({
   const commitPreset = useCallback(
     (preset: TriageDatePreset) => {
       const result = computeTriageResult(preset, now ?? new Date());
-      onCommit(new Date(result.dueDate), result.dueDatePrecision);
+      onCommit(new Date(result.dueDate), result.dueDatePrecision, result.tonight);
     },
     [onCommit, now],
   );
@@ -97,7 +102,7 @@ export function QuickDatePicker({
       }
       if (lower === "backspace" || lower === "delete") {
         e.preventDefault();
-        onCommit(null, "day");
+        onCommit(null, "day", false);
         return;
       }
       if (lower in DATE_LETTER_TO_PRESET) {
@@ -147,7 +152,7 @@ export function QuickDatePicker({
       }
       if (e.key === "Enter") {
         e.preventDefault();
-        onCommit(highlighted, "day");
+        onCommit(highlighted, "day", false);
         return;
       }
     }
@@ -173,7 +178,7 @@ export function QuickDatePicker({
         // computeTriageResult re-interprets the input through local components.
         now={now ?? new Date()}
         onCommitPreset={commitPreset}
-        onClear={() => onCommit(null, "day")}
+        onClear={() => onCommit(null, "day", false)}
       />
       <div className="w-[185px] border-l border-white/5 pl-2">
         <ScrollableCalendar
@@ -181,7 +186,7 @@ export function QuickDatePicker({
           highlightedDate={highlighted}
           selectedDate={initialDate}
           onHighlight={setHighlighted}
-          onCommit={(d) => onCommit(d, "day")}
+          onCommit={(d) => onCommit(d, "day", false)}
           now={today}
         />
       </div>

--- a/packages/ui/src/quickPicker/TriageQuickPicker.tsx
+++ b/packages/ui/src/quickPicker/TriageQuickPicker.tsx
@@ -11,7 +11,7 @@ export interface TriageQuickPickerProps {
   suggestedListIds: string[];
   suggestionMode: "suggested" | "recent" | "empty";
   startWith: "date" | "list";
-  onCommitDate: (date: Date | null, precision: DueDatePrecision) => void;
+  onCommitDate: (date: Date | null, precision: DueDatePrecision, tonight: boolean) => void;
   onCommitList: (listId: string | null) => void;
   onClose: () => void;
   placement?: "bottom-end" | "bottom-start" | "top-end" | "top-start";
@@ -22,8 +22,8 @@ export function TriageQuickPicker(props: TriageQuickPickerProps) {
   const { startWith } = props;
   const [step, setStep] = useState<"date" | "list">(startWith);
 
-  const handleDateCommit = (date: Date | null, precision: DueDatePrecision) => {
-    props.onCommitDate(date, precision);
+  const handleDateCommit = (date: Date | null, precision: DueDatePrecision, tonight: boolean) => {
+    props.onCommitDate(date, precision, tonight);
     if (step !== startWith) {
       // We are on step 2 (i.e. startWith was "list", we already committed a list)
       props.onClose();

--- a/packages/ui/src/quickPicker/letters.ts
+++ b/packages/ui/src/quickPicker/letters.ts
@@ -2,6 +2,10 @@ import type { TriageDatePreset } from "@brett/business";
 
 export const DATE_LETTER_TO_PRESET: Record<string, TriageDatePreset> = {
   t: "today",
+  // 'e' for evening — 'n' was the obvious pick but is already next_week;
+  // 't' / 'm' are taken by today/tomorrow; 'i' / 'g' from "tonight" read
+  // less naturally as a shortcut hint.
+  e: "tonight",
   m: "tomorrow",
   s: "this_weekend",
   w: "this_week",
@@ -11,6 +15,7 @@ export const DATE_LETTER_TO_PRESET: Record<string, TriageDatePreset> = {
 
 export const DATE_PRESET_ORDER: TriageDatePreset[] = [
   "today",
+  "tonight",
   "tomorrow",
   "this_weekend",
   "this_week",
@@ -20,6 +25,7 @@ export const DATE_PRESET_ORDER: TriageDatePreset[] = [
 
 export const DATE_PRESET_LABELS: Record<TriageDatePreset, string> = {
   today: "Today",
+  tonight: "Tonight",
   tomorrow: "Tomorrow",
   this_weekend: "This Weekend",
   this_week: "This Week",


### PR DESCRIPTION
## Summary
- Today badge narrowed to overdue + today (drops "this week" and weekend logic)
- Animated collapsible This Week / This Weekend / Done Today sections on desktop (220ms ease-out on the design-guide curve)
- Tonight concept: new \`tonight\` boolean on Item, "Tonight" chip in date pickers (desktop + iOS), Tonight section in Today view with 6pm auto-expand on desktop
- Per-account connection health visibility: \`/things/broken-connections\` exposes per-account details; Settings cards show inline warning chrome + reason text
- Google Calendar OAuth callback fixed to scope re-link resolution to the specific reconnecting account (matches existing Granola behavior)

Spec: [docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md](https://github.com/brentbarkman/brett/blob/main/docs/superpowers/specs/2026-05-18-brett-tuning-may-design.md)
Plan: [docs/superpowers/plans/2026-05-18-brett-tuning-may.md](https://github.com/brentbarkman/brett/blob/main/docs/superpowers/plans/2026-05-18-brett-tuning-may.md)

Includes PRs #172, #173, #174.

## Test plan
- [x] pnpm typecheck (all packages)
- [x] pnpm test (api 783, business 261, ui 134, desktop 202)
- [x] xcodebuild build -scheme Brett
- [ ] Manual: Today view collapse animation, badge narrowed, Tonight chip + section, per-account warning chrome

## Migration
Additive \`Item.tonight Boolean @default(false)\` — single \`ALTER\`, non-destructive. Older clients ignore unknown field on pull and cannot set it (fall back to "Today" semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)