### PR TITLE
fix(ios): silence the pulling sync dot in the top bar (#177)

### DIFF
--- a/apps/ios/Brett/Views/Shared/SyncStatusIndicator.swift
+++ b/apps/ios/Brett/Views/Shared/SyncStatusIndicator.swift
@@ -6,7 +6,12 @@ import SwiftUI
 /// - `idle` / no session → invisible 8x8 dot (kept in layout so other
 ///   icons don't shift when state flips).
 /// - `pushing`           → gold dot with a subtle pulse (local → server).
-/// - `pulling`           → cerulean dot with a subtle pulse (server → local).
+/// - `pulling`           → invisible (was a cerulean pulsing dot; removed
+///   because every pull — including the 30s background poll — was
+///   flashing a blue dot in the corner that read as debug residue
+///   without telling the user anything actionable. Pushes still show
+///   gold because they represent the user's own outbound writes;
+///   pulls now go silent unless they error).
 /// - `error`             → red dot, tappable; opens a sheet with the message.
 ///
 /// Mount inside the top bar next to the settings / scouts / search icons.
@@ -39,7 +44,10 @@ struct SyncStatusIndicator: View {
                 dot(color: BrettColors.gold.opacity(0.85), isInteractive: false, pulse: true)
 
             case .pulling:
-                dot(color: BrettColors.cerulean.opacity(0.85), isInteractive: false, pulse: true)
+                // Render the same invisible placeholder as `.idle` so the
+                // surrounding icon row doesn't shift when sync flips
+                // pulling↔idle on every 30s background poll.
+                dot(color: .clear, isInteractive: false, pulse: false)
 
             case .error:
                 dot(color: BrettColors.error, isInteractive: true, pulse: false)
@@ -57,7 +65,7 @@ struct SyncStatusIndicator: View {
         .animation(.easeInOut(duration: 0.2), value: state)
         .onChange(of: state) { _, newValue in
             switch newValue {
-            case .pushing, .pulling:
+            case .pushing:
                 isPulsing = true
             default:
                 isPulsing = false
@@ -98,9 +106,8 @@ struct SyncStatusIndicator: View {
 
     private var accessibilityLabel: String {
         switch state {
-        case .idle: return ""
+        case .idle, .pulling: return ""
         case .pushing: return "Sync: sending changes"
-        case .pulling: return "Sync: receiving changes"
         case .error(let message): return "Sync error: \(message)"
         }
     }


### PR DESCRIPTION
Closes #177

## Root cause

`SyncStatusIndicator` was rendering a pulsing cerulean dot for the `.pulling` state. That state fires on every pull-to-refresh AND on the 30s background sync poll, so the dot was flashing in the top-right corner of every screen (Inbox included) several times a minute without communicating anything actionable — exactly the "debug residue" feeling you described.

Mounted at `apps/ios/Brett/Views/MainContainer.swift:406`. State plumbing in `apps/ios/Brett/Sync/SyncManager.swift`.

## Approach

Three options considered:

1. **Hide the indicator on the Inbox screen only.** Rejected — the dot is global chrome on the top bar; cherry-picking by page would require plumbing the route into the indicator. Doesn't address the same noise on Today/Lists/Calendar/Scouts.
2. **Make pulling pulse less prominent (lower opacity, no animation).** Rejected — still draws the eye on every background poll without telling the user anything. The whole pull-state cadence is what makes it read as debug.
3. **Stop rendering pulling entirely; keep pushing (gold) and error (red).** ← picked. Pull-to-refresh already shows the system spinner during a user-initiated pull, so the user has feedback when they ask for it. Background polls go silent — the right default. Pushes still get the gold dot because they represent the user's own outbound writes (useful affordance: "I just toggled this task; is it saved?"). Errors still get the red dot (tappable for the message; preserves the existing `claude-needs-input` workflow for #109).

## Tests

UI-only change — no test added. **Reason:** the bug is "this state renders a visible dot when it shouldn't"; the right assertion is "does the user see a flash in the corner during a background sync?" — which is visual, not logic. A test like "`.pulling` renders `Color.clear`" would just mirror the implementation. No existing tests reference `SyncStatusIndicator` to break.

**Test-prevention check:** could a pragmatic test have caught this category of bug? No — the dot's existence was a deliberate UX choice that turned out to be wrong; no automated check would have flagged it. The fix is a product-judgement call.

Verify visually via `gh pr checkout 180` (or the equivalent), then sit on Inbox for ~60 seconds. Pre-fix: blue dot flashes a few times during the background poll. Post-fix: corner stays quiet.

## Risks

- **Discoverability of background sync.** Removing the indicator means users have no visible signal that the app is actively pulling. Mitigation: pull-to-refresh keeps its system spinner; errors still surface as the red tappable dot; pushes (the user's own writes) still surface as the gold dot.
- **Accessibility.** The VoiceOver label for `.pulling` is now an empty string, matching `.idle`. That matches behaviour — there's nothing visible to announce — and avoids announcing "Sync: receiving changes" every 30 seconds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5BvTNVwE9U4GHQE6Zp5Wh)_