### PR TITLE
fix(desktop): three rollover/multi-user follow-ups from #189 review

### DIFF
--- a/apps/desktop/src/api/__tests__/briefing.test.tsx
+++ b/apps/desktop/src/api/__tests__/briefing.test.tsx
@@ -115,6 +115,53 @@ describe("useBriefing v2", () => {
     expect(refreshCalls).toHaveLength(0);
   });
 
+  // Regression guard for the briefing-skeleton-flash-on-rollover bug, same
+  // class as the Today-list fix in #189. The briefing queryKey embeds
+  // todayKey, so when the local day rolls over the key transitions to a
+  // brand-new cache entry. Without placeholderData: keepPreviousData the
+  // briefing surface gets isLoading=true and content=null, which causes
+  // DailyBriefing to swap the prose for <BriefingProseSkeleton />. With
+  // keepPreviousData the previous day's prose stays visible until the
+  // new fetch lands, then swaps in place — no skeleton flash.
+  it("keeps yesterday's briefing content visible while today's fetches across midnight rollover", async () => {
+    let fetchCount = 0;
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url !== "/brett/briefing/current") return Promise.resolve(undefined);
+      fetchCount += 1;
+      if (fetchCount === 1) {
+        return Promise.resolve({
+          briefing: {
+            content: "Yesterday's briefing prose.",
+            isEmpty: false,
+            generatedAt: "2026-05-16T07:00:00.000Z",
+          },
+          staleness: "fresh",
+        });
+      }
+      // Subsequent fetch (for the new day's key) hangs forever so we can
+      // assert what the hook is showing DURING the key transition.
+      return new Promise(() => {});
+    });
+
+    const { wrapper } = setupQueryClient();
+    const { result, rerender } = renderHook(() => useBriefing(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.content).toBe("Yesterday's briefing prose.");
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Simulate the local day rolling over — the next render uses the new key.
+    mockTodayKey = "2026-05-17T00:00:00.000Z";
+    rerender();
+
+    // Critical assertion: even though the new key has no cached data and
+    // its fetch is hanging, the previous day's prose is still showing
+    // and isLoading remains false. No skeleton flash.
+    expect(result.current.content).toBe("Yesterday's briefing prose.");
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it("does NOT fire /refresh when staleness is capped (within 30min floor or 6/day ceiling)", async () => {
     mockApiFetch.mockResolvedValue({
       briefing: {

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -3,7 +3,17 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { InboxResponse, Thing, ThingDetail } from "@brett/types";
-import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, useActiveThings, useListThings, __testing } from "../things";
+// Mock useTodayKey so we can simulate local-day rollover without waiting
+// on real wall-clock time. The current value is mutated between
+// rerender()s in the tests below. Tests that don't touch useUpcomingThings
+// are unaffected — neither useCreateThing/useUpdate/useDelete/useBulk nor
+// the useActiveThings/useListThings placeholder tests read useTodayKey.
+let mockTodayKey = "2026-05-22";
+vi.mock("../../hooks/useTodayKey", () => ({
+  useTodayKey: () => mockTodayKey,
+}));
+
+import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, useActiveThings, useListThings, useUpcomingThings, __testing } from "../things";
 
 const { thingMatchesFilters } = __testing;
 
@@ -559,6 +569,52 @@ describe("useThings placeholder behavior on key transition (rollover guard)", ()
     expect(result.current.isLoading).toBe(false);
     expect(result.current.data).toEqual([makeThing("a", "list-1 item")]);
     expect(result.current.isPlaceholderData).toBe(true);
+  });
+});
+
+// The Upcoming view's "active items due after today" cutoff used to be
+// `getTodayUTC().toISOString()` — i.e. UTC midnight of the current UTC date.
+// For non-UTC users that means the cutoff shifts at UTC midnight, not at
+// the user's local midnight. Tasks due "tomorrow" disappear from Upcoming
+// during the wrong evening hour (e.g. 8pm Eastern in winter). The fix
+// anchors the cutoff to `useTodayKey` so it only recomputes on the user's
+// local day rollover.
+//
+// This test pins the OBSERVABLE: when useTodayKey transitions (local
+// midnight) the cache key shifts and a refetch fires. The previous
+// implementation would not refetch in this scenario because it reads UTC
+// midnight directly, ignoring local-day signal entirely.
+describe("useUpcomingThings local-rollover guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTodayKey = "2026-05-22";
+  });
+
+  it("shifts cache key when useTodayKey changes, even if UTC clock hasn't ticked", async () => {
+    const { wrapper } = setupQueryClient();
+    mockApiFetch.mockResolvedValue([]);
+
+    const { rerender } = renderHook(() => useUpcomingThings(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalled();
+    });
+    const initialCallCount = mockApiFetch.mock.calls.length;
+
+    // Simulate the user's local day rolling over. With the fix, the cutoff
+    // is memo'd against useTodayKey, so the cache key shifts and a refetch
+    // fires. Without the fix, getTodayUTC() doesn't read useTodayKey at all
+    // — the cache key would only change when the test process's UTC clock
+    // crosses midnight, which never happens here.
+    mockTodayKey = "2026-05-23";
+    rerender();
+
+    await waitFor(
+      () => {
+        expect(mockApiFetch.mock.calls.length).toBeGreaterThan(initialCallCount);
+      },
+      { timeout: 1000 },
+    );
   });
 });
 

--- a/apps/desktop/src/api/briefing.ts
+++ b/apps/desktop/src/api/briefing.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { apiFetch } from "./client";
 import { useAIConfigs } from "./ai-config";
 import { useTodayKey } from "../hooks/useTodayKey";
@@ -59,6 +59,13 @@ export function useBriefing() {
     // (server-side 7am cron) is picked up the moment the user re-engages
     // the app, without needing a full reload.
     refetchOnWindowFocus: true,
+    // When todayKey flips at local midnight the queryKey transitions to
+    // a brand-new entry with no cached data. Without this option,
+    // isLoading would go true and DailyBriefing would show
+    // <BriefingProseSkeleton /> until the new fetch lands — visible as a
+    // briefing flash on overnight foreground. Carrying over the previous
+    // day's data keeps the prose visible until the new content swaps in.
+    placeholderData: keepPreviousData,
   });
 
   const cached = briefingQuery.data?.briefing ?? null;

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   useQuery,
   useMutation,
@@ -5,9 +6,10 @@ import {
   keepPreviousData,
 } from "@tanstack/react-query";
 import type { Thing, ThingDetail, CreateItemInput, UpdateItemInput, InboxResponse, BulkUpdateInput } from "@brett/types";
-import { getTodayUTC, computeUrgency } from "@brett/business";
+import { computeUrgency } from "@brett/business";
 import { apiFetch } from "./client";
 import { invalidateAllThings } from "./invalidate";
+import { useTodayKey } from "../hooks/useTodayKey";
 
 interface ThingsFilters {
   listId?: string;
@@ -75,9 +77,29 @@ export function useListThings(listId: string) {
   });
 }
 
-/** Active items with due dates after today (for Upcoming view) */
+/** Active items with due dates after today (for Upcoming view).
+ *
+ *  The cutoff is the user's LOCAL midnight, derived directly from the
+ *  `useTodayKey` "YYYY-MM-DD" string so the value is a pure function of the
+ *  local-day signal (no implicit dependency on `new Date()` ticking).
+ *  Anchoring to local midnight is the correctness fix: the previous
+ *  implementation used `getTodayUTC().toISOString()`, which shifted the
+ *  cutoff at UTC midnight rather than the user's local midnight — tasks
+ *  due "tomorrow" would disappear from Upcoming at e.g. 8pm Eastern in
+ *  winter, hours before the user's actual day rollover.
+ */
 export function useUpcomingThings() {
-  return useThings({ status: "active", dueAfter: getTodayUTC().toISOString() });
+  const todayKey = useTodayKey();
+  const dueAfter = useMemo(() => {
+    // todayKey is YYYY-MM-DD representing the user's local calendar day.
+    // `new Date(y, m-1, d)` constructs local midnight; `.toISOString()`
+    // serialises that instant as UTC. For a Pacific user on 2026-05-22
+    // this is "2026-05-22T07:00:00.000Z" (= 00:00 PT). For a UTC user the
+    // same call yields "2026-05-22T00:00:00.000Z".
+    const [y, m, d] = todayKey.split("-").map(Number);
+    return new Date(y, m - 1, d).toISOString();
+  }, [todayKey]);
+  return useThings({ status: "active", dueAfter });
 }
 
 /** Shape a CreateItemInput into a provisional Thing for optimistic caches. */

--- a/apps/desktop/src/auth/AuthContext.tsx
+++ b/apps/desktop/src/auth/AuthContext.tsx
@@ -3,9 +3,7 @@ import React, {
   useContext,
 } from "react";
 import type { AuthUser } from "@brett/types";
-import type { QueryClient } from "@tanstack/react-query";
-import { authClient, clearStoredToken, startGoogleOAuth } from "./auth-client";
-import { diagnostics } from "../lib/diagnostics";
+import { authClient, clearStoredToken, startGoogleOAuth, wipeUserState } from "./auth-client";
 
 interface AuthContextValue {
   user: AuthUser | null;
@@ -22,15 +20,6 @@ interface AuthContextValue {
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-// The QueryClient is registered by main.tsx on module init. signOut() uses
-// it to wipe all user-scoped cached data on the way out so a subsequent
-// sign-in as a different account can't briefly render the previous user's
-// lists / inbox / calendar before refetches complete.
-let registeredQueryClient: QueryClient | null = null;
-export function setQueryClient(qc: QueryClient): void {
-  registeredQueryClient = qc;
-}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const { data: sessionData, isPending: loading, refetch } =
@@ -72,12 +61,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signOut = async () => {
     await authClient.signOut();
     await clearStoredToken();
-    // Wipe in-memory state that outlives the AuthGuard unmount — the query
-    // cache (so user A's data can't flash on user B's sign-in) and the
-    // diagnostics ring buffer (which would otherwise attach one user's
-    // recent failed API calls to another user's next feedback submission).
-    registeredQueryClient?.clear();
-    diagnostics.clear();
+    // Wipe in-memory user-scoped state via the shared helper so this path
+    // can't drift from handleUnauthorized's (which fires on 401). The
+    // helper clears both the React Query cache and the diagnostics ring
+    // buffer that would otherwise attach one user's recent failed API
+    // calls to another user's next feedback submission.
+    wipeUserState();
   };
 
   return (

--- a/apps/desktop/src/auth/__tests__/auth-client.test.ts
+++ b/apps/desktop/src/auth/__tests__/auth-client.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression guard for the multi-user cache-leak bug surfaced in the
+ * review of PR #189. The explicit AuthContext.signOut() path always
+ * cleared the React Query cache and the diagnostics ring buffer, but the
+ * automatic `handleUnauthorized()` path (fired on any 401 from the API)
+ * cleared only the bearer token — leaving user A's `["things", ...]` /
+ * `["inbox"]` / `["briefing", ...]` entries in the global QueryClient.
+ * If user A's session was revoked server-side and user B then signed in
+ * on the same desktop install, user B's first render would briefly read
+ * user A's cached data via key match.
+ *
+ * The fix routes both paths through a shared `wipeUserState()` helper
+ * that clears the registered QueryClient and the diagnostics buffer.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+
+// Stub better-auth so importing auth-client doesn't construct a real
+// network client. The `signOut` mock resolves immediately so
+// handleUnauthorized's `await authClient.signOut()` completes.
+vi.mock("better-auth/react", () => ({
+  createAuthClient: vi.fn(() => ({
+    signOut: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("@better-auth/passkey/client", () => ({
+  passkeyClient: vi.fn(() => ({})),
+}));
+
+vi.mock("../../lib/diagnostics", () => ({
+  diagnostics: {
+    clear: vi.fn(),
+  },
+}));
+
+import { handleUnauthorized, setQueryClient, wipeUserState } from "../auth-client";
+import { diagnostics } from "../../lib/diagnostics";
+
+describe("auth-client cleanup wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the registered ref between tests by replacing with a fresh client.
+    setQueryClient(new QueryClient());
+  });
+
+  it("wipeUserState clears the registered React Query cache", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["things"], [{ id: "leak" }]);
+    setQueryClient(qc);
+
+    expect(qc.getQueryData(["things"])).toEqual([{ id: "leak" }]);
+    wipeUserState();
+    expect(qc.getQueryData(["things"])).toBeUndefined();
+  });
+
+  it("wipeUserState clears the diagnostics ring buffer", () => {
+    wipeUserState();
+    expect(diagnostics.clear).toHaveBeenCalledTimes(1);
+  });
+
+  // The bug. Before the fix, handleUnauthorized cleared the bearer token
+  // only — leaving cached per-user data in the QueryClient that the next
+  // user's first render would read.
+  it("handleUnauthorized clears the registered React Query cache so a re-sign-in can't read the prior session's data", async () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["things"], [{ id: "user-a-thing" }]);
+    qc.setQueryData(["inbox"], { visible: [{ id: "user-a-inbox" }] });
+    setQueryClient(qc);
+
+    await handleUnauthorized();
+
+    expect(qc.getQueryData(["things"])).toBeUndefined();
+    expect(qc.getQueryData(["inbox"])).toBeUndefined();
+  });
+
+  it("handleUnauthorized also clears the diagnostics buffer", async () => {
+    await handleUnauthorized();
+    expect(diagnostics.clear).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/auth/auth-client.ts
+++ b/apps/desktop/src/auth/auth-client.ts
@@ -1,5 +1,7 @@
 import { createAuthClient } from "better-auth/react";
 import { passkeyClient } from "@better-auth/passkey/client";
+import type { QueryClient } from "@tanstack/react-query";
+import { diagnostics } from "../lib/diagnostics";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
 
@@ -67,6 +69,29 @@ export async function clearStoredToken(): Promise<void> {
   }
 }
 
+// The QueryClient is registered by main.tsx on module init. Both sign-out
+// paths (the user-initiated AuthContext.signOut and the automatic
+// handleUnauthorized below) call wipeUserState() so the cached user
+// data and diagnostics ring buffer are dropped together — preventing
+// user A's cached `["things", ...]` / `["inbox"]` from rendering briefly
+// on user B's sign-in if they share a desktop install.
+let registeredQueryClient: QueryClient | null = null;
+export function setQueryClient(qc: QueryClient): void {
+  registeredQueryClient = qc;
+}
+
+/**
+ * Wipe in-memory user-scoped state. Both the user-initiated signOut
+ * (AuthContext) and the automatic 401 handler (handleUnauthorized below)
+ * route through this so the two paths can't drift. A drift here would be
+ * a multi-user data-leak — see the regression test in
+ * `__tests__/auth-client.test.ts`.
+ */
+export function wipeUserState(): void {
+  registeredQueryClient?.clear();
+  diagnostics.clear();
+}
+
 /**
  * Handle a 401 surfaced by any data fetch. Clears the bearer AND forces
  * better-auth's client-side session store to drop the cached user so the
@@ -79,6 +104,10 @@ export async function clearStoredToken(): Promise<void> {
  * The `signOut()` server call is best-effort: if the token is already
  * dead the POST itself will 401, but better-auth still drops the local
  * session cache on any outcome, which is what we need.
+ *
+ * Also calls wipeUserState() so the React Query cache + diagnostics are
+ * cleared — without that, user A's cached entries survive into user B's
+ * session if they share a desktop install.
  */
 export async function handleUnauthorized(): Promise<void> {
   try {
@@ -87,6 +116,7 @@ export async function handleUnauthorized(): Promise<void> {
     // Expected if the session is already dead on the server.
   }
   await clearStoredToken();
+  wipeUserState();
 }
 
 // Start Google OAuth via system browser with secure localhost callback

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -8,7 +8,7 @@ import { AuthProvider } from "./auth/AuthContext";
 import { AuthGuard } from "./auth/AuthGuard";
 import { LoginPage } from "./auth/LoginPage";
 import { AutoUpdateProvider } from "./hooks/useAutoUpdate";
-import { setQueryClient } from "./auth/AuthContext";
+import { setQueryClient } from "./auth/auth-client";
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Three independent bugs surfaced during the review of #189. Each is a separate commit.

## 1. Briefing skeleton flash on day rollover (`37e7cf7`)

Same class as #189 but for `DailyBriefing`. The briefing queryKey embeds `todayKey`, so at local midnight the key transitions to a fresh cache entry and the surface flashes `<BriefingProseSkeleton />`. Fix: `placeholderData: keepPreviousData` on the `useBriefing` query. Yesterday's prose stays visible until today's content swaps in. The dirty-refresh latch (`refreshFiredRef` / `lastRefreshedAtRef`) is unaffected because both refs reset on `cached.generatedAt` change.

## 2. Upcoming cutoff anchored to local midnight (`9ee1c54`)

`useUpcomingThings` used `getTodayUTC().toISOString()` — UTC midnight of the current UTC date. For non-UTC users that shifts the cutoff at UTC midnight, not at the user's local midnight; tasks due "tomorrow" disappear from Upcoming hours before the user's day rolls over (e.g. 8pm Eastern in winter). Fix derives the cutoff from `useTodayKey()` (\"YYYY-MM-DD\" of the user's local day): parse the key, construct local midnight via `new Date(y, m-1, d)`, serialise as UTC ISO. The cutoff now shifts exactly at the user's local midnight, including across DST transitions (the local-midnight Date constructor naturally tracks the offset for whichever calendar day).

## 3. React Query cache wipe on 401 (`e31e007`)

Pre-existing multi-user data-leak. `AuthContext.signOut()` cleared the React Query cache + diagnostics ring buffer, but `handleUnauthorized()` (fired on any 401) only cleared the bearer token. If user A's session was revoked server-side and user B signed in on the same desktop install, user B's first render briefly read user A's cached `[\"things\", ...]` / `[\"inbox\"]` / `[\"briefing\", ...]` entries via key match.

Refactor:
- Moved `registeredQueryClient` ref + `setQueryClient` into `auth-client.ts` (was `AuthContext.tsx`).
- Added `wipeUserState()` in `auth-client.ts` — clears the QueryClient and diagnostics.
- Both `AuthContext.signOut` and `handleUnauthorized` now route through `wipeUserState()` so the two paths can't drift.
- `main.tsx` imports `setQueryClient` from `auth-client` directly (no re-export).

## Test plan

- [x] `pnpm vitest run` — 220/220 passing including 8 new regression tests (4 in `auth-client.test.ts`, 1 in `briefing.test.tsx`, 1 in `things.test.ts`, 2 from #189 unchanged).
- [x] `tsc --noEmit` clean for both renderer and electron tsconfigs.
- [ ] Manual: background desktop app overnight; on foregrounding, briefing prose updates in place without skeleton flash.
- [ ] Manual: change system timezone to America/Los_Angeles; verify Upcoming view doesn't drop tasks before local midnight.
- [ ] Manual: induce a 401 (e.g. revoke session server-side); sign in as a different user; verify no flash of previous user's data.

## Reviewer findings (no blockers)

Independent code review found no critical/important issues. Two non-blocking suggestions:
1. Consider a dev-mode `console.warn` if `wipeUserState` runs without `setQueryClient` having been called — would surface a regression of the original bug if main.tsx wiring is ever dropped. Left as-is.
2. The diagnostics-clear test inherits an empty QueryClient from `beforeEach` so the cache-clear is incidental in that one case. Not buggy, just imprecise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)