### PR TITLE
fix(ios): cancellations don't trigger API-unreachable banner

### DIFF
--- a/apps/ios/Brett/Sync/PullEngine.swift
+++ b/apps/ios/Brett/Sync/PullEngine.swift
@@ -443,6 +443,14 @@ final class PullEngine {
         let health = fetchHealth()
         health.isPulling = false
         if let error {
+            // Cancellation isn't a real failure — it just means a newer
+            // sync superseded this one, the user navigated mid-request, or
+            // iOS suspended the URLSession. Mirrors SyncManager.sync()'s
+            // own isCancellation filter so SyncHealth.consecutiveFailures
+            // (which the StatusBanner reads as the "is the API reachable"
+            // signal) doesn't flare on routine churn.
+            guard !SyncManager.isCancellation(error) else { return }
+
             health.consecutiveFailures += 1
             // APIError's `description` is PII-redacted to bare category names
             // ("APIError.unknown") — useless when diagnosing an outage from

--- a/apps/ios/Brett/Sync/PushEngine.swift
+++ b/apps/ios/Brett/Sync/PushEngine.swift
@@ -116,6 +116,17 @@ final class PushEngine {
             for entry in batch {
                 mutationQueue.fail(id: entry.id, error: "network: \(error)", errorCode: nil)
             }
+            // Cancellation isn't a real failure — it just means a newer
+            // sync superseded this one, the user navigated mid-request, or
+            // iOS suspended the URLSession. Mirrors SyncManager.sync()'s
+            // own isCancellation filter so SyncHealth.consecutiveFailures
+            // (which the StatusBanner reads as the "is the API reachable"
+            // signal) doesn't flare on routine churn. Mutations stay on the
+            // queue so the next push retries.
+            if SyncManager.isCancellation(error) {
+                markPushing(false)
+                throw error
+            }
             // APIError's `description` is PII-redacted to bare category
             // names ("APIError.unknown") — useless when diagnosing from
             // Sync Health settings. `diagnosticMessage` is the support-

--- a/apps/ios/BrettTests/Sync/PullEngineTests.swift
+++ b/apps/ios/BrettTests/Sync/PullEngineTests.swift
@@ -400,6 +400,32 @@ struct PullEngineTests {
         #expect(health.first?.lastError != nil)
     }
 
+    /// Cancellation errors (URLError.cancelled — SwiftUI .refreshable
+    /// dismissed, iOS suspended URLSession, debounced superseded) are NOT
+    /// real failures. SyncHealth.consecutiveFailures must stay at 0 so the
+    /// StatusBanner doesn't flare on routine view churn. Mirrors the
+    /// matching filter in SyncManager.sync().
+    @Test func cancelledPullDoesNotIncrementConsecutiveFailures() async throws {
+        let context = try InMemoryPersistenceController.makeContext()
+        MockURLProtocol.reset()
+        MockURLProtocol.stub(url: pullURL, error: URLError(.cancelled))
+
+        let engine = PullEngine(apiClient: makeStubbedClient(), context: context)
+
+        do {
+            _ = try await engine.pull()
+            Issue.record("expected cancellation to throw")
+        } catch {
+            // Expected — pull still throws so the caller can react.
+        }
+
+        let health: [SyncHealth] = (try? context.fetch(FetchDescriptor<SyncHealth>())) ?? []
+        #expect(health.first?.consecutiveFailures == 0,
+                "cancellation must not count toward the API-unreachable signal")
+        #expect(health.first?.lastError == nil,
+                "cancellation must not leave a stale error string")
+    }
+
     // MARK: - SyncHealth touched on success
 
     @Test func successfulPullUpdatesSyncHealth() async throws {

--- a/apps/ios/BrettTests/Sync/PushEngineTests.swift
+++ b/apps/ios/BrettTests/Sync/PushEngineTests.swift
@@ -382,4 +382,38 @@ struct PushEngineTests {
         // complete() must NOT be called.
         #expect(queue.completedIds.isEmpty)
     }
+
+    /// Cancellation errors (URLError.cancelled — debounced superseded, view
+    /// dismissed mid-refresh, iOS suspended URLSession) are NOT real
+    /// failures. SyncHealth.consecutiveFailures must stay at 0 so the
+    /// StatusBanner doesn't flare on routine churn. Mirrors the matching
+    /// filter in SyncManager.sync().
+    @Test func cancelledPushDoesNotIncrementConsecutiveFailures() async throws {
+        let context = try seedContext()
+        let queue = FakeMutationQueue()
+        queue.pending = [makePendingUpdate()]
+
+        MockURLProtocol.reset()
+        MockURLProtocol.stub(url: pushURL, error: URLError(.cancelled))
+
+        let engine = PushEngine(
+            mutationQueue: queue,
+            apiClient: makeStubbedClient(),
+            context: context
+        )
+
+        do {
+            _ = try await engine.push()
+            Issue.record("Expected push to throw on cancellation")
+        } catch {
+            // Expected — push still throws so the caller can react.
+        }
+
+        let health: [SyncHealth] = (try? context.fetch(FetchDescriptor<SyncHealth>())) ?? []
+        #expect(health.first?.consecutiveFailures ?? 0 == 0,
+                "cancellation must not count toward the API-unreachable signal")
+        // Mutation still returns to pending (handled before the
+        // cancellation guard fires) so the next push retries it.
+        #expect(queue.failedIds.count == 1)
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to [#187](https://github.com/brentbarkman/brett/pull/187) — once the diagnostic-message fix landed, [#185](https://github.com/brentbarkman/brett/issues/185)'s "Can't reach Brett" turned out to be **\`Request cancelled\`**.

`SyncManager.sync()` and `.pullToRefresh()` already filter cancellations out of their own state, but `PullEngine` / `PushEngine` write their own `SyncHealth.consecutiveFailures` **before** that filter sees the error. So a SwiftUI \`.refreshable\` getting cancelled, iOS suspending URLSession on background, or a debounced sync superseding the in-flight one all flared the banner — and it stuck until the next successful pull cleared it.

- Filter cancellations inside `recordPullFailure` and `PushEngine` transport catch, mirroring `SyncManager.isCancellation`.
- Push still returns mutations to pending before the cancellation guard, so retries are preserved.
- Added regression tests for both engines.

## Test plan

- [x] `pnpm test` n/a (iOS-only)
- [x] PullEngineTests + PushEngineTests pass (18 tests, including 2 new)
- [ ] After deploy: trigger pull-to-refresh on iOS; banner should not appear on routine churn, but a real outage (timeout, host unreachable) still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)