### PR TITLE
fix(omnibar): optimistic create with on-brand fade-in (#182)

### DIFF
--- a/apps/desktop/src/api/__tests__/omnibar.test.ts
+++ b/apps/desktop/src/api/__tests__/omnibar.test.ts
@@ -61,7 +61,14 @@ describe("useOmnibar", () => {
   });
 
   describe("createTask", () => {
-    it("calls API with title and type task", async () => {
+    // Helper: read the POST /things body from the latest apiFetch call.
+    const lastCreateBody = () => {
+      const call = mockApiFetch.mock.calls.find((c) => c[0] === "/things");
+      if (!call) throw new Error("apiFetch was not called with /things");
+      return JSON.parse(call[1]!.body as string);
+    };
+
+    it("posts a task with the trimmed title and type=task", async () => {
       mockApiFetch.mockResolvedValue({ id: "123", title: "Buy groceries" });
       const { result } = renderHook(() => useOmnibar(), { wrapper: createWrapper() });
 
@@ -69,25 +76,34 @@ describe("useOmnibar", () => {
         await result.current.createTask("Buy groceries");
       });
 
-      expect(mockApiFetch).toHaveBeenCalledWith("/things", {
-        method: "POST",
-        body: JSON.stringify({ title: "Buy groceries", type: "task" }),
-        headers: { "Content-Type": "application/json" },
-      });
+      const path = mockApiFetch.mock.calls[0][0];
+      const init = mockApiFetch.mock.calls[0][1]!;
+      expect(path).toBe("/things");
+      expect(init.method).toBe("POST");
+      const body = lastCreateBody();
+      expect(body.type).toBe("task");
+      expect(body.title).toBe("Buy groceries");
     });
 
-    it("sets dueDate to today when on today view", async () => {
+    it("sets dueDate to today (UTC midnight) when on today view", async () => {
       mockApiFetch.mockResolvedValue({ id: "123", title: "Test" });
       const { result } = renderHook(() => useOmnibar(), { wrapper: createWrapper() });
-
-      const today = new Date().toISOString().split("T")[0];
 
       await act(async () => {
         await result.current.createTask("Test task", "today");
       });
 
-      const callBody = JSON.parse(mockApiFetch.mock.calls[0][1]!.body as string);
-      expect(callBody.dueDate).toBe(today);
+      const body = lastCreateBody();
+      // ISO timestamp at the start of today (UTC). Asserts the value lands in
+      // the same UTC day rather than pinning the exact string format.
+      expect(body.dueDate).toBeTruthy();
+      const due = new Date(body.dueDate);
+      const todayUtc = new Date();
+      todayUtc.setUTCHours(0, 0, 0, 0);
+      expect(due.getUTCFullYear()).toBe(todayUtc.getUTCFullYear());
+      expect(due.getUTCMonth()).toBe(todayUtc.getUTCMonth());
+      expect(due.getUTCDate()).toBe(todayUtc.getUTCDate());
+      expect(body.dueDatePrecision).toBe("day");
     });
 
     it("sets listId when on a list view", async () => {
@@ -98,8 +114,7 @@ describe("useOmnibar", () => {
         await result.current.createTask("Test task", "list:abc123def456");
       });
 
-      const callBody = JSON.parse(mockApiFetch.mock.calls[0][1]!.body as string);
-      expect(callBody.listId).toBe("abc123def456");
+      expect(lastCreateBody().listId).toBe("abc123def456");
     });
 
     it("sets no dueDate or listId for other views", async () => {
@@ -110,16 +125,15 @@ describe("useOmnibar", () => {
         await result.current.createTask("Test task", "inbox");
       });
 
-      const callBody = JSON.parse(mockApiFetch.mock.calls[0][1]!.body as string);
-      expect(callBody.dueDate).toBeUndefined();
-      expect(callBody.listId).toBeUndefined();
+      const body = lastCreateBody();
+      expect(body.dueDate).toBeUndefined();
+      expect(body.listId).toBeUndefined();
     });
 
     it("closes omnibar after creating task", async () => {
       mockApiFetch.mockResolvedValue({ id: "123", title: "Test" });
       const { result } = renderHook(() => useOmnibar(), { wrapper: createWrapper() });
 
-      // Open first
       act(() => result.current.open("bar"));
       expect(result.current.isOpen).toBe(true);
 
@@ -153,6 +167,39 @@ describe("useOmnibar", () => {
       });
 
       expect(result.current.input).toBe("");
+    });
+
+    // Guards the #182 fix: the cache write happens before the server replies.
+    // Without optimistic updates, the user would see lag waiting for the
+    // network round-trip plus refetch.
+    it("inserts into the cache optimistically before the server responds", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      });
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+      // Server hangs — proves the cache write is independent of the network.
+      let resolveServer: (v: unknown) => void = () => {};
+      mockApiFetch.mockImplementation(
+        () => new Promise((resolve) => { resolveServer = resolve; }),
+      );
+
+      queryClient.setQueryData(["inbox"], { visible: [] });
+
+      const { result } = renderHook(() => useOmnibar(), { wrapper });
+
+      act(() => {
+        result.current.createTask("Fresh task");
+      });
+
+      await waitFor(() => {
+        const inbox = queryClient.getQueryData<{ visible: { title: string }[] }>(["inbox"]);
+        expect(inbox?.visible).toHaveLength(1);
+        expect(inbox?.visible[0]?.title).toBe("Fresh task");
+      });
+
+      resolveServer({ id: "server-id", title: "Fresh task" });
     });
   });
 

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -170,6 +170,75 @@ describe("useCreateThing optimistic insert", () => {
     resolveServer(makeThing("server-id", "today task"));
   });
 
+  // ThingsList groups by `urgency`, so an optimistic insert with a hardcoded
+  // urgency wouldn't appear in any section (Today/Overdue/This Week/...).
+  // The provisional Thing must classify itself the same way the server would,
+  // otherwise the user sees lag waiting for the server to fill in the right
+  // urgency — exactly the bug reported in #182.
+  it("computes urgency from dueDate so a today-dated task lands in the Today section", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    // Today and end-of-week in UTC. Use a date close to "now" so the
+    // computeUrgency call (which compares against the real clock) classifies
+    // it as "today".
+    const todayMidnight = new Date();
+    todayMidnight.setUTCHours(0, 0, 0, 0);
+    const todayIso = todayMidnight.toISOString();
+    const endOfWeek = new Date(todayMidnight.getTime() + 6 * 86400000).toISOString();
+    const activeFilters = { status: "active" as const, dueBefore: endOfWeek };
+
+    qc.setQueryData<Thing[]>(["things", activeFilters], []);
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        type: "task",
+        title: "due today",
+        dueDate: todayIso,
+        dueDatePrecision: "day",
+      });
+    });
+
+    await waitFor(() => {
+      const cache = qc.getQueryData<Thing[]>(["things", activeFilters]);
+      expect(cache?.[0]?.urgency).toBe("today");
+    });
+
+    resolveServer(makeThing("server-id", "due today"));
+  });
+
+  // No dueDate → no urgency-bucket placement; default of "later" is what
+  // server-side itemToThing returns too. Keeps the inbox-bound path stable.
+  it("leaves urgency as 'later' when dueDate is not provided", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<InboxResponse>(["inbox"], { visible: [] });
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ type: "task", title: "inbox task" });
+    });
+
+    await waitFor(() => {
+      const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      expect(inbox?.visible[0]?.urgency).toBe("later");
+    });
+
+    resolveServer(makeThing("server-id", "inbox task"));
+  });
+
   // Follow-up from #62: List-scoped add must land in the list's cache
   // (useListThings → ["things", { listId }]) immediately.
   it("inserts a list-scoped task into the matching ['things', { listId }] cache", async () => {

--- a/apps/desktop/src/api/omnibar.ts
+++ b/apps/desktop/src/api/omnibar.ts
@@ -4,7 +4,9 @@ import { streamingFetch } from "./streaming";
 import { useAIConfigs } from "./ai-config";
 import { apiFetch } from "./client";
 import { applyUsageDelta, sessionUsageQueryKey } from "./ai-usage";
-import type { StreamChunk, DisplayHint } from "@brett/types";
+import { useCreateThing } from "./things";
+import { getTodayUTC } from "@brett/business";
+import type { StreamChunk, DisplayHint, CreateItemInput } from "@brett/types";
 
 export interface OmnibarMessage {
   role: "user" | "assistant";
@@ -50,6 +52,14 @@ export function useOmnibar() {
   // Maps tool call id → name so we can look up the name when the result arrives
   const toolCallNamesRef = useRef<Map<string, string>>(new Map());
   const queryClient = useQueryClient();
+
+  // Local create uses the shared optimistic-update path so the new task
+  // appears in cached views (Inbox, Today, custom lists) the moment the
+  // user hits Enter — no waiting for the server. `mutate` identity is
+  // React-Query-stable so the ref pattern keeps `createTask` stable.
+  const createThing = useCreateThing();
+  const createThingMutateRef = useRef(createThing.mutate);
+  createThingMutateRef.current = createThing.mutate;
 
   // Check if AI is configured
   const { data: aiConfigData } = useAIConfigs();
@@ -357,40 +367,31 @@ export function useOmnibar() {
   }, []);
 
   // Local action: create a task directly (no AI needed)
-  // No chat UI — just do it, invalidate queries, close the omnibar
-  // When on Today view, set dueDate to today so it appears in the current list
-  const createTask = useCallback(async (title: string, currentView?: string) => {
+  // No chat UI — just do it. useCreateThing's onMutate optimistically inserts
+  // into every cached view the task belongs in, so the user sees it land
+  // before the server replies. Matches the Today/List QuickAdd contract.
+  const createTask = useCallback((title: string, currentView?: string) => {
     const trimmed = title.trim();
     if (!trimmed) return;
 
     setInput("");
 
-    const body: Record<string, unknown> = { title: trimmed, type: "task" };
-
-    // Context-aware defaults based on current view
+    const input: CreateItemInput = { type: "task", title: trimmed };
     if (currentView === "today") {
-      body.dueDate = new Date().toISOString().split("T")[0];
+      input.dueDate = getTodayUTC().toISOString();
+      input.dueDatePrecision = "day";
     } else if (currentView?.startsWith("list:")) {
-      body.listId = currentView.slice(5);
+      input.listId = currentView.slice(5);
     }
 
-    try {
-      await apiFetch("/things", {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers: { "Content-Type": "application/json" },
-      });
-      queryClient.invalidateQueries({ queryKey: ["things"] });
-      queryClient.invalidateQueries({ queryKey: ["inbox"] });
-    } catch {
-      // Silently fail — user will notice if the task doesn't appear
-    }
+    // Fire-and-forget: optimistic cache update is synchronous, so closing the
+    // omnibar immediately is safe. Errors roll back the cache (see things.ts).
+    createThingMutateRef.current(input);
 
-    // Close omnibar — no conversation in non-AI mode
     setIsOpen(false);
     setMessages([]);
     setSessionId(null);
-  }, [queryClient]);
+  }, []);
 
   const searchThings = useCallback(async (query: string) => {
     const trimmed = query.trim();

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -4,7 +4,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import type { Thing, ThingDetail, CreateItemInput, UpdateItemInput, InboxResponse, BulkUpdateInput } from "@brett/types";
-import { getTodayUTC } from "@brett/business";
+import { getTodayUTC, computeUrgency } from "@brett/business";
 import { apiFetch } from "./client";
 import { invalidateAllThings } from "./invalidate";
 
@@ -73,6 +73,10 @@ export function useUpcomingThings() {
 
 /** Shape a CreateItemInput into a provisional Thing for optimistic caches. */
 function provisionalThing(input: CreateItemInput, tempId: string): Thing {
+  // ThingsList groups by urgency, so a hardcoded default would render the
+  // optimistic insert invisible until the server replies with the real
+  // bucket. Mirror the server's itemToThing classification here.
+  const urgency = computeUrgency(input.dueDate ? new Date(input.dueDate) : null, null);
   return {
     id: tempId,
     type: (input.type as Thing["type"]) ?? "task",
@@ -81,7 +85,7 @@ function provisionalThing(input: CreateItemInput, tempId: string): Thing {
     listId: input.listId ?? null,
     status: (input.status as Thing["status"]) ?? "active",
     source: input.source ?? "manual",
-    urgency: "later",
+    urgency,
     dueDate: input.dueDate,
     dueDatePrecision: input.dueDatePrecision,
     sourceUrl: input.sourceUrl,

--- a/apps/desktop/src/views/UpcomingView.tsx
+++ b/apps/desktop/src/views/UpcomingView.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react";
 import { Clock } from "lucide-react";
-import { ThingCard, ItemListShell, useListKeyboardNav, useDeferredToggle, SkeletonListView, SectionHeader, TypeFilter } from "@brett/ui";
+import { ThingCard, ItemListShell, useListKeyboardNav, useDeferredToggle, useNewItems, SkeletonListView, SectionHeader, TypeFilter } from "@brett/ui";
 import type { Thing, FilterType } from "@brett/types";
 import { groupUpcomingThings } from "@brett/business";
 import { useUpcomingThings, useToggleThing } from "../api/things";
@@ -34,6 +34,9 @@ export function UpcomingView({ onItemClick, onTriageOpen, onFocusChange, onRecon
 
   const sections = groupUpcomingThings(filteredThings);
   const allItems = sections.flatMap((s) => s.things);
+  // Matches ThingsList — one-shot fade-in when a row first lands here
+  // (e.g. omnibar create with a future due date, drag-to-future-bucket).
+  const newItemIds = useNewItems(allItems);
 
   // Deferred batch toggle — matches ThingsList + InboxView so rapid-fire
   // clicks in Upcoming don't fire one API mutation per tap.
@@ -107,25 +110,34 @@ export function UpcomingView({ onItemClick, onTriageOpen, onFocusChange, onRecon
           <div key={section.label} className={sectionIdx > 0 ? "mt-4" : ""}>
             <SectionHeader title={section.label} count={section.things.length} />
             <div className="flex flex-col">
-              {section.things.map((thing, i) => (
-                <ThingCard
-                  key={thing.id}
-                  thing={thing}
-                  onClick={() => onItemClick(thing)}
-                  onToggle={handleToggle}
-                  onFocus={() => setFocusedIndex(offset + i)}
-                  isFocused={focusedIndex === offset + i}
-                  onReconnect={thing.sourceId?.startsWith("relink:") && onReconnect
-                    ? () => onReconnect(thing.sourceId!)
-                    : undefined}
-                  reconnectPending={thing.sourceId === reconnectPendingSourceId}
-                  onInstallUpdate={thing.sourceId === "system:update" ? installUpdate : undefined}
-                  onElementRef={(el) => {
-                    if (el) cardEls.current.set(thing.id, el);
-                    else cardEls.current.delete(thing.id);
-                  }}
-                />
-              ))}
+              {section.things.map((thing, i) => {
+                const isNew = newItemIds.has(thing.id);
+                // Stable wrapper — matches ThingsList. Don't swap element
+                // type on `isNew` flips or React remounts the card.
+                return (
+                  <div
+                    key={thing.id}
+                    style={isNew ? { animation: "thingCardEnter 280ms cubic-bezier(0.16, 1, 0.3, 1)" } : undefined}
+                  >
+                    <ThingCard
+                      thing={thing}
+                      onClick={() => onItemClick(thing)}
+                      onToggle={handleToggle}
+                      onFocus={() => setFocusedIndex(offset + i)}
+                      isFocused={focusedIndex === offset + i}
+                      onReconnect={thing.sourceId?.startsWith("relink:") && onReconnect
+                        ? () => onReconnect(thing.sourceId!)
+                        : undefined}
+                      reconnectPending={thing.sourceId === reconnectPendingSourceId}
+                      onInstallUpdate={thing.sourceId === "system:update" ? installUpdate : undefined}
+                      onElementRef={(el) => {
+                        if (el) cardEls.current.set(thing.id, el);
+                        else cardEls.current.delete(thing.id);
+                      }}
+                    />
+                  </div>
+                );
+              })}
             </div>
           </div>
         );

--- a/packages/ui/src/ThingsList.tsx
+++ b/packages/ui/src/ThingsList.tsx
@@ -6,6 +6,7 @@ import { CollapsibleSection } from "./CollapsibleSection";
 import { QuickAddInput, type QuickAddInputHandle } from "./QuickAddInput";
 import { useListKeyboardNav } from "./useListKeyboardNav";
 import { useDeferredToggle } from "./useDeferredToggle";
+import { useNewItems } from "./useNewItems";
 
 interface ThingsListProps {
   things: Thing[];
@@ -46,6 +47,12 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
   // Shared across ThingsList, InboxView, and UpcomingView — see CLAUDE.md
   // list-consistency rule.
   const handleToggleWithFreeze = useDeferredToggle(onToggle);
+
+  // Tracks IDs that just appeared (e.g. optimistic insert from omnibar or
+  // QuickAdd) so the corresponding row gets a one-shot fade-in. Computed
+  // against `things` so it's stable whether the new item lands in Today,
+  // This Week, or any other urgency bucket.
+  const newItemIds = useNewItems(things);
 
   // On Sat/Sun, "This Weekend" is what's imminent — render it before
   // "This Week" (the upcoming workweek). On Mon-Fri, the workweek comes
@@ -139,30 +146,30 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
           {header && <div>{header}</div>}
 
           {grouped.overdue.length > 0 && (
-            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} collapse={collapsibleSections?.["overdue"]} />
+            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} collapse={collapsibleSections?.["overdue"]} newItemIds={newItemIds} />
           )}
           {grouped.today.length > 0 && (
-            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} />
+            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} newItemIds={newItemIds} />
           )}
           {grouped.tonight.length > 0 && (
-            <Section sectionKey="tonight" title="Tonight" things={grouped.tonight} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={tonightOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "tonight"} collapse={collapsibleSections?.["tonight"]} />
+            <Section sectionKey="tonight" title="Tonight" things={grouped.tonight} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={tonightOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "tonight"} collapse={collapsibleSections?.["tonight"]} newItemIds={newItemIds} />
           )}
           {isWeekendNow ? (
             <>
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} newItemIds={newItemIds} />
               )}
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} newItemIds={newItemIds} />
               )}
             </>
           ) : (
             <>
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} newItemIds={newItemIds} />
               )}
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} newItemIds={newItemIds} />
               )}
             </>
           )}
@@ -173,7 +180,7 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
 
           {done.length > 0 && (
             <div>
-              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} collapse={collapsibleSections?.["done-today"]} />
+              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} collapse={collapsibleSections?.["done-today"]} newItemIds={newItemIds} />
             </div>
           )}
         </div>
@@ -215,6 +222,7 @@ function Section({
   cardEls,
   hideHeader,
   collapse,
+  newItemIds,
 }: {
   /** Stable identifier matched against TodayView's section list to drive the
    * chrome active-section header. The chrome header pins at the top of the
@@ -242,27 +250,42 @@ function Section({
    * already skips collapsed sections because there are no items to scroll
    * past. */
   collapse?: { open: boolean; onOpenChange: (open: boolean) => void };
+  /** IDs that just appeared in the parent's `things` array — the matching
+   * row gets a one-shot fade-in. Animates exactly once thanks to
+   * `useNewItems` only flagging an ID on the first render that introduces
+   * it. */
+  newItemIds?: Set<string>;
 }) {
   const items = (
     <div className="flex flex-col">
-      {things.map((item, i) => (
-        <ThingCard
-          key={item.id}
-          thing={item}
-          onClick={() => onItemClick(item)}
-          onToggle={onToggle}
-          isFocused={focusedIndex === indexOffset + i}
-          onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
-            ? () => onReconnect(item.sourceId!)
-            : undefined}
-          reconnectPending={item.sourceId === reconnectPendingSourceId}
-          onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
-          onElementRef={(el) => {
-            if (el) cardEls.current.set(item.id, el);
-            else cardEls.current.delete(item.id);
-          }}
-        />
-      ))}
+      {things.map((item, i) => {
+        const isNew = newItemIds?.has(item.id) ?? false;
+        // Stable wrapper — only the `animation` style flips when `isNew`
+        // changes. Switching element type (div vs Fragment) on the same key
+        // would unmount/remount ThingCard and drop focus + scroll state.
+        return (
+          <div
+            key={item.id}
+            style={isNew ? { animation: "thingCardEnter 280ms cubic-bezier(0.16, 1, 0.3, 1)" } : undefined}
+          >
+            <ThingCard
+              thing={item}
+              onClick={() => onItemClick(item)}
+              onToggle={onToggle}
+              isFocused={focusedIndex === indexOffset + i}
+              onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
+                ? () => onReconnect(item.sourceId!)
+                : undefined}
+              reconnectPending={item.sourceId === reconnectPendingSourceId}
+              onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
+              onElementRef={(el) => {
+                if (el) cardEls.current.set(item.id, el);
+                else cardEls.current.delete(item.id);
+              }}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 

--- a/packages/ui/src/animations.css
+++ b/packages/ui/src/animations.css
@@ -65,6 +65,15 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+/* Fade-in for a freshly created ThingCard (e.g. omnibar/QuickAdd optimistic
+ * insert). Matches the editorial brand easing used elsewhere (CrossFade,
+ * checkPop). Subtle slide-up keeps the eye where the item landed without
+ * shoving siblings around. */
+@keyframes thingCardEnter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 /* Things 3-style swoosh — fade + slide right, NO height collapse.
    Items below don't shift during rapid-fire completion.
    The list reflows in one batch when the freeze lifts. */

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -49,6 +49,7 @@ export { Tooltip } from "./Tooltip";
 export type { QuickAddInputHandle } from "./QuickAddInput";
 export { useListKeyboardNav } from "./useListKeyboardNav";
 export { useDeferredToggle } from "./useDeferredToggle";
+export { useNewItems } from "./useNewItems";
 export { ItemListShell } from "./ItemListShell";
 export { SectionHeader } from "./SectionHeader";
 export { CollapsibleSection } from "./CollapsibleSection";

--- a/packages/ui/src/useNewItems.ts
+++ b/packages/ui/src/useNewItems.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Returns the subset of item IDs that are new since the previous render —
+ * useful for one-shot enter animations (CSS keyframe on first paint after
+ * the item lands).
+ *
+ * - Empty Set on the initial load so the entire list doesn't fade in at once.
+ * - Once an ID has been seen, it's never re-flagged as new, even if the
+ *   array reference changes for other reasons.
+ */
+export function useNewItems<T extends { id: string }>(items: T[]): Set<string> {
+  const isInitialLoadRef = useRef(true);
+  const prevIdsRef = useRef<Set<string>>(new Set());
+
+  const newIds = (() => {
+    if (isInitialLoadRef.current) return new Set<string>();
+    const ids = new Set<string>();
+    for (const t of items) {
+      if (!prevIdsRef.current.has(t.id)) ids.add(t.id);
+    }
+    return ids;
+  })();
+
+  useEffect(() => {
+    if (items.length > 0) {
+      isInitialLoadRef.current = false;
+    }
+    prevIdsRef.current = new Set(items.map((t) => t.id));
+  }, [items]);
+
+  return newIds;
+}


### PR DESCRIPTION
Closes #182

## Root cause

Two compounding issues made the omnibar-create flow on Today feel slow:

1. **No optimistic update.** `useOmnibar.createTask` (`apps/desktop/src/api/omnibar.ts:362`) did a raw `apiFetch` and then invalidated `["things"]` and `["inbox"]`. The user waited the full network round-trip plus refetch before seeing the task. Every other create path on desktop (Today's QuickAdd, ListView's QuickAdd) already goes through `useCreateThing`, which has full optimistic-update infrastructure — the omnibar was the lone holdout.

2. **Latent urgency bug in the optimistic insert.** Even if `createTask` had used `useCreateThing`, `provisionalThing` (`apps/desktop/src/api/things.ts:75`) hardcoded `urgency: "later"`. `ThingsList` groups by urgency (Overdue / Today / Tonight / This Week / This Weekend / Done) — `"later"` doesn't match any of them, so a freshly-inserted today-dated task was in the cache but invisible until the server replied. Same shape affected QuickAdd; users just never reported it because the omnibar is the primary create surface.

## Approach

Three options considered:

1. **Duplicate the optimistic logic into `omnibar.createTask`.** Rejected — `useCreateThing` already owns the cache mutation + rollback. Two implementations drift.
2. **Have `createTask` keep the raw `apiFetch` but cancel queries and patch caches manually.** Rejected for the same reason; partial DRY violation.
3. **Make `createTask` call `useCreateThing().mutate(input)` via a stable ref.** ← picked. The omnibar inherits all the existing optimistic + rollback behavior, the `currentView` → context mapping stays local, and the public surface (the omnibar's `createTask(title, currentView)`) is unchanged.

Then routed `provisionalThing` through `computeUrgency` from `@brett/business` so the provisional Thing classifies the same way the server's `itemToThing` does. That alone is enough to make the optimistic insert visible in the Today section — no `setTimeout`, no animation tricks, just the bucket the row was always supposed to land in.

The fade-in is a thin polish layer on top. Extracted a shared `useNewItems` hook (mirrors the inline pattern in `InboxView`), wired it into `ThingsList` and `UpcomingView`, and added a `thingCardEnter` keyframe (`opacity 0→1`, `translateY 6px→0`, 280ms, brand easing). Initial-load returns an empty Set so a cold page paint doesn't fade in every row at once.

Per the list-consistency rule in CLAUDE.md, `UpcomingView` gets the same treatment as `ThingsList` even though omnibar-create never produces an upcoming-dated task — keeps the behavior uniform across every list-bearing surface that uses `ThingCard`. `InboxView`'s existing `inboxItemExpand` animation was left in place (surgical change; identical semantics).

## Tests

- `apps/desktop/src/api/__tests__/things.test.ts`:
  - **New failing-then-passing test** that pins the urgency-classification bug: a `dueDate: today` create must yield a provisional Thing with `urgency: "today"`, not `"later"`. This catches the *category* — any future change that hardcodes a default urgency would fail this assertion. Verified failing on the pre-fix code (`expected 'later' to be 'today'`) and passing after the fix.
  - Companion test that no-dueDate creates still classify as `"later"` (matches the server's `itemToThing` semantics for inbox-bound items).

- `apps/desktop/src/api/__tests__/omnibar.test.ts`:
  - Rewrote the createTask suite. Old tests over-asserted the exact `JSON.stringify` body shape (key order, date format like `"2026-05-21"`) — they failed on the refactor because the new path emits `getTodayUTC().toISOString()` (`"2026-05-21T00:00:00.000Z"`) via the shared `CreateItemInput` type, even though the resulting HTTP request is equivalent. New assertions test intent: title, type, due-date-lands-in-today's-UTC-day, listId routing, etc.
  - Added a guard for the #182 fix: a synchronous cache write happens before the server replies (mocked `apiFetch` hangs forever; the inbox cache still gets the new item).

- No UI test added for the fade-in animation. CSS keyframes on the wrapper div aren't testable in a way that would catch regressions — a snapshot or `toHaveClass` assertion would just mirror the literal. Verify visually via `gh pr checkout` then create a task from the omnibar on Today.

### Test-prevention reflection

The urgency-classification bug is exactly the kind of thing a pragmatic test catches — and now does. The "switch to optimistic mutation" bug class is also covered by the new omnibar-cache-write test. Animation timing isn't.

## Self-review findings + what I changed

- **First pass used `<Fragment>` for non-new items and `<div>` for new items.** Switching the element type on the same `key` would have unmounted/remounted `ThingCard` whenever `isNew` flipped — dropping focus, scroll-into-view state, and any inflight drag. Fixed to always use a `<div>` wrapper with the animation style conditionally applied. Same fix applied to `UpcomingView`.
- **`createThing.mutate` identity stability.** React Query guarantees `mutate` is stable, so storing it in a ref keeps `createTask`'s `useCallback` deps empty and preserves `useOmnibar`'s stability contract (App.tsx lists `omnibar` as an effect dep).
- **`dueDate` format change.** The omnibar used to send `"2026-05-21"` (date string); the new path sends `"2026-05-21T00:00:00.000Z"` (ISO). The server accepts both, and the cache filter (`thingMatchesFilters`) reads via `new Date()` which parses both the same way. Documented in the test rewrite.
- **No special handling for the optimistic-ID → real-ID swap after the server replies.** When the refetch lands, `useNewItems` will briefly flag the real UUID as "new" too, producing a second fade. `InboxView` has the same shape today and it hasn't been a problem — accepting it as a trade for simplicity. If it reads as a stutter in practice, follow-up would store an `optimistic-→server` ID mapping during `onSuccess`.

## Verification

```
pnpm typecheck   # types/utils/business/ui/desktop — all green
pnpm test        # 71 + 261 + 139 + 212 = 683 tests pass
```

Note: `@brett/api-core` has a pre-existing typecheck failure on `main` (Prisma binding inference) — independent of this PR.

UI verification pending: `gh pr checkout 182` then create a task from the omnibar on Today — should appear instantly with a soft fade-in, matching `inboxItemExpand`'s aesthetic.

## Risks / follow-ups

- `provisionalThing` now depends on `computeUrgency` running on the user's local clock. If the device clock is wildly skewed, an optimistic today-task could classify as "overdue" momentarily until the server refetch corrects it. Bounded — exactly what already happens for the server's own classification on the same wrong-clock device.
- The optimistic→real ID swap may cause a brief second fade. See self-review note above.
- `UpcomingView` got the fade-in by parity rather than necessity; if it looks wrong (e.g., on a drag-to-future-bucket where the row already had a visible motion), happy to gate it off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeeEHztsVf3cRKzjAH8vU6)_