### PR TITLE
fix(ios): persist storage base URL so wallpaper survives cold-launch API outages (#185)

### DIFF
--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -8,20 +8,31 @@ import SwiftUI
 ///      photography + abstract image paths, grouped by time-of-day and
 ///      "busyness" tier.
 ///   2. `/config` (network) — gives us the `storageBaseUrl` where images
-///      actually live. Cached in-memory for the session; re-fetched on
-///      each fresh app launch and after `clearForSignOut()`.
+///      actually live. Cached in-memory for the session AND persisted to
+///      UserDefaults so a cold launch with `/config` unreachable can still
+///      resolve image URLs against the cached manifest. Re-fetched on
+///      every `load()` to pick up env shifts. The base URL is env-level
+///      (not per-user) — see `storageBaseUrl` docs for why persisting it
+///      doesn't reintroduce the cross-user leak the URL cache had.
 ///   3. `UserProfile.backgroundStyle` + `UserProfile.pinnedBackground` —
 ///      what the user picked. Either a relative path (e.g.
 ///      "photo/evening/light-2.webp") or a "solid:#RRGGBB" sentinel.
 ///
-/// **No on-disk URL cache.** The service deliberately does not persist
-/// the last-resolved URL to UserDefaults. Cold launch starts from the
-/// wash bed (`defaultWashColor`) and the resolved photo fades in over
-/// it via `BackgroundView.paintAnimation` once `load()` + `recompute()`
-/// complete. The previous design persisted the URL to skip a blank
-/// frame, but that produced a cross-user leak (the cached URL survived
-/// sign-out) and a visible cached → resolved swap on every cold
-/// launch. See `BackgroundView` for the rendering pipeline.
+/// **No on-disk per-user URL cache.** The service deliberately does not
+/// persist `currentRemoteURL` (the resolved photo URL) to UserDefaults.
+/// Cold launch starts from the wash bed (`defaultWashColor`) and the
+/// resolved photo fades in over it via `BackgroundView.paintAnimation`
+/// once `load()` + `recompute()` complete. The previous design persisted
+/// that URL to skip a blank frame, but it leaked across sign-out and
+/// produced a visible cached → resolved swap on every cold launch.
+///
+/// The env-level `storageBaseUrl` IS persisted (see
+/// `persistedStorageBaseUrl(defaults:)`) so the photo can still resolve
+/// from the on-disk manifest cache + iOS URLCache on cold launch when
+/// `/config` is unreachable. Without that, an API outage at cold launch
+/// would leave the user staring at the bare wash bed — the prior
+/// session's photo couldn't render because the base URL was gone, even
+/// though the manifest and image bytes were both still on disk.
 ///
 /// The service is a singleton on the main actor because `BackgroundView`
 /// reads it from SwiftUI, and because the manifest + base URL are
@@ -43,7 +54,13 @@ final class BackgroundService: Clearable {
     /// Base URL of the storage server (e.g.
     /// `https://api.brett.brentbarkman.com/public`). Images are served
     /// under `{storageBaseUrl}/backgrounds/{path}`. `nil` until `/config`
-    /// returns.
+    /// returns or `loadConfigIfNeeded()` hydrates the value from
+    /// UserDefaults (see `persistedStorageBaseUrl(defaults:)`).
+    ///
+    /// The base URL is environment-level (every prod user shares the
+    /// same value), so persisting it is safe — unlike `currentRemoteURL`,
+    /// which embeds the user's pinned-photo selection and is deliberately
+    /// not persisted to avoid the cross-user leak fixed in 2026-05-17.
     private(set) var storageBaseUrl: URL?
 
     /// True once both the manifest and base URL have resolved.
@@ -378,6 +395,21 @@ final class BackgroundService: Clearable {
     }
 
     private func loadConfigIfNeeded() async {
+        // Hydrate from UserDefaults before we hit the network so a cold
+        // launch with `/config` unreachable still has a base URL to
+        // resolve cached manifest entries against. Without this, an API
+        // outage at cold launch falls through to the wash-only render
+        // even when the manifest cache and AsyncImage URLCache could
+        // have served the photo. Only fills when we don't already have
+        // a value in-memory — `clearForSignOut()` deliberately leaves
+        // `storageBaseUrl` nil until the next `load()` to keep the
+        // sign-out → sign-in race window safe (a stale prior-user
+        // profile + a non-nil base URL would resolve the prior user's
+        // pinned photo on the sign-in screen).
+        if storageBaseUrl == nil {
+            self.storageBaseUrl = Self.persistedStorageBaseUrl()
+        }
+
         // Re-fetch each call — storageBaseUrl is cheap and shifts between
         // dev and prod. We don't cache aggressively because the manifest
         // is the expensive part and already memoized.
@@ -394,10 +426,41 @@ final class BackgroundService: Clearable {
             )
             if let parsed = URL(string: response.storageBaseUrl) {
                 self.storageBaseUrl = parsed
+                Self.persistStorageBaseUrl(parsed)
             }
         } catch {
             BrettLog.app.error("BackgroundService: failed to load /config: \(String(describing: error), privacy: .public)")
         }
+    }
+
+    // MARK: - storageBaseUrl persistence
+
+    /// UserDefaults key for the persisted storage base URL. Versioned
+    /// so a future format change (e.g. moving to a struct payload) can
+    /// invalidate the old key without colliding.
+    static let storageBaseUrlDefaultsKey = "BackgroundService.storageBaseUrl.v1"
+
+    /// Read the previously-persisted storage base URL, if any. Pure
+    /// (UserDefaults-only) so tests can pass an isolated suite. The
+    /// defaults parameter has a `.standard` default for production
+    /// callers — `loadConfigIfNeeded()` uses that path.
+    static func persistedStorageBaseUrl(
+        defaults: UserDefaults = .standard
+    ) -> URL? {
+        guard let raw = defaults.string(forKey: storageBaseUrlDefaultsKey),
+              !raw.isEmpty else { return nil }
+        return URL(string: raw)
+    }
+
+    /// Persist the storage base URL so the next cold launch can resolve
+    /// image URLs even if `/config` is unreachable. Stored as the raw
+    /// string (not Data) so a quick inspection of UserDefaults during
+    /// debugging stays human-readable.
+    static func persistStorageBaseUrl(
+        _ url: URL,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(url.absoluteString, forKey: storageBaseUrlDefaultsKey)
     }
 
     // MARK: - Network manifest

--- a/apps/ios/BrettTests/Views/BackgroundServiceRendererTests.swift
+++ b/apps/ios/BrettTests/Views/BackgroundServiceRendererTests.swift
@@ -219,4 +219,71 @@ struct BackgroundServiceRendererTests {
         // displayedKey of `solid:#0040DD` (not `solid:0040DD`).
         #expect(svc.displayedKey == "solid:#0040DD")
     }
+
+    // MARK: - storageBaseUrl persistence
+    //
+    // The bug class these tests guard against: on cold launch with
+    // `/config` unreachable, the in-memory `storageBaseUrl` is nil,
+    // `currentImageURL(...)` returns nil for every URL request, and
+    // BackgroundView renders only the wash bed — so the user sees a
+    // dark solid wash where their wallpaper photo should be, even
+    // though the manifest cache + AsyncImage URLCache could otherwise
+    // have served the same image they saw last session.
+    //
+    // Persisting the env-level base URL across launches closes that
+    // gap. Per-user data (`currentRemoteURL`, pinned photo selection)
+    // is deliberately NOT persisted — that was the cross-user leak the
+    // 2026-05-17 rewrite removed and it must stay removed. The tests
+    // below pin that distinction explicitly.
+
+    /// Each test uses its own UserDefaults suite so the round-trip
+    /// doesn't touch `.standard` (which would persist across test
+    /// runs and bleed state between tests).
+    private func isolatedDefaults(_ suiteName: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func persistedStorageBaseUrlReturnsNilWhenUnset() {
+        let defaults = isolatedDefaults("BackgroundServiceTests.unset")
+        #expect(BackgroundService.persistedStorageBaseUrl(defaults: defaults) == nil)
+    }
+
+    @Test func storageBaseUrlPersistRoundTrip() {
+        let defaults = isolatedDefaults("BackgroundServiceTests.roundtrip")
+        let original = URL(string: "https://storage.example.com/public")!
+
+        BackgroundService.persistStorageBaseUrl(original, defaults: defaults)
+        let restored = BackgroundService.persistedStorageBaseUrl(defaults: defaults)
+
+        #expect(restored == original)
+    }
+
+    @Test func persistedStorageBaseUrlIgnoresEmptyString() {
+        // Defensive: a wider rewrite that ever stores an empty string
+        // (e.g. via a future migration) must not return an
+        // `URL(string: "")` to callers — `currentImageURL(...)` would
+        // then build malformed URLs. Empty string → nil keeps the
+        // wash-only fallback predictable.
+        let defaults = isolatedDefaults("BackgroundServiceTests.empty")
+        defaults.set("", forKey: BackgroundService.storageBaseUrlDefaultsKey)
+        #expect(BackgroundService.persistedStorageBaseUrl(defaults: defaults) == nil)
+    }
+
+    @Test func persistStorageBaseUrlOverwritesPriorValue() {
+        // The persisted base URL must follow the latest network value,
+        // not the first. Env shifts (dev ↔ prod, prod URL migration)
+        // need to win over a stale UserDefaults entry — otherwise a
+        // device that ran against the old base URL once would resolve
+        // images from the wrong host forever.
+        let defaults = isolatedDefaults("BackgroundServiceTests.overwrite")
+        let oldURL = URL(string: "https://old.example.com/public")!
+        let newURL = URL(string: "https://new.example.com/public")!
+
+        BackgroundService.persistStorageBaseUrl(oldURL, defaults: defaults)
+        BackgroundService.persistStorageBaseUrl(newURL, defaults: defaults)
+
+        #expect(BackgroundService.persistedStorageBaseUrl(defaults: defaults) == newURL)
+    }
 }


### PR DESCRIPTION
Closes #185

## Root cause (not symptom)

The user reports three things on iOS 26.5, build 26: "Can't reach server, no background, pull to refresh says there's an error reaching server." The first and third are correct behavior when the API is unreachable — `0208c63` (shipped earlier the same day) added the StatusBanner specifically to communicate that state. **The "no background" symptom is the actual iOS bug.**

`BackgroundService.storageBaseUrl` is loaded from `/config` and held in memory only. The 2026-05-17 rewrite (commit `dacbc34`) deleted UserDefaults caching of `currentRemoteURL` to fix a cross-user wallpaper leak and the visible cached-→-resolved swap on every cold launch. That fix was correct, but it also removed the only mechanism keeping ANY URL resolvable when `/config` was unreachable. So on cold launch with an API outage:

1. `loadManifestIfNeeded()` succeeds (manifest is cached to `applicationSupportDirectory/background-manifest.json` from a prior session)
2. `loadConfigIfNeeded()` fails — `storageBaseUrl` stays `nil`
3. `currentImageURL(...)` returns `nil` for every URL request because `storageBaseUrl` is nil
4. `BackgroundView` falls through to the wash-only branch — the user sees only the dark burnt-umber wash (`#1A1612`)

This is what the user means by "no background." The AsyncImage URLCache likely still has the photo bytes on disk; we just have nothing to point at it.

## Approach

Three options considered:

**A. Persist `storageBaseUrl` to UserDefaults (chosen).** The base URL is environment-level — every user on prod shares the same value — so persisting it doesn't reintroduce a per-user URL leak. Two-line change inside `loadConfigIfNeeded`. Doesn't touch `currentRemoteURL` or any per-user state.

**B. Persist a per-user fallback image URL, properly user-scoped.** More resilient (works even when the manifest changes between launches), but reintroduces the exact risk surface the 2026-05-17 rewrite went to lengths to remove. Rejected — the cross-user defense is worth more than the marginal extra coverage.

**C. Bundle a generic default photo and render it when no remote URL resolves.** Goes against the explicit decision in `dacbc34` to remove the bundled-asset cold-launch path, and would mean a fallback photo that the user did not pick. Rejected.

Option A is the smallest change that solves the actual reported symptom. The doc on `BackgroundService` now distinguishes "no on-disk per-user URL cache" (still true) from "env-level base URL persisted" (new).

Sign-out defense window is preserved:
- `clearForSignOut()` still wipes the **in-memory** `storageBaseUrl` to nil
- Hydration happens inside `loadConfigIfNeeded()` (which only fires from `BackgroundView.task`, AFTER `onAppear` and AFTER `@Query<UserProfile>` has refreshed)
- So the race window where SignInView's BackgroundView could see a stale prior-user profile + a non-nil base URL never opens

## What this fix does NOT do

- **Doesn't fix "Can't reach server" or the pull-to-refresh error.** Those are the StatusBanner from `0208c63` correctly reporting an API outage. If the user wants those treated differently, that's a separate decision.
- **Doesn't help the first-ever launch case** where no URL has ever been persisted. That's the unavoidable cost of removing the bundled-asset path; rare enough that the wash-only render is acceptable.
- **Doesn't diagnose whether there's a real Railway outage right now.** That's an API/infra concern, not iOS.

## Tests

Added four unit tests against the new static helpers in `BackgroundServiceRendererTests.swift`, each using an isolated `UserDefaults(suiteName:)` so they don't bleed into `.standard` or each other:

- `persistedStorageBaseUrlReturnsNilWhenUnset` — empty defaults → nil
- `storageBaseUrlPersistRoundTrip` — write then read returns the same URL
- `persistedStorageBaseUrlIgnoresEmptyString` — defensive: empty string → nil (not `URL(string: "")`)
- `persistStorageBaseUrlOverwritesPriorValue` — env shifts must win over stale cache

What these tests guard against (category, not just instance): a future change that silently breaks the UserDefaults round-trip (wrong key, wrong serialization, eager-fallback to `URL(string: "")`) would fail at least one of these and the cold-launch outage path would silently regress. The integration into `loadConfigIfNeeded` is verifiable by code review — three lines, no branching logic, calls only the tested static helpers.

**Test-prevention reflection:** Could a pragmatic test have caught the original bug? Not really — the bug is the absence of a persistence layer, not a wrong one. A test that asserted "after a successful `/config` call, the URL is persisted" would have failed both before and after `dacbc34` because no such persistence ever existed. The post-fix test set pins the persistence contract going forward.

## CI / verification

- `pnpm typecheck` — fails only on pre-existing `packages/api-core/src/prisma.ts` errors (visible on `main`, unrelated to this change)
- `pnpm test` — fails only on environmental issues (Postgres not running locally, flaky external test against example.com). Same failures on `main`.
- **iOS test suite cannot run in this Linux environment** — Brett's CI is Ubuntu-only per `CLAUDE.md` ("No desktop build, no iOS build"). The Swift tests above need to be run by Brent locally via `xcodebuild test` or the Brett scheme in Xcode.

**Visual verification pending — `gh pr checkout 186` (or whatever number this lands as) and confirm**: airplane mode + cold-launch the app on a device that's seen a wallpaper before → the wallpaper photo should fade in over the wash bed within ~1s (the AsyncImage URLCache serves the bytes locally). The StatusBanner should also appear with "Can't reach Brett — showing cached data."

## Assumptions / risks / follow-ups

- **Assumption:** the user's device has a previously-cached `background-manifest.json` and AsyncImage URLCache entries from a prior successful session. True for any user who's used the app for more than a few minutes (which fits the reporter).
- **Risk:** if the storage base URL is ever rotated server-side (e.g., switching CDN providers), devices with the old value cached would resolve to the old host. The `persistStorageBaseUrl` call on every successful `/config` response overwrites with the latest, so the staleness window is bounded to one online session.
- **Follow-up if signal continues:** if the cold-launch wallpaper still doesn't render after this ships, the next bottleneck is the on-disk manifest cache itself. We could add a `persistedManifest()` integration test to nail down that side of the cache too. Not in scope here because the manifest cache is already known to work via `cachedManifestURL`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmzvSZjgAGg7aNVxYKU4bA)_