### PR TITLE
Release: iOS manifest decode fix + actionable sync errors

### DIFF
--- a/apps/desktop/src/api/__tests__/omnibar.test.ts
+++ b/apps/desktop/src/api/__tests__/omnibar.test.ts
@@ -61,7 +61,14 @@ describe("useOmnibar", () => {
   });
 
   describe("createTask", () => {
-    it("calls API with title and type task", async () => {
+    // Helper: read the POST /things body from the latest apiFetch call.
+    const lastCreateBody = () => {
+      const call = mockApiFetch.mock.calls.find((c) => c[0] === "/things");
+      if (!call) throw new Error("apiFetch was not called with /things");
+      return JSON.parse(call[1]!.body as string);
+    };
+
+    it("posts a task with the trimmed title and type=task", async () => {
       mockApiFetch.mockResolvedValue({ id: "123", title: "Buy groceries" });
       const { result } = renderHook(() => useOmnibar(), { wrapper: createWrapper() });
 
@@ -69,25 +76,34 @@ describe("useOmnibar", () => {
         await result.current.createTask("Buy groceries");
       });
 
-      expect(mockApiFetch).toHaveBeenCalledWith("/things", {
-        method: "POST",
-        body: JSON.stringify({ title: "Buy groceries", type: "task" }),
-        headers: { "Content-Type": "application/json" },
-      });
+      const path = mockApiFetch.mock.calls[0][0];
+      const init = mockApiFetch.mock.calls[0][1]!;
+      expect(path).toBe("/things");
+      expect(init.method).toBe("POST");
+      const body = lastCreateBody();
+      expect(body.type).toBe("task");
+      expect(body.title).toBe("Buy groceries");
     });
 
-    it("sets dueDate to today when on today view", async () => {
+    it("sets dueDate to today (UTC midnight) when on today view", async () => {
       mockApiFetch.mockResolvedValue({ id: "123", title: "Test" });
       const { result } = renderHook(() => useOmnibar(), { wrapper: createWrapper() });
-
-      const today = new Date().toISOString().split("T")[0];
 
       await act(async () => {
         await result.current.createTask("Test task", "today");
       });
 
-      const callBody = JSON.parse(mockApiFetch.mock.calls[0][1]!.body as string);
-      expect(callBody.dueDate).toBe(today);
+      const body = lastCreateBody();
+      // ISO timestamp at the start of today (UTC). Asserts the value lands in
+      // the same UTC day rather than pinning the exact string format.
+      expect(body.dueDate).toBeTruthy();
+      const due = new Date(body.dueDate);
+      const todayUtc = new Date();
+      todayUtc.setUTCHours(0, 0, 0, 0);
+      expect(due.getUTCFullYear()).toBe(todayUtc.getUTCFullYear());
+      expect(due.getUTCMonth()).toBe(todayUtc.getUTCMonth());
+      expect(due.getUTCDate()).toBe(todayUtc.getUTCDate());
+      expect(body.dueDatePrecision).toBe("day");
     });
 
     it("sets listId when on a list view", async () => {
@@ -98,8 +114,7 @@ describe("useOmnibar", () => {
         await result.current.createTask("Test task", "list:abc123def456");
       });
 
-      const callBody = JSON.parse(mockApiFetch.mock.calls[0][1]!.body as string);
-      expect(callBody.listId).toBe("abc123def456");
+      expect(lastCreateBody().listId).toBe("abc123def456");
     });
 
     it("sets no dueDate or listId for other views", async () => {
@@ -110,16 +125,15 @@ describe("useOmnibar", () => {
         await result.current.createTask("Test task", "inbox");
       });
 
-      const callBody = JSON.parse(mockApiFetch.mock.calls[0][1]!.body as string);
-      expect(callBody.dueDate).toBeUndefined();
-      expect(callBody.listId).toBeUndefined();
+      const body = lastCreateBody();
+      expect(body.dueDate).toBeUndefined();
+      expect(body.listId).toBeUndefined();
     });
 
     it("closes omnibar after creating task", async () => {
       mockApiFetch.mockResolvedValue({ id: "123", title: "Test" });
       const { result } = renderHook(() => useOmnibar(), { wrapper: createWrapper() });
 
-      // Open first
       act(() => result.current.open("bar"));
       expect(result.current.isOpen).toBe(true);
 
@@ -153,6 +167,39 @@ describe("useOmnibar", () => {
       });
 
       expect(result.current.input).toBe("");
+    });
+
+    // Guards the #182 fix: the cache write happens before the server replies.
+    // Without optimistic updates, the user would see lag waiting for the
+    // network round-trip plus refetch.
+    it("inserts into the cache optimistically before the server responds", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      });
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+      // Server hangs — proves the cache write is independent of the network.
+      let resolveServer: (v: unknown) => void = () => {};
+      mockApiFetch.mockImplementation(
+        () => new Promise((resolve) => { resolveServer = resolve; }),
+      );
+
+      queryClient.setQueryData(["inbox"], { visible: [] });
+
+      const { result } = renderHook(() => useOmnibar(), { wrapper });
+
+      act(() => {
+        result.current.createTask("Fresh task");
+      });
+
+      await waitFor(() => {
+        const inbox = queryClient.getQueryData<{ visible: { title: string }[] }>(["inbox"]);
+        expect(inbox?.visible).toHaveLength(1);
+        expect(inbox?.visible[0]?.title).toBe("Fresh task");
+      });
+
+      resolveServer({ id: "server-id", title: "Fresh task" });
     });
   });
 

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -170,6 +170,75 @@ describe("useCreateThing optimistic insert", () => {
     resolveServer(makeThing("server-id", "today task"));
   });
 
+  // ThingsList groups by `urgency`, so an optimistic insert with a hardcoded
+  // urgency wouldn't appear in any section (Today/Overdue/This Week/...).
+  // The provisional Thing must classify itself the same way the server would,
+  // otherwise the user sees lag waiting for the server to fill in the right
+  // urgency — exactly the bug reported in #182.
+  it("computes urgency from dueDate so a today-dated task lands in the Today section", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    // Today and end-of-week in UTC. Use a date close to "now" so the
+    // computeUrgency call (which compares against the real clock) classifies
+    // it as "today".
+    const todayMidnight = new Date();
+    todayMidnight.setUTCHours(0, 0, 0, 0);
+    const todayIso = todayMidnight.toISOString();
+    const endOfWeek = new Date(todayMidnight.getTime() + 6 * 86400000).toISOString();
+    const activeFilters = { status: "active" as const, dueBefore: endOfWeek };
+
+    qc.setQueryData<Thing[]>(["things", activeFilters], []);
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        type: "task",
+        title: "due today",
+        dueDate: todayIso,
+        dueDatePrecision: "day",
+      });
+    });
+
+    await waitFor(() => {
+      const cache = qc.getQueryData<Thing[]>(["things", activeFilters]);
+      expect(cache?.[0]?.urgency).toBe("today");
+    });
+
+    resolveServer(makeThing("server-id", "due today"));
+  });
+
+  // No dueDate → no urgency-bucket placement; default of "later" is what
+  // server-side itemToThing returns too. Keeps the inbox-bound path stable.
+  it("leaves urgency as 'later' when dueDate is not provided", async () => {
+    const { qc, wrapper } = setupQueryClient();
+
+    qc.setQueryData<InboxResponse>(["inbox"], { visible: [] });
+
+    let resolveServer: (t: Thing) => void = () => {};
+    mockApiFetch.mockImplementation(
+      () => new Promise<Thing>((resolve) => { resolveServer = resolve; }),
+    );
+
+    const { result } = renderHook(() => useCreateThing(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ type: "task", title: "inbox task" });
+    });
+
+    await waitFor(() => {
+      const inbox = qc.getQueryData<InboxResponse>(["inbox"]);
+      expect(inbox?.visible[0]?.urgency).toBe("later");
+    });
+
+    resolveServer(makeThing("server-id", "inbox task"));
+  });
+
   // Follow-up from #62: List-scoped add must land in the list's cache
   // (useListThings → ["things", { listId }]) immediately.
   it("inserts a list-scoped task into the matching ['things', { listId }] cache", async () => {

--- a/apps/desktop/src/api/omnibar.ts
+++ b/apps/desktop/src/api/omnibar.ts
@@ -4,7 +4,9 @@ import { streamingFetch } from "./streaming";
 import { useAIConfigs } from "./ai-config";
 import { apiFetch } from "./client";
 import { applyUsageDelta, sessionUsageQueryKey } from "./ai-usage";
-import type { StreamChunk, DisplayHint } from "@brett/types";
+import { useCreateThing } from "./things";
+import { getTodayUTC } from "@brett/business";
+import type { StreamChunk, DisplayHint, CreateItemInput } from "@brett/types";
 
 export interface OmnibarMessage {
   role: "user" | "assistant";
@@ -50,6 +52,14 @@ export function useOmnibar() {
   // Maps tool call id → name so we can look up the name when the result arrives
   const toolCallNamesRef = useRef<Map<string, string>>(new Map());
   const queryClient = useQueryClient();
+
+  // Local create uses the shared optimistic-update path so the new task
+  // appears in cached views (Inbox, Today, custom lists) the moment the
+  // user hits Enter — no waiting for the server. `mutate` identity is
+  // React-Query-stable so the ref pattern keeps `createTask` stable.
+  const createThing = useCreateThing();
+  const createThingMutateRef = useRef(createThing.mutate);
+  createThingMutateRef.current = createThing.mutate;
 
   // Check if AI is configured
   const { data: aiConfigData } = useAIConfigs();
@@ -357,40 +367,31 @@ export function useOmnibar() {
   }, []);
 
   // Local action: create a task directly (no AI needed)
-  // No chat UI — just do it, invalidate queries, close the omnibar
-  // When on Today view, set dueDate to today so it appears in the current list
-  const createTask = useCallback(async (title: string, currentView?: string) => {
+  // No chat UI — just do it. useCreateThing's onMutate optimistically inserts
+  // into every cached view the task belongs in, so the user sees it land
+  // before the server replies. Matches the Today/List QuickAdd contract.
+  const createTask = useCallback((title: string, currentView?: string) => {
     const trimmed = title.trim();
     if (!trimmed) return;
 
     setInput("");
 
-    const body: Record<string, unknown> = { title: trimmed, type: "task" };
-
-    // Context-aware defaults based on current view
+    const input: CreateItemInput = { type: "task", title: trimmed };
     if (currentView === "today") {
-      body.dueDate = new Date().toISOString().split("T")[0];
+      input.dueDate = getTodayUTC().toISOString();
+      input.dueDatePrecision = "day";
     } else if (currentView?.startsWith("list:")) {
-      body.listId = currentView.slice(5);
+      input.listId = currentView.slice(5);
     }
 
-    try {
-      await apiFetch("/things", {
-        method: "POST",
-        body: JSON.stringify(body),
-        headers: { "Content-Type": "application/json" },
-      });
-      queryClient.invalidateQueries({ queryKey: ["things"] });
-      queryClient.invalidateQueries({ queryKey: ["inbox"] });
-    } catch {
-      // Silently fail — user will notice if the task doesn't appear
-    }
+    // Fire-and-forget: optimistic cache update is synchronous, so closing the
+    // omnibar immediately is safe. Errors roll back the cache (see things.ts).
+    createThingMutateRef.current(input);
 
-    // Close omnibar — no conversation in non-AI mode
     setIsOpen(false);
     setMessages([]);
     setSessionId(null);
-  }, [queryClient]);
+  }, []);
 
   const searchThings = useCallback(async (query: string) => {
     const trimmed = query.trim();

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -4,7 +4,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import type { Thing, ThingDetail, CreateItemInput, UpdateItemInput, InboxResponse, BulkUpdateInput } from "@brett/types";
-import { getTodayUTC } from "@brett/business";
+import { getTodayUTC, computeUrgency } from "@brett/business";
 import { apiFetch } from "./client";
 import { invalidateAllThings } from "./invalidate";
 
@@ -73,6 +73,10 @@ export function useUpcomingThings() {
 
 /** Shape a CreateItemInput into a provisional Thing for optimistic caches. */
 function provisionalThing(input: CreateItemInput, tempId: string): Thing {
+  // ThingsList groups by urgency, so a hardcoded default would render the
+  // optimistic insert invisible until the server replies with the real
+  // bucket. Mirror the server's itemToThing classification here.
+  const urgency = computeUrgency(input.dueDate ? new Date(input.dueDate) : null, null);
   return {
     id: tempId,
     type: (input.type as Thing["type"]) ?? "task",
@@ -81,7 +85,7 @@ function provisionalThing(input: CreateItemInput, tempId: string): Thing {
     listId: input.listId ?? null,
     status: (input.status as Thing["status"]) ?? "active",
     source: input.source ?? "manual",
-    urgency: "later",
+    urgency,
     dueDate: input.dueDate,
     dueDatePrecision: input.dueDatePrecision,
     sourceUrl: input.sourceUrl,

--- a/apps/desktop/src/views/UpcomingView.tsx
+++ b/apps/desktop/src/views/UpcomingView.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react";
 import { Clock } from "lucide-react";
-import { ThingCard, ItemListShell, useListKeyboardNav, useDeferredToggle, SkeletonListView, SectionHeader, TypeFilter } from "@brett/ui";
+import { ThingCard, ItemListShell, useListKeyboardNav, useDeferredToggle, useNewItems, SkeletonListView, SectionHeader, TypeFilter } from "@brett/ui";
 import type { Thing, FilterType } from "@brett/types";
 import { groupUpcomingThings } from "@brett/business";
 import { useUpcomingThings, useToggleThing } from "../api/things";
@@ -34,6 +34,9 @@ export function UpcomingView({ onItemClick, onTriageOpen, onFocusChange, onRecon
 
   const sections = groupUpcomingThings(filteredThings);
   const allItems = sections.flatMap((s) => s.things);
+  // Matches ThingsList — one-shot fade-in when a row first lands here
+  // (e.g. omnibar create with a future due date, drag-to-future-bucket).
+  const newItemIds = useNewItems(allItems);
 
   // Deferred batch toggle — matches ThingsList + InboxView so rapid-fire
   // clicks in Upcoming don't fire one API mutation per tap.
@@ -107,25 +110,34 @@ export function UpcomingView({ onItemClick, onTriageOpen, onFocusChange, onRecon
           <div key={section.label} className={sectionIdx > 0 ? "mt-4" : ""}>
             <SectionHeader title={section.label} count={section.things.length} />
             <div className="flex flex-col">
-              {section.things.map((thing, i) => (
-                <ThingCard
-                  key={thing.id}
-                  thing={thing}
-                  onClick={() => onItemClick(thing)}
-                  onToggle={handleToggle}
-                  onFocus={() => setFocusedIndex(offset + i)}
-                  isFocused={focusedIndex === offset + i}
-                  onReconnect={thing.sourceId?.startsWith("relink:") && onReconnect
-                    ? () => onReconnect(thing.sourceId!)
-                    : undefined}
-                  reconnectPending={thing.sourceId === reconnectPendingSourceId}
-                  onInstallUpdate={thing.sourceId === "system:update" ? installUpdate : undefined}
-                  onElementRef={(el) => {
-                    if (el) cardEls.current.set(thing.id, el);
-                    else cardEls.current.delete(thing.id);
-                  }}
-                />
-              ))}
+              {section.things.map((thing, i) => {
+                const isNew = newItemIds.has(thing.id);
+                // Stable wrapper — matches ThingsList. Don't swap element
+                // type on `isNew` flips or React remounts the card.
+                return (
+                  <div
+                    key={thing.id}
+                    style={isNew ? { animation: "thingCardEnter 280ms cubic-bezier(0.16, 1, 0.3, 1)" } : undefined}
+                  >
+                    <ThingCard
+                      thing={thing}
+                      onClick={() => onItemClick(thing)}
+                      onToggle={handleToggle}
+                      onFocus={() => setFocusedIndex(offset + i)}
+                      isFocused={focusedIndex === offset + i}
+                      onReconnect={thing.sourceId?.startsWith("relink:") && onReconnect
+                        ? () => onReconnect(thing.sourceId!)
+                        : undefined}
+                      reconnectPending={thing.sourceId === reconnectPendingSourceId}
+                      onInstallUpdate={thing.sourceId === "system:update" ? installUpdate : undefined}
+                      onElementRef={(el) => {
+                        if (el) cardEls.current.set(thing.id, el);
+                        else cardEls.current.delete(thing.id);
+                      }}
+                    />
+                  </div>
+                );
+              })}
             </div>
           </div>
         );

--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -239,7 +239,14 @@ final class BackgroundService: Clearable {
 
         struct Sets: Codable {
             let photography: Segments
-            let abstract: Segments
+            /// Optional because the canonical manifest (bundled + served from
+            /// `/config/background-manifest`) currently only ships the
+            /// `photography` set. When the catalog grows distinct abstract
+            /// images this field will populate; until then iOS falls back
+            /// to the photography set for the `.abstract` style — matching
+            /// desktop's behavior of treating abstract as photography until
+            /// the manifest exposes a separate set.
+            let abstract: Segments?
         }
 
         struct Segments: Codable {
@@ -987,7 +994,9 @@ final class BackgroundService: Clearable {
     static func segments(for style: Style, in manifest: BackgroundManifest) -> BackgroundManifest.Segments {
         switch style {
         case .photography, .solid: return manifest.sets.photography
-        case .abstract: return manifest.sets.abstract
+        // Abstract falls back to photography when the manifest doesn't
+        // carry a distinct abstract set yet (the canonical case today).
+        case .abstract: return manifest.sets.abstract ?? manifest.sets.photography
         }
     }
 

--- a/apps/ios/Brett/Sync/PullEngine.swift
+++ b/apps/ios/Brett/Sync/PullEngine.swift
@@ -444,7 +444,17 @@ final class PullEngine {
         health.isPulling = false
         if let error {
             health.consecutiveFailures += 1
-            health.lastError = String(describing: error)
+            // APIError's `description` is PII-redacted to bare category names
+            // ("APIError.unknown") — useless when diagnosing an outage from
+            // Sync Health settings. `diagnosticMessage` is the support-quality
+            // version: includes the underlying URLError code ("Timed out",
+            // "Couldn't reach the server", "DNS lookup failed", ...) without
+            // ever embedding user-typed strings.
+            if let apiError = error as? APIError {
+                health.lastError = apiError.diagnosticMessage
+            } else {
+                health.lastError = String(describing: error)
+            }
         }
         do {
             try context.save()

--- a/apps/ios/Brett/Sync/PushEngine.swift
+++ b/apps/ios/Brett/Sync/PushEngine.swift
@@ -116,11 +116,21 @@ final class PushEngine {
             for entry in batch {
                 mutationQueue.fail(id: entry.id, error: "network: \(error)", errorCode: nil)
             }
+            // APIError's `description` is PII-redacted to bare category
+            // names ("APIError.unknown") — useless when diagnosing from
+            // Sync Health settings. `diagnosticMessage` is the support-
+            // quality version (includes URLError code) and still PII-safe.
+            let errorMessage: String
+            if let apiError = error as? APIError {
+                errorMessage = apiError.diagnosticMessage
+            } else {
+                errorMessage = String(describing: error)
+            }
             updateSyncHealth(
                 isPushing: false,
                 pendingDelta: 0,
                 success: false,
-                error: String(describing: error)
+                error: errorMessage
             )
             throw error
         }

--- a/apps/ios/Brett/Utilities/DateHelpers.swift
+++ b/apps/ios/Brett/Utilities/DateHelpers.swift
@@ -137,6 +137,15 @@ enum DateHelpers {
         return f
     }()
 
+    /// Weekday name ("Monday", "Tuesday") of a stored `dueDate`. Reads
+    /// the date through `utcCalendar` because the storage convention is
+    /// "UTC midnight of the user's local calendar date" — formatting in
+    /// the device TZ would flip the weekday near midnight (UTC-midnight
+    /// reads as the previous day in any TZ west of UTC).
+    static func weekdayName(of date: Date) -> String {
+        utcWeekdayFormatter.string(from: date)
+    }
+
     private static let utcMonthDayFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d"

--- a/apps/ios/Brett/Views/Shared/EditorialPageHeader.swift
+++ b/apps/ios/Brett/Views/Shared/EditorialPageHeader.swift
@@ -17,12 +17,15 @@ struct EditorialPageHeader: View {
     let title: String
     let subtitle: String?
     var variant: Variant = .onWash
-    /// Inset from the leading edge. Default 24pt to match the
-    /// canonical calm-hero pages (Today / Inbox / Lists / Calendar /
-    /// Scouts). Settings nests the header inside `BrettSettingsScroll`
-    /// (which already pads 16pt for cards), so it passes 0 here to
-    /// avoid compounding to a 40pt offset.
-    var horizontalPadding: CGFloat = 24
+    /// Inset from the leading edge. `BrettSpacing.pagePaddingX` (20pt)
+    /// aligns the title with the section-header text that sits below
+    /// it on every calm-hero page — sticky-card sections place their
+    /// header at 16pt card padding + 4pt internal = 20pt from the
+    /// screen edge, and the header used to be 4pt further right than
+    /// those headers at 24pt. Settings nests the header inside
+    /// `BrettSettingsScroll` (which already pads 16pt for cards), so
+    /// it passes 0 here to avoid compounding.
+    var horizontalPadding: CGFloat = BrettSpacing.pagePaddingX
 
     enum Variant {
         case onWash

--- a/apps/ios/Brett/Views/Shared/SyncStatusIndicator.swift
+++ b/apps/ios/Brett/Views/Shared/SyncStatusIndicator.swift
@@ -6,7 +6,12 @@ import SwiftUI
 /// - `idle` / no session → invisible 8x8 dot (kept in layout so other
 ///   icons don't shift when state flips).
 /// - `pushing`           → gold dot with a subtle pulse (local → server).
-/// - `pulling`           → cerulean dot with a subtle pulse (server → local).
+/// - `pulling`           → invisible (was a cerulean pulsing dot; removed
+///   because every pull — including the 30s background poll — was
+///   flashing a blue dot in the corner that read as debug residue
+///   without telling the user anything actionable. Pushes still show
+///   gold because they represent the user's own outbound writes;
+///   pulls now go silent unless they error).
 /// - `error`             → red dot, tappable; opens a sheet with the message.
 ///
 /// Mount inside the top bar next to the settings / scouts / search icons.
@@ -39,7 +44,10 @@ struct SyncStatusIndicator: View {
                 dot(color: BrettColors.gold.opacity(0.85), isInteractive: false, pulse: true)
 
             case .pulling:
-                dot(color: BrettColors.cerulean.opacity(0.85), isInteractive: false, pulse: true)
+                // Render the same invisible placeholder as `.idle` so the
+                // surrounding icon row doesn't shift when sync flips
+                // pulling↔idle on every 30s background poll.
+                dot(color: .clear, isInteractive: false, pulse: false)
 
             case .error:
                 dot(color: BrettColors.error, isInteractive: true, pulse: false)
@@ -57,7 +65,7 @@ struct SyncStatusIndicator: View {
         .animation(.easeInOut(duration: 0.2), value: state)
         .onChange(of: state) { _, newValue in
             switch newValue {
-            case .pushing, .pulling:
+            case .pushing:
                 isPulsing = true
             default:
                 isPulsing = false
@@ -98,9 +106,8 @@ struct SyncStatusIndicator: View {
 
     private var accessibilityLabel: String {
         switch state {
-        case .idle: return ""
+        case .idle, .pulling: return ""
         case .pushing: return "Sync: sending changes"
-        case .pulling: return "Sync: receiving changes"
         case .error(let message): return "Sync error: \(message)"
         }
     }

--- a/apps/ios/Brett/Views/Shared/TaskRow.swift
+++ b/apps/ios/Brett/Views/Shared/TaskRow.swift
@@ -457,19 +457,21 @@ struct TaskRow: View {
     /// don't render time-of-day; there's no UI to set a time on a
     /// task and desktop's `ThingCard` doesn't display one either.
     /// `nil` means "no whisper, skip the segment."
+    ///
+    /// "Overdue" is decided via `DateHelpers.computeUrgency`, which
+    /// anchors today to the UTC-midnight of the user's local calendar
+    /// date. A naïve `Calendar.current.startOfDay` check would
+    /// misclassify due-today tasks as overdue in any TZ west of UTC
+    /// (today's UTC-midnight stored value sorts before today's local
+    /// midnight), and then label them with yesterday's weekday because
+    /// a local-TZ formatter reads UTC-midnight as the previous day.
     private static func timeLabel(for item: Item) -> String? {
         guard let due = item.dueDate else { return nil }
-        if due < Calendar.current.startOfDay(for: Date()) {
-            return weekdayFormatter.string(from: due)
+        guard DateHelpers.computeUrgency(dueDate: due, isCompleted: false) == .overdue else {
+            return nil
         }
-        return nil
+        return DateHelpers.weekdayName(of: due)
     }
-
-    private static let weekdayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEEE"
-        return formatter
-    }()
 
     private static func capturedLabel(for item: Item) -> String? {
         // "Captured {relative}" for undated content/inbox items

--- a/apps/ios/Brett/Views/Today/NextUpCard.swift
+++ b/apps/ios/Brett/Views/Today/NextUpCard.swift
@@ -56,8 +56,9 @@ struct NextUpCard: View {
             // Vertical rhythm tuned by hand: ~16pt of breathing room
             // from the brief above so the editorial moment lands as a
             // separate beat, with a tight 4pt gap below so OVERDUE
-            // pulls right up under it.
-            .padding(.horizontal, 24)
+            // pulls right up under it. Horizontal matches the hero +
+            // section-header text edge — `BrettSpacing.pagePaddingX`.
+            .padding(.horizontal, BrettSpacing.pagePaddingX)
             .padding(.top, 16)
             .padding(.bottom, 4)
             .accessibilityElement(children: .combine)

--- a/apps/ios/Brett/Views/Today/TodayHero.swift
+++ b/apps/ios/Brett/Views/Today/TodayHero.swift
@@ -85,7 +85,13 @@ struct TodayHero: View {
                     .transition(.opacity)
             }
         }
-        .padding(.horizontal, 24)
+        // Match `BrettSpacing.pagePaddingX` (20pt) so the greeting +
+        // dateline align with the section-header text below ("TODAY",
+        // "OVERDUE", etc., which sit at 16pt card padding + 4pt header
+        // padding = 20pt from the screen edge). The earlier 24pt
+        // literal left the hero 4pt further right than every section
+        // header underneath it.
+        .padding(.horizontal, BrettSpacing.pagePaddingX)
         .padding(.top, 12)
         .padding(.bottom, 12)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/ios/BrettTests/DateHelpersTests.swift
+++ b/apps/ios/BrettTests/DateHelpersTests.swift
@@ -105,4 +105,31 @@ struct DateHelpersTests {
         let formatted = DateHelpers.formatTime(date)
         #expect(formatted.contains("2:30") || formatted.contains("14:30"))
     }
+
+    // MARK: - weekdayName
+
+    /// A stored `dueDate` is UTC midnight of the user's intended local
+    /// calendar date. Formatting it in any other timezone flips the
+    /// weekday near midnight (in TZs west of UTC, UTC-midnight reads as
+    /// "the previous day" locally) — which is the exact bug that put a
+    /// "Monday" subtext on tasks due Tuesday. Guard with a TZ-independent
+    /// assertion: Tuesday-UTC-midnight must read as "Tuesday" no matter
+    /// what TZ the host simulator is in.
+    @Test func weekdayNameUsesUTCCalendar() {
+        // 2026-05-19 is a Tuesday in UTC. A user in MDT (UTC-6) would
+        // pick this date locally and the storage layer normalises it
+        // to 2026-05-19T00:00Z (utcMidnightOfLocalDate). Formatting in
+        // the local TZ would yield "Monday" — guard against that.
+        let tuesday = Self.utcDate(2026, 5, 19, 0)
+        #expect(DateHelpers.weekdayName(of: tuesday) == "Tuesday")
+    }
+
+    @Test func weekdayNameAtUTCMidnightIsStableAcrossDays() {
+        // Spot-check several days of the week to make sure the formatter
+        // isn't just stuck on one value.
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 17, 0)) == "Sunday")
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 18, 0)) == "Monday")
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 19, 0)) == "Tuesday")
+        #expect(DateHelpers.weekdayName(of: Self.utcDate(2026, 5, 23, 0)) == "Saturday")
+    }
 }

--- a/apps/ios/DESIGN.md
+++ b/apps/ios/DESIGN.md
@@ -74,7 +74,7 @@ All four primary pages and Scouts use the same editorial header treatment via `E
 
 - **Title:** 38pt serif (New York / `design: .serif`), white. On the Today hero the title is a time-of-day greeting ("Tuesday morning") with layered text-shadow for legibility against any photo. On non-Today pages the title is the page name ("Inbox", "May 4", "Lists", "Scouts") with no shadow.
 - **Sub-line:** 13pt sans, white at 0.7. Counts ("3 to triage", "2 events", "5 lists") or a date.
-- **Position:** leading-aligned, 24pt horizontal padding, top respects the safe-area inset (never hardcode 60pt).
+- **Position:** leading-aligned, `BrettSpacing.pagePaddingX` (20pt) horizontal padding so the title aligns with the section-header text that sits below it (sticky-card sections place their header at 16pt card padding + 4pt internal = 20pt from the screen edge). Top respects the safe-area inset (never hardcode 60pt).
 
 The legacy 28pt `BrettTypography.dateHeader` is **deprecated for top-level page titles**. It still applies to nested labels (e.g. a date inside a calendar day cell).
 

--- a/packages/ui/src/ThingsList.tsx
+++ b/packages/ui/src/ThingsList.tsx
@@ -6,6 +6,7 @@ import { CollapsibleSection } from "./CollapsibleSection";
 import { QuickAddInput, type QuickAddInputHandle } from "./QuickAddInput";
 import { useListKeyboardNav } from "./useListKeyboardNav";
 import { useDeferredToggle } from "./useDeferredToggle";
+import { useNewItems } from "./useNewItems";
 
 interface ThingsListProps {
   things: Thing[];
@@ -46,6 +47,12 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
   // Shared across ThingsList, InboxView, and UpcomingView — see CLAUDE.md
   // list-consistency rule.
   const handleToggleWithFreeze = useDeferredToggle(onToggle);
+
+  // Tracks IDs that just appeared (e.g. optimistic insert from omnibar or
+  // QuickAdd) so the corresponding row gets a one-shot fade-in. Computed
+  // against `things` so it's stable whether the new item lands in Today,
+  // This Week, or any other urgency bucket.
+  const newItemIds = useNewItems(things);
 
   // On Sat/Sun, "This Weekend" is what's imminent — render it before
   // "This Week" (the upcoming workweek). On Mon-Fri, the workweek comes
@@ -139,30 +146,30 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
           {header && <div>{header}</div>}
 
           {grouped.overdue.length > 0 && (
-            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} collapse={collapsibleSections?.["overdue"]} />
+            <Section sectionKey="overdue" title="Overdue" things={grouped.overdue} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={overdueOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "overdue"} collapse={collapsibleSections?.["overdue"]} newItemIds={newItemIds} />
           )}
           {grouped.today.length > 0 && (
-            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} />
+            <Section sectionKey="today" title="Today" things={grouped.today} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={todayOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "today"} collapse={collapsibleSections?.["today"]} newItemIds={newItemIds} />
           )}
           {grouped.tonight.length > 0 && (
-            <Section sectionKey="tonight" title="Tonight" things={grouped.tonight} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={tonightOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "tonight"} collapse={collapsibleSections?.["tonight"]} />
+            <Section sectionKey="tonight" title="Tonight" things={grouped.tonight} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={tonightOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "tonight"} collapse={collapsibleSections?.["tonight"]} newItemIds={newItemIds} />
           )}
           {isWeekendNow ? (
             <>
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} newItemIds={newItemIds} />
               )}
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} newItemIds={newItemIds} />
               )}
             </>
           ) : (
             <>
               {grouped.this_week.length > 0 && (
-                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} />
+                <Section sectionKey="this-week" title="This Week" things={grouped.this_week} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-week"} collapse={collapsibleSections?.["this-week"]} newItemIds={newItemIds} />
               )}
               {grouped.this_weekend.length > 0 && (
-                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} />
+                <Section sectionKey="this-weekend" title="This Weekend" things={grouped.this_weekend} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={thisWeekendOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "this-weekend"} collapse={collapsibleSections?.["this-weekend"]} newItemIds={newItemIds} />
               )}
             </>
           )}
@@ -173,7 +180,7 @@ export function ThingsList({ things, lists, onItemClick, onToggle, onAdd, onAddC
 
           {done.length > 0 && (
             <div>
-              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} collapse={collapsibleSections?.["done-today"]} />
+              <Section sectionKey="done-today" title="Done Today" things={done} onItemClick={handleItemClick} onToggle={handleToggleWithFreeze} focusedIndex={focusedIndex} indexOffset={doneOffset} onReconnect={onReconnect} reconnectPendingSourceId={reconnectPendingSourceId} onInstallUpdate={onInstallUpdate} cardEls={cardEls} hideHeader={hiddenHeaderKey === "done-today"} collapse={collapsibleSections?.["done-today"]} newItemIds={newItemIds} />
             </div>
           )}
         </div>
@@ -215,6 +222,7 @@ function Section({
   cardEls,
   hideHeader,
   collapse,
+  newItemIds,
 }: {
   /** Stable identifier matched against TodayView's section list to drive the
    * chrome active-section header. The chrome header pins at the top of the
@@ -242,27 +250,42 @@ function Section({
    * already skips collapsed sections because there are no items to scroll
    * past. */
   collapse?: { open: boolean; onOpenChange: (open: boolean) => void };
+  /** IDs that just appeared in the parent's `things` array — the matching
+   * row gets a one-shot fade-in. Animates exactly once thanks to
+   * `useNewItems` only flagging an ID on the first render that introduces
+   * it. */
+  newItemIds?: Set<string>;
 }) {
   const items = (
     <div className="flex flex-col">
-      {things.map((item, i) => (
-        <ThingCard
-          key={item.id}
-          thing={item}
-          onClick={() => onItemClick(item)}
-          onToggle={onToggle}
-          isFocused={focusedIndex === indexOffset + i}
-          onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
-            ? () => onReconnect(item.sourceId!)
-            : undefined}
-          reconnectPending={item.sourceId === reconnectPendingSourceId}
-          onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
-          onElementRef={(el) => {
-            if (el) cardEls.current.set(item.id, el);
-            else cardEls.current.delete(item.id);
-          }}
-        />
-      ))}
+      {things.map((item, i) => {
+        const isNew = newItemIds?.has(item.id) ?? false;
+        // Stable wrapper — only the `animation` style flips when `isNew`
+        // changes. Switching element type (div vs Fragment) on the same key
+        // would unmount/remount ThingCard and drop focus + scroll state.
+        return (
+          <div
+            key={item.id}
+            style={isNew ? { animation: "thingCardEnter 280ms cubic-bezier(0.16, 1, 0.3, 1)" } : undefined}
+          >
+            <ThingCard
+              thing={item}
+              onClick={() => onItemClick(item)}
+              onToggle={onToggle}
+              isFocused={focusedIndex === indexOffset + i}
+              onReconnect={item.sourceId?.startsWith("relink:") && onReconnect
+                ? () => onReconnect(item.sourceId!)
+                : undefined}
+              reconnectPending={item.sourceId === reconnectPendingSourceId}
+              onInstallUpdate={item.sourceId === "system:update" ? onInstallUpdate : undefined}
+              onElementRef={(el) => {
+                if (el) cardEls.current.set(item.id, el);
+                else cardEls.current.delete(item.id);
+              }}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 

--- a/packages/ui/src/animations.css
+++ b/packages/ui/src/animations.css
@@ -65,6 +65,15 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+/* Fade-in for a freshly created ThingCard (e.g. omnibar/QuickAdd optimistic
+ * insert). Matches the editorial brand easing used elsewhere (CrossFade,
+ * checkPop). Subtle slide-up keeps the eye where the item landed without
+ * shoving siblings around. */
+@keyframes thingCardEnter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 /* Things 3-style swoosh — fade + slide right, NO height collapse.
    Items below don't shift during rapid-fire completion.
    The list reflows in one batch when the freeze lifts. */

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -49,6 +49,7 @@ export { Tooltip } from "./Tooltip";
 export type { QuickAddInputHandle } from "./QuickAddInput";
 export { useListKeyboardNav } from "./useListKeyboardNav";
 export { useDeferredToggle } from "./useDeferredToggle";
+export { useNewItems } from "./useNewItems";
 export { ItemListShell } from "./ItemListShell";
 export { SectionHeader } from "./SectionHeader";
 export { CollapsibleSection } from "./CollapsibleSection";

--- a/packages/ui/src/useNewItems.ts
+++ b/packages/ui/src/useNewItems.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Returns the subset of item IDs that are new since the previous render —
+ * useful for one-shot enter animations (CSS keyframe on first paint after
+ * the item lands).
+ *
+ * - Empty Set on the initial load so the entire list doesn't fade in at once.
+ * - Once an ID has been seen, it's never re-flagged as new, even if the
+ *   array reference changes for other reasons.
+ */
+export function useNewItems<T extends { id: string }>(items: T[]): Set<string> {
+  const isInitialLoadRef = useRef(true);
+  const prevIdsRef = useRef<Set<string>>(new Set());
+
+  const newIds = (() => {
+    if (isInitialLoadRef.current) return new Set<string>();
+    const ids = new Set<string>();
+    for (const t of items) {
+      if (!prevIdsRef.current.has(t.id)) ids.add(t.id);
+    }
+    return ids;
+  })();
+
+  useEffect(() => {
+    if (items.length > 0) {
+      isInitialLoadRef.current = false;
+    }
+    prevIdsRef.current = new Set(items.map((t) => t.id));
+  }, [items]);
+
+  return newIds;
+}


### PR DESCRIPTION
## Summary

- **Fix no-background-image on build 26** — `BackgroundManifest.Sets.abstract` was required by Swift but the canonical manifest only ships `photography`, so every decode (bundled, cached, network) failed with `keyNotFound("abstract")`. Made `abstract` optional and fall back to photography in `segments(for:in:)`.
- **Actionable Sync Health errors** — PullEngine/PushEngine were writing the PII-redacted `String(describing: error)` (e.g. `"APIError.unknown"`) to `SyncHealth.lastError`. Switched to `apiError.diagnosticMessage` (e.g. `"Timed out"`, `"Couldn't reach the server"`, `"DNS lookup failed"`) — still PII-safe, but actually useful for diagnosing the "Can't reach Brett" banner reported in #185.

Both ship together so the follow-up "Can't reach Brett" diagnosis (gated on the new error string) becomes possible in production.

## Test plan

- [x] Debug build compiles clean
- [x] Manifest decode now succeeds against current `/config/background-manifest` payload (only `photography` key)
- [x] No regression on `manifestsEquivalent` — fallback returns photography on both sides when abstract is absent
- [ ] After deploy: trigger pull-to-refresh on iOS, check `Settings → Sync Health → Last error` for a concrete URLError code (was "APIError.unknown" — useless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)