### PR TITLE
fix(ios): align hero text with section-header text edge (#178)

### DIFF
--- a/apps/ios/Brett/Views/Shared/EditorialPageHeader.swift
+++ b/apps/ios/Brett/Views/Shared/EditorialPageHeader.swift
@@ -17,12 +17,15 @@ struct EditorialPageHeader: View {
     let title: String
     let subtitle: String?
     var variant: Variant = .onWash
-    /// Inset from the leading edge. Default 24pt to match the
-    /// canonical calm-hero pages (Today / Inbox / Lists / Calendar /
-    /// Scouts). Settings nests the header inside `BrettSettingsScroll`
-    /// (which already pads 16pt for cards), so it passes 0 here to
-    /// avoid compounding to a 40pt offset.
-    var horizontalPadding: CGFloat = 24
+    /// Inset from the leading edge. `BrettSpacing.pagePaddingX` (20pt)
+    /// aligns the title with the section-header text that sits below
+    /// it on every calm-hero page — sticky-card sections place their
+    /// header at 16pt card padding + 4pt internal = 20pt from the
+    /// screen edge, and the header used to be 4pt further right than
+    /// those headers at 24pt. Settings nests the header inside
+    /// `BrettSettingsScroll` (which already pads 16pt for cards), so
+    /// it passes 0 here to avoid compounding.
+    var horizontalPadding: CGFloat = BrettSpacing.pagePaddingX
 
     enum Variant {
         case onWash

--- a/apps/ios/Brett/Views/Today/NextUpCard.swift
+++ b/apps/ios/Brett/Views/Today/NextUpCard.swift
@@ -56,8 +56,9 @@ struct NextUpCard: View {
             // Vertical rhythm tuned by hand: ~16pt of breathing room
             // from the brief above so the editorial moment lands as a
             // separate beat, with a tight 4pt gap below so OVERDUE
-            // pulls right up under it.
-            .padding(.horizontal, 24)
+            // pulls right up under it. Horizontal matches the hero +
+            // section-header text edge — `BrettSpacing.pagePaddingX`.
+            .padding(.horizontal, BrettSpacing.pagePaddingX)
             .padding(.top, 16)
             .padding(.bottom, 4)
             .accessibilityElement(children: .combine)

--- a/apps/ios/Brett/Views/Today/TodayHero.swift
+++ b/apps/ios/Brett/Views/Today/TodayHero.swift
@@ -85,7 +85,13 @@ struct TodayHero: View {
                     .transition(.opacity)
             }
         }
-        .padding(.horizontal, 24)
+        // Match `BrettSpacing.pagePaddingX` (20pt) so the greeting +
+        // dateline align with the section-header text below ("TODAY",
+        // "OVERDUE", etc., which sit at 16pt card padding + 4pt header
+        // padding = 20pt from the screen edge). The earlier 24pt
+        // literal left the hero 4pt further right than every section
+        // header underneath it.
+        .padding(.horizontal, BrettSpacing.pagePaddingX)
         .padding(.top, 12)
         .padding(.bottom, 12)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/ios/DESIGN.md
+++ b/apps/ios/DESIGN.md
@@ -74,7 +74,7 @@ All four primary pages and Scouts use the same editorial header treatment via `E
 
 - **Title:** 38pt serif (New York / `design: .serif`), white. On the Today hero the title is a time-of-day greeting ("Tuesday morning") with layered text-shadow for legibility against any photo. On non-Today pages the title is the page name ("Inbox", "May 4", "Lists", "Scouts") with no shadow.
 - **Sub-line:** 13pt sans, white at 0.7. Counts ("3 to triage", "2 events", "5 lists") or a date.
-- **Position:** leading-aligned, 24pt horizontal padding, top respects the safe-area inset (never hardcode 60pt).
+- **Position:** leading-aligned, `BrettSpacing.pagePaddingX` (20pt) horizontal padding so the title aligns with the section-header text that sits below it (sticky-card sections place their header at 16pt card padding + 4pt internal = 20pt from the screen edge). Top respects the safe-area inset (never hardcode 60pt).
 
 The legacy 28pt `BrettTypography.dateHeader` is **deprecated for top-level page titles**. It still applies to nested labels (e.g. a date inside a calendar day cell).
 


### PR DESCRIPTION
Closes #178

## Root cause

The hero band (Day / Date / Briefing on Today) was rendered at 24pt of horizontal padding. The section headers below it ("TODAY", "OVERDUE", etc.) sit inside a `StickyCardSection` at 16pt outer card padding + 4pt internal header padding = **20pt** from the screen edge. So every calm-hero page on iOS had a 4pt mismatch between the editorial header and the section-header text below it.

It's not only Today — the same shape applies to Inbox, Calendar, Lists, and Scouts via the shared `EditorialPageHeader` component, which defaulted to `horizontalPadding: 24`. Same 4pt drift on every page.

## Approach

Three options considered:

1. **Move section headers right (4 → 8 internal padding, shifts header text from x=20 → x=24).** Rejected — touches `StickyCardSection`, which is shared by *all* list surfaces (Today, Inbox, Lists, Calendar, Scouts), and pushes the count pill 4pt inward from the card edge on every one. Bigger blast radius for the same visual result.
2. **Move hero left only on Today (TodayHero + NextUpCard).** Rejected — fixes Brent's reproducer but leaves Inbox / Calendar / Lists / Scouts with the same 4pt mismatch, violating the "iOS visual parity" rule.
3. **Move the hero edge to `BrettSpacing.pagePaddingX` (20pt) everywhere it lives — TodayHero, NextUpCard, and `EditorialPageHeader`'s default.** ← picked. `BrettSpacing.pagePaddingX` already exists as the canonical "page-level horizontal padding" constant; we just weren't using it. Smallest set of edits to fix the whole class of misalignment.

Settings is unaffected — it nests the header inside `BrettSettingsScroll` and passes its own `horizontalPadding: 0` to avoid compounding.

## Tests

UI-only change — no tests added. **Reason:** the bug is a 4pt visual offset; a snapshot would just mirror the literal. No existing tests assert padding values for these views.

**Test-prevention check:** could a pragmatic test have caught this? Not really — alignment between two views in different files isn't easily expressed as a unit assertion without screenshot testing, which isn't set up here. The fix is to route both call-sites through the same `BrettSpacing` constant so future drift is mechanically harder.

Verify visually via `gh pr checkout 181`:
- **Today:** the "Tuesday" greeting + date sub-line + briefing prose + "NEXT UP" event should now share the same left edge as the "TODAY" section-header text below them.
- **Inbox / Calendar / Lists / Scouts:** the editorial page title should share the same left edge as the first section header on that page.

## Risks

- **DESIGN.md said 24pt explicitly.** Updated in this PR to reflect the actual value plus a one-line rationale, so the doc stops contradicting the code.
- **4pt visual shift on the editorial title across 4 non-Today pages.** Intentional and the whole point — they all had the same drift you noticed on Today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5BvTNVwE9U4GHQE6Zp5Wh)_