### PR TITLE
fix(ios): format overdue task weekday in UTC, not device TZ (#176)

### DIFF
--- a/apps/ios/Brett/Utilities/DateHelpers.swift
+++ b/apps/ios/Brett/Utilities/DateHelpers.swift
@@ -137,6 +137,15 @@ enum DateHelpers {
         return f
     }()
 
+    /// Weekday name ("Monday", "Tuesday") of a stored `dueDate`. Reads
+    /// the date through `utcCalendar` because the storage convention is
+    /// "UTC midnight of the user's local calendar date" — formatting in
+    /// the device TZ would flip the weekday near midnight (UTC-midnight
+    /// reads as the previous day in any TZ west of UTC).
+    static func weekdayName(of date: Date) -> String {
+        utcWeekdayFormatter.string(from: date)
+    }
+
     private static let utcMonthDayFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d"

--- a/apps/ios/Brett/Views/Shared/TaskRow.swift
+++ b/apps/ios/Brett/Views/Shared/TaskRow.swift
@@ -457,19 +457,21 @@ struct TaskRow: View {
     /// don't render time-of-day; there's no UI to set a time on a
     /// task and desktop's `ThingCard` doesn't display one either.
     /// `nil` means "no whisper, skip the segment."
+    ///
+    /// "Overdue" is decided via `DateHelpers.computeUrgency`, which
+    /// anchors today to the UTC-midnight of the user's local calendar
+    /// date. A naïve `Calendar.current.startOfDay` check would
+    /// misclassify due-today tasks as overdue in any TZ west of UTC
+    /// (today's UTC-midnight stored value sorts before today's local
+    /// midnight), and then label them with yesterday's weekday because
+    /// a local-TZ formatter reads UTC-midnight as the previous day.
     private static func timeLabel(for item: Item) -> String? {
         guard let due = item.dueDate else { return nil }
-        if due < Calendar.current.startOfDay(for: Date()) {
-            return weekdayFormatter.string(from: due)
+        guard DateHelpers.computeUrgency(dueDate: due, isCompleted: false) == .overdue else {
+            return nil
         }
-        return nil
+        return DateHelpers.weekdayName(of: due)
     }
-
-    private static let weekdayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEEE"
-        return formatter
-    }()
 
     private static func capturedLabel(for item: Item) -> String? {
         // "Captured {relative}" for undated content/inbox items

--- a/apps/ios/BrettTests/DateHelpersTests.swift
+++ b/apps/ios/BrettTests/DateHelpersTests.swift
@@ -105,4 +105,31 @@ struct DateHelpersTests {
         let formatted = DateHelpers.formatTime(date)
         #expect(formatted.contains("2:30") || formatted.contains("14:30"))
     }
+
+    // MARK: - weekdayName
+
+    /// A stored `dueDate` is UTC midnight of the user's intended local
+    /// calendar date. Formatting it in any other timezone flips the
+    /// weekday near midnight (in TZs west of UTC, UTC-midnight reads as
+    /// "the previous day" locally) — which is the exact bug that put a
+    /// "Monday" subtext on tasks due Tuesday. Guard with a TZ-independent
+    /// assertion: Tuesday-UTC-midnight must read as "Tuesday" no matter
+    /// what TZ the host simulator is in.
+    @Test func weekdayNameUsesUTCCalendar() {
+        // 2026-05-19 is a Tuesday in UTC. A user in MDT (UTC-6) would
+        // pick this date locally and the storage layer normalises it
+        // to 2026-05-19T00:00Z (utcMidnightOfLocalDate). Formatting in
+        // the local TZ would yield "Monday" — guard against that.
+        let tuesday = Self.utcDate(2026, 5, 19, 0)
+        #expect(DateHelpers.weekdayName(of: tuesday) == "Tuesday")
+    }
+
+    @Test func weekdayNameAtUTCMidnightIsStableAcrossDays() {
+        // Spot-check several days of the week to make sure the formatter
+        // isn't just stuck on one value.
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 17, 0)) == "Sunday")
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 18, 0)) == "Monday")
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 19, 0)) == "Tuesday")
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 23, 0)) == "Saturday")
+    }
 }


### PR DESCRIPTION
Closes #176

## Root cause

The "Monday" subtext on tasks you saw on Tuesday is a compound timezone bug in `TaskRow`:

1. **Wrong "today" anchor.** `timeLabel(for:)` was checking `due < Calendar.current.startOfDay(for: Date())`. That uses *local* midnight — which in MDT is 06:00 UTC, i.e. *after* the UTC-midnight stored value for today. So a task due today (stored as `2026-05-19T00:00Z`) sorted before "local startOfDay" and got classified as overdue.
2. **Wrong formatter timezone.** The private `weekdayFormatter` had no `timeZone` set, so it used the device TZ. Reading `2026-05-19T00:00Z` (Tuesday) in MDT (UTC−6) yields `2026-05-18 18:00 MDT`, which formats as **Monday**.

Result: today's task → falsely flagged overdue → label rendered as yesterday's weekday.

The rest of the app already had this figured out — `DateHelpers.computeUrgency` anchors today via `utcMidnightOfLocalDate`, and the private `utcWeekdayFormatter` already pinned UTC. `TaskRow` just hadn't been wired through them.

## Approach

Considered three options:

1. **Set `timeZone = UTC` on TaskRow's local formatter, swap the local `startOfDay` for `DateHelpers.utcMidnightOfLocalDate`.** Two literal patches; keeps date logic in the view layer. Rejected — duplicates the canonical UTC formatter and the urgency-anchor logic that `DateHelpers` already owns.
2. **Extract a shared `isOverdue(dueDate:)` helper.** Cleaner API but a new concept; `computeUrgency(...) == .overdue` already encodes it.
3. **Use the existing helpers — `DateHelpers.computeUrgency` for the overdue check, a new `DateHelpers.weekdayName(of:)` for the formatter.** ← picked. Zero new concepts; deletes the duplicate formatter; routes through code that's already covered by the `computeUrgency` test suite and the new `weekdayName` tests below.

## Tests

Added two `@Test` cases under `DateHelpersTests`:

- `weekdayNameUsesUTCCalendar` — pins the exact bug: `weekdayName(of: 2026-05-19T00:00Z) == "Tuesday"`. Would have failed before the formatter set UTC (the value reads as Monday in MDT).
- `weekdayNameAtUTCMidnightIsStableAcrossDays` — spot-checks Sun/Mon/Tue/Sat so the formatter isn't accidentally pinned to a single day.

The "today is not overdue" half of the bug is already covered by the existing `computeUrgencyToday` test, which the new code now routes through.

I deliberately did not add a test for `TaskRow.timeLabel` directly — it's `private static`, and now that it's a 4-line composition of two well-tested helpers, an integration test would just mirror the implementation. **Test-prevention check:** the failing assertion `weekdayName(of: TuesdayUTC) == "Tuesday"` catches the *category* of bug (any code formatting a stored due date in the device TZ), not just this instance.

## Verification

iOS-only change. `pnpm typecheck` / `pnpm test` don't cover Swift, so the new test cases need `xcodebuild test` locally on macOS to confirm green. Visual verification on the simulator at any time of day in MDT: today's tasks should now have no overdue whisper; yesterday's tasks should whisper "Monday" (correctly), not "Sunday".

## Risks

Behavioral change is intended and narrow: tasks due today no longer get an overdue whisper in any negative-UTC timezone. Historically those users saw a `(yesterday)` whisper on today's task — they'll now see no whisper, which matches what users in UTC/Asia have been seeing all along.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5BvTNVwE9U4GHQE6Zp5Wh)_