### PR TITLE
Release: desktop rollover fixes, iOS storage URL persistence, iOS scroll perf

### DIFF
--- a/apps/desktop/src/api/__tests__/briefing.test.tsx
+++ b/apps/desktop/src/api/__tests__/briefing.test.tsx
@@ -115,6 +115,53 @@ describe("useBriefing v2", () => {
     expect(refreshCalls).toHaveLength(0);
   });
 
+  // Regression guard for the briefing-skeleton-flash-on-rollover bug, same
+  // class as the Today-list fix in #189. The briefing queryKey embeds
+  // todayKey, so when the local day rolls over the key transitions to a
+  // brand-new cache entry. Without placeholderData: keepPreviousData the
+  // briefing surface gets isLoading=true and content=null, which causes
+  // DailyBriefing to swap the prose for <BriefingProseSkeleton />. With
+  // keepPreviousData the previous day's prose stays visible until the
+  // new fetch lands, then swaps in place — no skeleton flash.
+  it("keeps yesterday's briefing content visible while today's fetches across midnight rollover", async () => {
+    let fetchCount = 0;
+    mockApiFetch.mockImplementation((url: string) => {
+      if (url !== "/brett/briefing/current") return Promise.resolve(undefined);
+      fetchCount += 1;
+      if (fetchCount === 1) {
+        return Promise.resolve({
+          briefing: {
+            content: "Yesterday's briefing prose.",
+            isEmpty: false,
+            generatedAt: "2026-05-16T07:00:00.000Z",
+          },
+          staleness: "fresh",
+        });
+      }
+      // Subsequent fetch (for the new day's key) hangs forever so we can
+      // assert what the hook is showing DURING the key transition.
+      return new Promise(() => {});
+    });
+
+    const { wrapper } = setupQueryClient();
+    const { result, rerender } = renderHook(() => useBriefing(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.content).toBe("Yesterday's briefing prose.");
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Simulate the local day rolling over — the next render uses the new key.
+    mockTodayKey = "2026-05-17T00:00:00.000Z";
+    rerender();
+
+    // Critical assertion: even though the new key has no cached data and
+    // its fetch is hanging, the previous day's prose is still showing
+    // and isLoading remains false. No skeleton flash.
+    expect(result.current.content).toBe("Yesterday's briefing prose.");
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it("does NOT fire /refresh when staleness is capped (within 30min floor or 6/day ceiling)", async () => {
     mockApiFetch.mockResolvedValue({
       briefing: {

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -3,7 +3,17 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { InboxResponse, Thing, ThingDetail } from "@brett/types";
-import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, useActiveThings, useListThings, __testing } from "../things";
+// Mock useTodayKey so we can simulate local-day rollover without waiting
+// on real wall-clock time. The current value is mutated between
+// rerender()s in the tests below. Tests that don't touch useUpcomingThings
+// are unaffected — neither useCreateThing/useUpdate/useDelete/useBulk nor
+// the useActiveThings/useListThings placeholder tests read useTodayKey.
+let mockTodayKey = "2026-05-22";
+vi.mock("../../hooks/useTodayKey", () => ({
+  useTodayKey: () => mockTodayKey,
+}));
+
+import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, useActiveThings, useListThings, useUpcomingThings, __testing } from "../things";
 
 const { thingMatchesFilters } = __testing;
 
@@ -559,6 +569,52 @@ describe("useThings placeholder behavior on key transition (rollover guard)", ()
     expect(result.current.isLoading).toBe(false);
     expect(result.current.data).toEqual([makeThing("a", "list-1 item")]);
     expect(result.current.isPlaceholderData).toBe(true);
+  });
+});
+
+// The Upcoming view's "active items due after today" cutoff used to be
+// `getTodayUTC().toISOString()` — i.e. UTC midnight of the current UTC date.
+// For non-UTC users that means the cutoff shifts at UTC midnight, not at
+// the user's local midnight. Tasks due "tomorrow" disappear from Upcoming
+// during the wrong evening hour (e.g. 8pm Eastern in winter). The fix
+// anchors the cutoff to `useTodayKey` so it only recomputes on the user's
+// local day rollover.
+//
+// This test pins the OBSERVABLE: when useTodayKey transitions (local
+// midnight) the cache key shifts and a refetch fires. The previous
+// implementation would not refetch in this scenario because it reads UTC
+// midnight directly, ignoring local-day signal entirely.
+describe("useUpcomingThings local-rollover guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTodayKey = "2026-05-22";
+  });
+
+  it("shifts cache key when useTodayKey changes, even if UTC clock hasn't ticked", async () => {
+    const { wrapper } = setupQueryClient();
+    mockApiFetch.mockResolvedValue([]);
+
+    const { rerender } = renderHook(() => useUpcomingThings(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalled();
+    });
+    const initialCallCount = mockApiFetch.mock.calls.length;
+
+    // Simulate the user's local day rolling over. With the fix, the cutoff
+    // is memo'd against useTodayKey, so the cache key shifts and a refetch
+    // fires. Without the fix, getTodayUTC() doesn't read useTodayKey at all
+    // — the cache key would only change when the test process's UTC clock
+    // crosses midnight, which never happens here.
+    mockTodayKey = "2026-05-23";
+    rerender();
+
+    await waitFor(
+      () => {
+        expect(mockApiFetch.mock.calls.length).toBeGreaterThan(initialCallCount);
+      },
+      { timeout: 1000 },
+    );
   });
 });
 

--- a/apps/desktop/src/api/__tests__/things.test.ts
+++ b/apps/desktop/src/api/__tests__/things.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { InboxResponse, Thing, ThingDetail } from "@brett/types";
-import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, __testing } from "../things";
+import { useCreateThing, useUpdateThing, useDeleteThing, useBulkUpdateThings, useActiveThings, useListThings, __testing } from "../things";
 
 const { thingMatchesFilters } = __testing;
 
@@ -483,6 +483,82 @@ describe("thingMatchesFilters", () => {
 
   it("never matches a completedAfter filter (new items aren't pre-completed)", () => {
     expect(thingMatchesFilters(baseThing, { completedAfter: "2026-04-20T00:00:00.000Z" })).toBe(false);
+  });
+});
+
+// Regression guard for the Today-list-reloads-overnight bug. The Today
+// view's active/done queries embed ISO date bounds in their cache key; when
+// the local day rolls over, those bounds shift and the key transitions to
+// a brand-new entry. Without placeholderData: keepPreviousData, isLoading
+// would flip true and the entire list would be replaced by a skeleton
+// until the new fetch lands. With keepPreviousData, the previous result
+// stays visible (isPlaceholderData=true) and isLoading stays false — no
+// skeleton flash. If this test fails, the Today list is going to visibly
+// reload on day rollover.
+describe("useThings placeholder behavior on key transition (rollover guard)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps showing previous data with isLoading=false when the date-bound key changes", async () => {
+    const { wrapper } = setupQueryClient();
+
+    const yesterdayBound = "2026-05-21T23:59:59.999Z";
+    const todayBound = "2026-05-22T23:59:59.999Z";
+
+    // First fetch resolves with seed data; second fetch hangs forever so we
+    // can assert what the hook is showing DURING the key transition.
+    let fetchCount = 0;
+    mockApiFetch.mockImplementation(() => {
+      fetchCount += 1;
+      if (fetchCount === 1) return Promise.resolve([makeThing("a", "carry-over")]);
+      return new Promise(() => {}); // hang
+    });
+
+    const { result, rerender } = renderHook(
+      ({ d }: { d: string }) => useActiveThings(d),
+      { wrapper, initialProps: { d: yesterdayBound } },
+    );
+
+    // Initial load completes.
+    await waitFor(() => {
+      expect(result.current.data).toEqual([makeThing("a", "carry-over")]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Simulate the local day rolling over: new ISO bound → new cache key.
+    rerender({ d: todayBound });
+
+    // Critical assertion: even though the new key has no cached data and
+    // its fetch is still in flight, isLoading is FALSE and the previous
+    // data is still rendered. This is what prevents the skeleton flash.
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual([makeThing("a", "carry-over")]);
+    expect(result.current.isPlaceholderData).toBe(true);
+  });
+
+  it("also keeps previous data when useListThings switches listId", async () => {
+    const { wrapper } = setupQueryClient();
+
+    let fetchCount = 0;
+    mockApiFetch.mockImplementation(() => {
+      fetchCount += 1;
+      if (fetchCount === 1) return Promise.resolve([makeThing("a", "list-1 item")]);
+      return new Promise(() => {});
+    });
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useListThings(id),
+      { wrapper, initialProps: { id: "list-1" } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([makeThing("a", "list-1 item")]);
+    });
+
+    rerender({ id: "list-2" });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual([makeThing("a", "list-1 item")]);
+    expect(result.current.isPlaceholderData).toBe(true);
   });
 });
 

--- a/apps/desktop/src/api/briefing.ts
+++ b/apps/desktop/src/api/briefing.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { apiFetch } from "./client";
 import { useAIConfigs } from "./ai-config";
 import { useTodayKey } from "../hooks/useTodayKey";
@@ -59,6 +59,13 @@ export function useBriefing() {
     // (server-side 7am cron) is picked up the moment the user re-engages
     // the app, without needing a full reload.
     refetchOnWindowFocus: true,
+    // When todayKey flips at local midnight the queryKey transitions to
+    // a brand-new entry with no cached data. Without this option,
+    // isLoading would go true and DailyBriefing would show
+    // <BriefingProseSkeleton /> until the new fetch lands — visible as a
+    // briefing flash on overnight foreground. Carrying over the previous
+    // day's data keeps the prose visible until the new content swaps in.
+    placeholderData: keepPreviousData,
   });
 
   const cached = briefingQuery.data?.briefing ?? null;

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -2,6 +2,7 @@ import {
   useQuery,
   useMutation,
   useQueryClient,
+  keepPreviousData,
 } from "@tanstack/react-query";
 import type { Thing, ThingDetail, CreateItemInput, UpdateItemInput, InboxResponse, BulkUpdateInput } from "@brett/types";
 import { getTodayUTC, computeUrgency } from "@brett/business";
@@ -44,6 +45,13 @@ export function useThings(filters?: ThingsFilters) {
   return useQuery({
     queryKey: ["things", filters ?? {}],
     queryFn: () => apiFetch<Thing[]>(`/things${buildQuery(filters)}`),
+    // When date-bound filters shift (e.g. midnight rollover updates
+    // dueBefore/completedAfter on Today), keep showing the previous
+    // result while the new key fetches. Without this, the cache key
+    // changes to a fresh entry with no data, isLoading flips true,
+    // and the entire list is replaced by a skeleton for one round-trip
+    // — visible to the user as the whole list reloading.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -63,6 +71,7 @@ export function useListThings(listId: string) {
     queryKey: ["things", { listId }],
     queryFn: () => apiFetch<Thing[]>(`/things?listId=${listId}`),
     enabled: !!listId,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/apps/desktop/src/api/things.ts
+++ b/apps/desktop/src/api/things.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   useQuery,
   useMutation,
@@ -5,9 +6,10 @@ import {
   keepPreviousData,
 } from "@tanstack/react-query";
 import type { Thing, ThingDetail, CreateItemInput, UpdateItemInput, InboxResponse, BulkUpdateInput } from "@brett/types";
-import { getTodayUTC, computeUrgency } from "@brett/business";
+import { computeUrgency } from "@brett/business";
 import { apiFetch } from "./client";
 import { invalidateAllThings } from "./invalidate";
+import { useTodayKey } from "../hooks/useTodayKey";
 
 interface ThingsFilters {
   listId?: string;
@@ -75,9 +77,29 @@ export function useListThings(listId: string) {
   });
 }
 
-/** Active items with due dates after today (for Upcoming view) */
+/** Active items with due dates after today (for Upcoming view).
+ *
+ *  The cutoff is the user's LOCAL midnight, derived directly from the
+ *  `useTodayKey` "YYYY-MM-DD" string so the value is a pure function of the
+ *  local-day signal (no implicit dependency on `new Date()` ticking).
+ *  Anchoring to local midnight is the correctness fix: the previous
+ *  implementation used `getTodayUTC().toISOString()`, which shifted the
+ *  cutoff at UTC midnight rather than the user's local midnight — tasks
+ *  due "tomorrow" would disappear from Upcoming at e.g. 8pm Eastern in
+ *  winter, hours before the user's actual day rollover.
+ */
 export function useUpcomingThings() {
-  return useThings({ status: "active", dueAfter: getTodayUTC().toISOString() });
+  const todayKey = useTodayKey();
+  const dueAfter = useMemo(() => {
+    // todayKey is YYYY-MM-DD representing the user's local calendar day.
+    // `new Date(y, m-1, d)` constructs local midnight; `.toISOString()`
+    // serialises that instant as UTC. For a Pacific user on 2026-05-22
+    // this is "2026-05-22T07:00:00.000Z" (= 00:00 PT). For a UTC user the
+    // same call yields "2026-05-22T00:00:00.000Z".
+    const [y, m, d] = todayKey.split("-").map(Number);
+    return new Date(y, m - 1, d).toISOString();
+  }, [todayKey]);
+  return useThings({ status: "active", dueAfter });
 }
 
 /** Shape a CreateItemInput into a provisional Thing for optimistic caches. */

--- a/apps/desktop/src/auth/AuthContext.tsx
+++ b/apps/desktop/src/auth/AuthContext.tsx
@@ -3,9 +3,7 @@ import React, {
   useContext,
 } from "react";
 import type { AuthUser } from "@brett/types";
-import type { QueryClient } from "@tanstack/react-query";
-import { authClient, clearStoredToken, startGoogleOAuth } from "./auth-client";
-import { diagnostics } from "../lib/diagnostics";
+import { authClient, clearStoredToken, startGoogleOAuth, wipeUserState } from "./auth-client";
 
 interface AuthContextValue {
   user: AuthUser | null;
@@ -22,15 +20,6 @@ interface AuthContextValue {
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-// The QueryClient is registered by main.tsx on module init. signOut() uses
-// it to wipe all user-scoped cached data on the way out so a subsequent
-// sign-in as a different account can't briefly render the previous user's
-// lists / inbox / calendar before refetches complete.
-let registeredQueryClient: QueryClient | null = null;
-export function setQueryClient(qc: QueryClient): void {
-  registeredQueryClient = qc;
-}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const { data: sessionData, isPending: loading, refetch } =
@@ -72,12 +61,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signOut = async () => {
     await authClient.signOut();
     await clearStoredToken();
-    // Wipe in-memory state that outlives the AuthGuard unmount — the query
-    // cache (so user A's data can't flash on user B's sign-in) and the
-    // diagnostics ring buffer (which would otherwise attach one user's
-    // recent failed API calls to another user's next feedback submission).
-    registeredQueryClient?.clear();
-    diagnostics.clear();
+    // Wipe in-memory user-scoped state via the shared helper so this path
+    // can't drift from handleUnauthorized's (which fires on 401). The
+    // helper clears both the React Query cache and the diagnostics ring
+    // buffer that would otherwise attach one user's recent failed API
+    // calls to another user's next feedback submission.
+    wipeUserState();
   };
 
   return (

--- a/apps/desktop/src/auth/__tests__/auth-client.test.ts
+++ b/apps/desktop/src/auth/__tests__/auth-client.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression guard for the multi-user cache-leak bug surfaced in the
+ * review of PR #189. The explicit AuthContext.signOut() path always
+ * cleared the React Query cache and the diagnostics ring buffer, but the
+ * automatic `handleUnauthorized()` path (fired on any 401 from the API)
+ * cleared only the bearer token — leaving user A's `["things", ...]` /
+ * `["inbox"]` / `["briefing", ...]` entries in the global QueryClient.
+ * If user A's session was revoked server-side and user B then signed in
+ * on the same desktop install, user B's first render would briefly read
+ * user A's cached data via key match.
+ *
+ * The fix routes both paths through a shared `wipeUserState()` helper
+ * that clears the registered QueryClient and the diagnostics buffer.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+
+// Stub better-auth so importing auth-client doesn't construct a real
+// network client. The `signOut` mock resolves immediately so
+// handleUnauthorized's `await authClient.signOut()` completes.
+vi.mock("better-auth/react", () => ({
+  createAuthClient: vi.fn(() => ({
+    signOut: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("@better-auth/passkey/client", () => ({
+  passkeyClient: vi.fn(() => ({})),
+}));
+
+vi.mock("../../lib/diagnostics", () => ({
+  diagnostics: {
+    clear: vi.fn(),
+  },
+}));
+
+import { handleUnauthorized, setQueryClient, wipeUserState } from "../auth-client";
+import { diagnostics } from "../../lib/diagnostics";
+
+describe("auth-client cleanup wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the registered ref between tests by replacing with a fresh client.
+    setQueryClient(new QueryClient());
+  });
+
+  it("wipeUserState clears the registered React Query cache", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["things"], [{ id: "leak" }]);
+    setQueryClient(qc);
+
+    expect(qc.getQueryData(["things"])).toEqual([{ id: "leak" }]);
+    wipeUserState();
+    expect(qc.getQueryData(["things"])).toBeUndefined();
+  });
+
+  it("wipeUserState clears the diagnostics ring buffer", () => {
+    wipeUserState();
+    expect(diagnostics.clear).toHaveBeenCalledTimes(1);
+  });
+
+  // The bug. Before the fix, handleUnauthorized cleared the bearer token
+  // only — leaving cached per-user data in the QueryClient that the next
+  // user's first render would read.
+  it("handleUnauthorized clears the registered React Query cache so a re-sign-in can't read the prior session's data", async () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["things"], [{ id: "user-a-thing" }]);
+    qc.setQueryData(["inbox"], { visible: [{ id: "user-a-inbox" }] });
+    setQueryClient(qc);
+
+    await handleUnauthorized();
+
+    expect(qc.getQueryData(["things"])).toBeUndefined();
+    expect(qc.getQueryData(["inbox"])).toBeUndefined();
+  });
+
+  it("handleUnauthorized also clears the diagnostics buffer", async () => {
+    await handleUnauthorized();
+    expect(diagnostics.clear).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/auth/auth-client.ts
+++ b/apps/desktop/src/auth/auth-client.ts
@@ -1,5 +1,7 @@
 import { createAuthClient } from "better-auth/react";
 import { passkeyClient } from "@better-auth/passkey/client";
+import type { QueryClient } from "@tanstack/react-query";
+import { diagnostics } from "../lib/diagnostics";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
 
@@ -67,6 +69,29 @@ export async function clearStoredToken(): Promise<void> {
   }
 }
 
+// The QueryClient is registered by main.tsx on module init. Both sign-out
+// paths (the user-initiated AuthContext.signOut and the automatic
+// handleUnauthorized below) call wipeUserState() so the cached user
+// data and diagnostics ring buffer are dropped together — preventing
+// user A's cached `["things", ...]` / `["inbox"]` from rendering briefly
+// on user B's sign-in if they share a desktop install.
+let registeredQueryClient: QueryClient | null = null;
+export function setQueryClient(qc: QueryClient): void {
+  registeredQueryClient = qc;
+}
+
+/**
+ * Wipe in-memory user-scoped state. Both the user-initiated signOut
+ * (AuthContext) and the automatic 401 handler (handleUnauthorized below)
+ * route through this so the two paths can't drift. A drift here would be
+ * a multi-user data-leak — see the regression test in
+ * `__tests__/auth-client.test.ts`.
+ */
+export function wipeUserState(): void {
+  registeredQueryClient?.clear();
+  diagnostics.clear();
+}
+
 /**
  * Handle a 401 surfaced by any data fetch. Clears the bearer AND forces
  * better-auth's client-side session store to drop the cached user so the
@@ -79,6 +104,10 @@ export async function clearStoredToken(): Promise<void> {
  * The `signOut()` server call is best-effort: if the token is already
  * dead the POST itself will 401, but better-auth still drops the local
  * session cache on any outcome, which is what we need.
+ *
+ * Also calls wipeUserState() so the React Query cache + diagnostics are
+ * cleared — without that, user A's cached entries survive into user B's
+ * session if they share a desktop install.
  */
 export async function handleUnauthorized(): Promise<void> {
   try {
@@ -87,6 +116,7 @@ export async function handleUnauthorized(): Promise<void> {
     // Expected if the session is already dead on the server.
   }
   await clearStoredToken();
+  wipeUserState();
 }
 
 // Start Google OAuth via system browser with secure localhost callback

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -8,7 +8,7 @@ import { AuthProvider } from "./auth/AuthContext";
 import { AuthGuard } from "./auth/AuthGuard";
 import { LoginPage } from "./auth/LoginPage";
 import { AutoUpdateProvider } from "./hooks/useAutoUpdate";
-import { setQueryClient } from "./auth/AuthContext";
+import { setQueryClient } from "./auth/auth-client";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -8,20 +8,31 @@ import SwiftUI
 ///      photography + abstract image paths, grouped by time-of-day and
 ///      "busyness" tier.
 ///   2. `/config` (network) — gives us the `storageBaseUrl` where images
-///      actually live. Cached in-memory for the session; re-fetched on
-///      each fresh app launch and after `clearForSignOut()`.
+///      actually live. Cached in-memory for the session AND persisted to
+///      UserDefaults so a cold launch with `/config` unreachable can still
+///      resolve image URLs against the cached manifest. Re-fetched on
+///      every `load()` to pick up env shifts. The base URL is env-level
+///      (not per-user) — see `storageBaseUrl` docs for why persisting it
+///      doesn't reintroduce the cross-user leak the URL cache had.
 ///   3. `UserProfile.backgroundStyle` + `UserProfile.pinnedBackground` —
 ///      what the user picked. Either a relative path (e.g.
 ///      "photo/evening/light-2.webp") or a "solid:#RRGGBB" sentinel.
 ///
-/// **No on-disk URL cache.** The service deliberately does not persist
-/// the last-resolved URL to UserDefaults. Cold launch starts from the
-/// wash bed (`defaultWashColor`) and the resolved photo fades in over
-/// it via `BackgroundView.paintAnimation` once `load()` + `recompute()`
-/// complete. The previous design persisted the URL to skip a blank
-/// frame, but that produced a cross-user leak (the cached URL survived
-/// sign-out) and a visible cached → resolved swap on every cold
-/// launch. See `BackgroundView` for the rendering pipeline.
+/// **No on-disk per-user URL cache.** The service deliberately does not
+/// persist `currentRemoteURL` (the resolved photo URL) to UserDefaults.
+/// Cold launch starts from the wash bed (`defaultWashColor`) and the
+/// resolved photo fades in over it via `BackgroundView.paintAnimation`
+/// once `load()` + `recompute()` complete. The previous design persisted
+/// that URL to skip a blank frame, but it leaked across sign-out and
+/// produced a visible cached → resolved swap on every cold launch.
+///
+/// The env-level `storageBaseUrl` IS persisted (see
+/// `persistedStorageBaseUrl(defaults:)`) so the photo can still resolve
+/// from the on-disk manifest cache + iOS URLCache on cold launch when
+/// `/config` is unreachable. Without that, an API outage at cold launch
+/// would leave the user staring at the bare wash bed — the prior
+/// session's photo couldn't render because the base URL was gone, even
+/// though the manifest and image bytes were both still on disk.
 ///
 /// The service is a singleton on the main actor because `BackgroundView`
 /// reads it from SwiftUI, and because the manifest + base URL are
@@ -43,7 +54,13 @@ final class BackgroundService: Clearable {
     /// Base URL of the storage server (e.g.
     /// `https://api.brett.brentbarkman.com/public`). Images are served
     /// under `{storageBaseUrl}/backgrounds/{path}`. `nil` until `/config`
-    /// returns.
+    /// returns or `loadConfigIfNeeded()` hydrates the value from
+    /// UserDefaults (see `persistedStorageBaseUrl(defaults:)`).
+    ///
+    /// The base URL is environment-level (every prod user shares the
+    /// same value), so persisting it is safe — unlike `currentRemoteURL`,
+    /// which embeds the user's pinned-photo selection and is deliberately
+    /// not persisted to avoid the cross-user leak fixed in 2026-05-17.
     private(set) var storageBaseUrl: URL?
 
     /// True once both the manifest and base URL have resolved.
@@ -385,6 +402,21 @@ final class BackgroundService: Clearable {
     }
 
     private func loadConfigIfNeeded() async {
+        // Hydrate from UserDefaults before we hit the network so a cold
+        // launch with `/config` unreachable still has a base URL to
+        // resolve cached manifest entries against. Without this, an API
+        // outage at cold launch falls through to the wash-only render
+        // even when the manifest cache and AsyncImage URLCache could
+        // have served the photo. Only fills when we don't already have
+        // a value in-memory — `clearForSignOut()` deliberately leaves
+        // `storageBaseUrl` nil until the next `load()` to keep the
+        // sign-out → sign-in race window safe (a stale prior-user
+        // profile + a non-nil base URL would resolve the prior user's
+        // pinned photo on the sign-in screen).
+        if storageBaseUrl == nil {
+            self.storageBaseUrl = Self.persistedStorageBaseUrl()
+        }
+
         // Re-fetch each call — storageBaseUrl is cheap and shifts between
         // dev and prod. We don't cache aggressively because the manifest
         // is the expensive part and already memoized.
@@ -401,10 +433,41 @@ final class BackgroundService: Clearable {
             )
             if let parsed = URL(string: response.storageBaseUrl) {
                 self.storageBaseUrl = parsed
+                Self.persistStorageBaseUrl(parsed)
             }
         } catch {
             BrettLog.app.error("BackgroundService: failed to load /config: \(String(describing: error), privacy: .public)")
         }
+    }
+
+    // MARK: - storageBaseUrl persistence
+
+    /// UserDefaults key for the persisted storage base URL. Versioned
+    /// so a future format change (e.g. moving to a struct payload) can
+    /// invalidate the old key without colliding.
+    static let storageBaseUrlDefaultsKey = "BackgroundService.storageBaseUrl.v1"
+
+    /// Read the previously-persisted storage base URL, if any. Pure
+    /// (UserDefaults-only) so tests can pass an isolated suite. The
+    /// defaults parameter has a `.standard` default for production
+    /// callers — `loadConfigIfNeeded()` uses that path.
+    static func persistedStorageBaseUrl(
+        defaults: UserDefaults = .standard
+    ) -> URL? {
+        guard let raw = defaults.string(forKey: storageBaseUrlDefaultsKey),
+              !raw.isEmpty else { return nil }
+        return URL(string: raw)
+    }
+
+    /// Persist the storage base URL so the next cold launch can resolve
+    /// image URLs even if `/config` is unreachable. Stored as the raw
+    /// string (not Data) so a quick inspection of UserDefaults during
+    /// debugging stays human-readable.
+    static func persistStorageBaseUrl(
+        _ url: URL,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(url.absoluteString, forKey: storageBaseUrlDefaultsKey)
     }
 
     // MARK: - Network manifest

--- a/apps/ios/Brett/Views/Inbox/InboxPage.swift
+++ b/apps/ios/Brett/Views/Inbox/InboxPage.swift
@@ -158,8 +158,8 @@ private struct InboxPageBody: View {
                 // No per-page wash. The global `WashBackground` in
                 // `MainContainer` is the sole backdrop; page content
                 // slides over it during swipes while the global photo
-                // crossfades to wash on top. See `photoOpacity`
-                // computation in `MainContainer.swift`.
+                // crossfades to wash on top. See `GlobalPhotoLayer`
+                // in `MainContainer.swift` for the crossfade math.
 
                 ScrollView {
                     VStack(spacing: 0) {

--- a/apps/ios/Brett/Views/List/ListsPage.swift
+++ b/apps/ios/Brett/Views/List/ListsPage.swift
@@ -118,7 +118,7 @@ private struct ListsPageBody: View {
         ZStack {
             // No per-page wash — the global wash in `MainContainer`
             // is the backdrop, and page content slides over it during
-            // pager transitions. See `photoOpacity` in MainContainer.
+            // pager transitions. See `GlobalPhotoLayer` in MainContainer.
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {

--- a/apps/ios/Brett/Views/MainContainer.swift
+++ b/apps/ios/Brett/Views/MainContainer.swift
@@ -188,72 +188,33 @@ struct MainContainer: View {
     /// background state explicitly.
     @State private var wasBackgrounded: Bool = false
 
-    /// Reactive read of the shared hero-scroll state. Writes happen
-    /// inside TodayPage via `HeroScrollState.shared.publish(...)` —
-    /// reading the offset here causes MainContainer to re-render the
-    /// adaptive chrome (pills opacity + omnibar bg opacity).
-    @State private var heroScroll = HeroScrollState.shared
-
-    /// Distance over which the pills + omnibar transition between hero
-    /// (calm) and work (substantive) modes. Matches the photo→wash
-    /// gradient height in `TodayPage` so all the calm-hero affordances
-    /// transition together.
-    private static let heroFadeDistance: CGFloat = 140
-
-    /// Visibility (0–1) for the bottom view-pills row.
-    /// - On Today, ramps from 0 at the top of the hero to 1 at
-    ///   `heroFadeDistance` of scroll — pills only earn their place
-    ///   once the user is in the working zone.
-    /// - On every other page, hidden (0). Calm-hero direction is
-    ///   swipe-only navigation between pages; the pills aren't a
-    ///   primary affordance, just a "here's where you are when you
-    ///   land back on Today" signal.
-    private var pillsVisibility: Double {
-        guard currentPage == 2 else { return 0 }
-        let progress = Double(heroScroll.offset / Self.heroFadeDistance)
-        return min(max(progress, 0), 1)
-    }
-
-    /// Background opacity for the omnibar. Calm-hero spec: 0.55 at
-    /// the top of Today (thinner glass so the photo breathes), 1.0
-    /// past the hero (substantive glass against busy lists). Same
-    /// adaptive curve as `pillsVisibility` — both anchor on the
-    /// 140pt hero fade distance so all calm-hero affordances
-    /// transition together. Always 1.0 on non-Today pages.
-    private var omnibarBackgroundOpacity: Double {
-        guard currentPage == 2 else { return 1 }
-        let progress = Double(heroScroll.offset / Self.heroFadeDistance)
-        let clamped = min(max(progress, 0), 1)
-        // Lerp from 0.55 (hero) to 1.0 (work). Never goes below 0.55
-        // even at scroll=0 because the omnibar input is interactive
-        // and needs *some* glass plate for the field to read against.
-        return 0.55 + (1.0 - 0.55) * clamped
-    }
-
-    /// Magnitude of the current pager swipe (0 settled, 1 fully
-    /// dragged to an adjacent page).
-    @State private var pagerDragProgress: CGFloat = 0
-    /// Signed pager swipe progress. Positive = dragging toward a
-    /// HIGHER page index, negative toward a LOWER index. Combined
-    /// with `currentPage` we can compute "effective page position"
-    /// during the swipe and drive a smooth photo↔wash crossfade.
-    @State private var pagerSignedDragProgress: CGFloat = 0
-
-    /// Opacity for the global background photo. Crossfades smoothly
-    /// to the wash as the user swipes away from Today (and back as
-    /// they swipe toward Today). The "effective page" is `currentPage
-    /// + signedDragProgress`; how close that is to Today's index (2)
-    /// is the photo's visibility. Multiplied by the Today scroll
-    /// factor so scrolling past the hero also fades the photo out.
-    private var photoOpacity: Double {
-        let effectivePage = Double(currentPage) + Double(pagerSignedDragProgress)
-        let distanceFromToday = abs(effectivePage - 2)
-        let proximityToToday = max(0, 1 - distanceFromToday)
-        let scrollFactor = currentPage == 2
-            ? 1 - min(max(Double(heroScroll.offset / Self.heroFadeDistance), 0), 1)
-            : 1.0
-        return proximityToToday * scrollFactor
-    }
+    // MARK: - Adaptive-chrome read budget
+    //
+    // `HeroScrollState.shared` (vertical scroll on Today) and
+    // `PagerProgressState.shared` (horizontal page swipes) both
+    // publish 60-120 times per second while the user's finger is on
+    // the screen. MainContainer used to read both directly in
+    // computed properties (`photoOpacity`, `pillsVisibility`,
+    // `omnibarBackgroundOpacity`), which made the Observation
+    // framework register MainContainer as a subscriber to every
+    // change — re-evaluating the entire ZStack on every scroll frame.
+    //
+    // That re-render storm starved the main thread, dropped scroll
+    // callback frames, and false-positive-tripped the
+    // `PagedSwipeResetDetector` threshold — visible to the user as
+    // page swipes that snapped back without committing and as
+    // jittery Today scroll.
+    //
+    // Resolution: route the reads through small leaf views
+    // (`GlobalPhotoLayer`, `BriefingCanopyOverlay`,
+    // `AdaptiveViewPillsBar`, `AdaptiveOmnibarView` — all below).
+    // The leaves subscribe to the singletons; MainContainer's body
+    // no longer reads either, so it no longer re-renders during
+    // scroll or swipe.
+    //
+    // `Self.heroFadeDistance` is the constant the leaves use — kept
+    // here as the single source of truth.
+    static let heroFadeDistance: CGFloat = 140
 
     var body: some View {
         // `@Bindable` projection so we can pass `$selection.currentDestination`
@@ -275,50 +236,24 @@ struct MainContainer: View {
                 // Photo on top of the wash, opacity tied to current
                 // page + scroll position + live swipe progress. Lives
                 // here (not inside Today) so it can reach the safe-
-                // area zones — `PagedSwipeView` gives us live swipe
-                // progress so the photo crossfades smoothly during a
-                // side-swipe instead of snapping at midpoint.
-                BackgroundView()
-                    .opacity(photoOpacity)
-                    .ignoresSafeArea()
-                    .allowsHitTesting(false)
+                // area zones. The leaf view subscribes to
+                // `PagerProgressState.shared` and `HeroScrollState.shared`
+                // directly so its re-renders stay contained — see the
+                // "Adaptive-chrome read budget" note above for why
+                // MainContainer must not subscribe at this level.
+                GlobalPhotoLayer(currentPage: currentPage)
 
                 // Top-edge briefing canopy — V2 readability scrim. Gives
                 // the TodayHero briefing prose a uniform field to sit on
                 // regardless of the wallpaper's upper composition;
                 // replaces the per-photo color sampling we used to do
-                // for prose color. Only mounted on Today and fades with
-                // the photo so non-Today pages don't get an unmotivated
+                // for prose color. Only renders on Today (the leaf
+                // view gates internally) and rides the same photo
+                // opacity so non-Today pages don't get an unmotivated
                 // top darkening. See briefing-readability review notes
                 // in `docs/backgrounds.md` companion + the
                 // `packages/ui/src/BriefingCanopy.tsx` desktop mate.
-                if currentPage == 2 {
-                    // Phone is ~844pt tall; the desktop canopy covers
-                    // 55% of viewport which on a 900px Electron window is
-                    // ~495pt. On phone, 40% of GeometryReader height
-                    // (~338pt of an 844pt frame) lands the gradient's
-                    // feather end at the same visual point relative to
-                    // the briefing-prose paragraph. The two clients use
-                    // the same gradient stops (0.55 → 0.26 → 0) so the
-                    // perceived darkening at any given pixel is matched
-                    // — only the height scales with surface.
-                    GeometryReader { geo in
-                        LinearGradient(
-                            stops: [
-                                .init(color: Color.black.opacity(0.55), location: 0.0),
-                                .init(color: Color.black.opacity(0.26), location: 0.5),
-                                .init(color: Color.black.opacity(0.0), location: 1.0),
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                        .frame(height: geo.size.height * 0.40)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    }
-                    .opacity(photoOpacity)
-                    .ignoresSafeArea(edges: .top)
-                    .allowsHitTesting(false)
-                }
+                BriefingCanopyOverlay(currentPage: currentPage)
 
                 // Shake detection is handled by `ShakeMonitor.shared` (polls
                 // CoreMotion at the app level) and presented by
@@ -330,12 +265,14 @@ struct MainContainer: View {
                 // currentPage at midpoint, which made the photo
                 // snap-fade at the swipe midpoint instead of
                 // crossfading with the drag. Pages still respect the
-                // safe area for their own content layout.
+                // safe area for their own content layout. Drag
+                // progress is published to `PagerProgressState.shared`
+                // (not a binding here) so leaf views like
+                // `GlobalPhotoLayer` can subscribe without forcing
+                // MainContainer to re-render on every scroll frame.
                 PagedSwipeView(
                     pageCount: 4,
-                    selection: $currentPage,
-                    dragProgress: $pagerDragProgress,
-                    signedDragProgress: $pagerSignedDragProgress
+                    selection: $currentPage
                 ) { idx in
                     switch idx {
                     case 0: AnyView(ListsPage())
@@ -448,44 +385,33 @@ struct MainContainer: View {
                 .opacity(awakening.contentOpacity)
             }
             .overlay(alignment: .bottom) {
-                VStack(spacing: 0) {
-                    ViewPillsBar(
-                        currentPage: $currentPage,
-                        onMenuTap: { selection.currentDestination = .menu },
-                        visibility: pillsVisibility
-                    )
-
-                    // Omnibar fades out on Calendar but its layout
-                    // slot stays reserved — otherwise removing it
-                    // would shrink the bottom VStack and snap the
-                    // view-pills row down to fill the space, which
-                    // reads as a jarring pop. Opacity + hit-testing
-                    // gating gives a calm fade in/out instead.
-                    OmnibarView(
-                        placeholder: omnibarPlaceholder,
-                        currentPage: currentPage,
-                        backgroundOpacity: omnibarBackgroundOpacity,
-                        onSelectList: { id in
-                            // Drawer is gone (Lists has its own tab now), but
-                            // the callback is still wired so any future entry
-                            // point that re-introduces a list picker works.
-                            // Defer the push by ~350ms so the sheet dismissal
-                            // animation completes before the navigation
-                            // transition starts. Structured-Task form (vs.
-                            // DispatchQueue.main.asyncAfter) suspends with the
-                            // process and uses idiomatic concurrency; SwiftUI
-                            // doesn't auto-cancel inline Tasks on unmount but
-                            // mutating a detached @State is a no-op.
-                            Task { @MainActor in
-                                try? await Task.sleep(nanoseconds: 350_000_000)
-                                path.append(NavDestination.listView(id: id))
-                            }
+                // Wrapped in `AdaptiveBottomChrome` so the pills-row
+                // visibility + omnibar background opacity, both of
+                // which read `HeroScrollState.shared.offset` at scroll
+                // rate, do their reads inside a small leaf instead of
+                // at MainContainer scope. MainContainer stops
+                // re-rendering on every Today-scroll frame.
+                AdaptiveBottomChrome(
+                    currentPage: $currentPage,
+                    placeholder: omnibarPlaceholder,
+                    onMenuTap: { selection.currentDestination = .menu },
+                    onSelectList: { id in
+                        // Drawer is gone (Lists has its own tab now), but
+                        // the callback is still wired so any future entry
+                        // point that re-introduces a list picker works.
+                        // Defer the push by ~350ms so the sheet dismissal
+                        // animation completes before the navigation
+                        // transition starts. Structured-Task form (vs.
+                        // DispatchQueue.main.asyncAfter) suspends with the
+                        // process and uses idiomatic concurrency; SwiftUI
+                        // doesn't auto-cancel inline Tasks on unmount but
+                        // mutating a detached @State is a no-op.
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 350_000_000)
+                            path.append(NavDestination.listView(id: id))
                         }
-                    )
-                    .opacity(currentPage == 3 ? 0 : 1)
-                    .allowsHitTesting(currentPage != 3)
-                    .animation(.easeOut(duration: 0.20), value: currentPage)
-                }
+                    }
+                )
                 .opacity(awakening.contentOpacity)
             }
             .navigationDestination(for: NavDestination.self) { destination in
@@ -712,6 +638,188 @@ struct MainContainer: View {
                 // metadata surfaces it, otherwise fall back to the roster.
                 path.append(NavDestination.scoutsRoster)
             }
+        }
+    }
+}
+
+// MARK: - Adaptive-chrome leaf views
+//
+// Each of these subscribes to one or both of `HeroScrollState.shared`
+// and `PagerProgressState.shared` — the two high-frequency publishers
+// that drive the calm-hero crossfades. Keeping the subscription
+// scoped to small leaf views (instead of MainContainer-level
+// computed properties) means SwiftUI's Observation framework only
+// invalidates these leaves on every scroll/swipe frame, not the
+// entire MainContainer ZStack.
+//
+// This is load-bearing for swipe correctness: when MainContainer
+// re-rendered on every scroll callback, the main thread ran out of
+// budget for the next `scrollViewDidScroll` delivery, callbacks
+// arrived with frame-gap-sized offset deltas, and the
+// `PagedSwipeResetDetector` heuristic false-positive-tripped on
+// normal settles — visible as page swipes that snapped back without
+// committing.
+
+/// Renders the global background photo with adaptive opacity that
+/// crossfades to the wash as the user swipes away from Today and as
+/// they scroll the Today hero downward.
+///
+/// The "effective page" is `currentPage + signedDragProgress`; how
+/// close that is to Today's index (2) is the photo's visibility.
+/// Multiplied by the Today scroll factor so scrolling past the hero
+/// also fades the photo out.
+private struct GlobalPhotoLayer: View {
+    let currentPage: Int
+
+    @State private var pager = PagerProgressState.shared
+    @State private var heroScroll = HeroScrollState.shared
+
+    var body: some View {
+        let opacity = AdaptiveChromeOpacity.compute(
+            currentPage: currentPage,
+            signedDragProgress: pager.signedDragProgress,
+            heroScrollOffset: heroScroll.offset,
+            heroFadeDistance: MainContainer.heroFadeDistance
+        )
+
+        BackgroundView()
+            .opacity(opacity)
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+    }
+}
+
+/// Top-edge briefing canopy gradient. Renders only on Today, riding
+/// the same photo opacity so non-Today pages don't get an unmotivated
+/// top darkening. Reads `PagerProgressState.shared` so it crossfades
+/// during page swipes; reads `HeroScrollState.shared` so it also
+/// fades as the user scrolls Today's hero away.
+///
+/// Phone is ~844pt tall; the desktop canopy covers 55% of viewport
+/// which on a 900px Electron window is ~495pt. On phone, 40% of
+/// GeometryReader height (~338pt of an 844pt frame) lands the
+/// gradient's feather end at the same visual point relative to the
+/// briefing-prose paragraph. The two clients use the same gradient
+/// stops (0.55 → 0.26 → 0) so the perceived darkening at any given
+/// pixel is matched — only the height scales with surface.
+private struct BriefingCanopyOverlay: View {
+    let currentPage: Int
+
+    @State private var pager = PagerProgressState.shared
+    @State private var heroScroll = HeroScrollState.shared
+
+    var body: some View {
+        // Same opacity curve as GlobalPhotoLayer (by construction —
+        // both route through `AdaptiveChromeOpacity.compute`) so the
+        // canopy fades in lockstep with the photo during page swipes.
+        // If the canopy and photo diverged the user would see an
+        // unmotivated dim strip during the crossfade.
+        let opacity = AdaptiveChromeOpacity.compute(
+            currentPage: currentPage,
+            signedDragProgress: pager.signedDragProgress,
+            heroScrollOffset: heroScroll.offset,
+            heroFadeDistance: MainContainer.heroFadeDistance
+        )
+
+        // The `> 0` gate keeps the GeometryReader out of the view
+        // tree entirely on non-Today pages and well-past-hero scroll
+        // positions, so its measurement pass doesn't run when its
+        // output is invisible anyway. Note: this also lets the
+        // canopy crossfade IN during a swipe TOWARD Today (the
+        // pre-refactor code mounted it only on `currentPage == 2`,
+        // which produced a pop-in at commit instead of a fade-in
+        // with the photo). Both leaves now use the same effective-
+        // page math, so they enter and exit together.
+        if opacity > 0 {
+            GeometryReader { geo in
+                LinearGradient(
+                    stops: [
+                        .init(color: Color.black.opacity(0.55), location: 0.0),
+                        .init(color: Color.black.opacity(0.26), location: 0.5),
+                        .init(color: Color.black.opacity(0.0), location: 1.0),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: geo.size.height * 0.40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+            .opacity(opacity)
+            .ignoresSafeArea(edges: .top)
+            .allowsHitTesting(false)
+        }
+    }
+}
+
+/// Bottom-chrome wrapper holding the view-pills row and the omnibar.
+/// Owns the high-frequency subscription to `HeroScrollState.shared`
+/// (vertical Today scroll drives both children's adaptive opacity).
+/// Splitting this out of MainContainer's overlay keeps the
+/// `HeroScrollState` reads inside a small subtree that contains only
+/// the chrome — the rest of MainContainer (NavigationStack content,
+/// sheet presenter, background ZStack) doesn't re-render on Today
+/// scroll.
+private struct AdaptiveBottomChrome: View {
+    @Binding var currentPage: Int
+    let placeholder: String
+    let onMenuTap: () -> Void
+    let onSelectList: (String) -> Void
+
+    @State private var heroScroll = HeroScrollState.shared
+
+    /// Visibility (0–1) for the bottom view-pills row.
+    /// - On Today, ramps from 0 at the top of the hero to 1 at
+    ///   `heroFadeDistance` of scroll — pills only earn their place
+    ///   once the user is in the working zone.
+    /// - On every other page, hidden (0). Calm-hero direction is
+    ///   swipe-only navigation between pages; the pills aren't a
+    ///   primary affordance, just a "here's where you are when you
+    ///   land back on Today" signal.
+    private var pillsVisibility: Double {
+        guard currentPage == 2 else { return 0 }
+        let progress = Double(heroScroll.offset / MainContainer.heroFadeDistance)
+        return min(max(progress, 0), 1)
+    }
+
+    /// Background opacity for the omnibar. Calm-hero spec: 0.55 at
+    /// the top of Today (thinner glass so the photo breathes), 1.0
+    /// past the hero (substantive glass against busy lists). Same
+    /// adaptive curve as `pillsVisibility` — both anchor on the
+    /// 140pt hero fade distance so all calm-hero affordances
+    /// transition together. Always 1.0 on non-Today pages.
+    private var omnibarBackgroundOpacity: Double {
+        guard currentPage == 2 else { return 1 }
+        let progress = Double(heroScroll.offset / MainContainer.heroFadeDistance)
+        let clamped = min(max(progress, 0), 1)
+        // Lerp from 0.55 (hero) to 1.0 (work). Never goes below 0.55
+        // even at scroll=0 because the omnibar input is interactive
+        // and needs *some* glass plate for the field to read against.
+        return 0.55 + (1.0 - 0.55) * clamped
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ViewPillsBar(
+                currentPage: $currentPage,
+                onMenuTap: onMenuTap,
+                visibility: pillsVisibility
+            )
+
+            // Omnibar fades out on Calendar but its layout
+            // slot stays reserved — otherwise removing it
+            // would shrink the bottom VStack and snap the
+            // view-pills row down to fill the space, which
+            // reads as a jarring pop. Opacity + hit-testing
+            // gating gives a calm fade in/out instead.
+            OmnibarView(
+                placeholder: placeholder,
+                currentPage: currentPage,
+                backgroundOpacity: omnibarBackgroundOpacity,
+                onSelectList: onSelectList
+            )
+            .opacity(currentPage == 3 ? 0 : 1)
+            .allowsHitTesting(currentPage != 3)
+            .animation(.easeOut(duration: 0.20), value: currentPage)
         }
     }
 }

--- a/apps/ios/Brett/Views/Shared/PagedSwipeView.swift
+++ b/apps/ios/Brett/Views/Shared/PagedSwipeView.swift
@@ -4,11 +4,11 @@ import UIKit
 /// Horizontal pager built on `UIPageViewController` so we can read
 /// real-time swipe progress (something SwiftUI's `TabView(.page)`
 /// doesn't expose). Drives the calm-hero photo crossfade: as the user
-/// drags Today off-screen toward Inbox, `signedDragProgress` ramps
-/// from 0 toward ±1, and the photo's opacity fades in lockstep — no
-/// snap at midpoint, no snap at commit, no top/bottom safe-area lag.
+/// drags Today off-screen toward Inbox, `PagerProgressState.shared.signedDragProgress`
+/// ramps from 0 toward ±1, and the photo's opacity fades in lockstep —
+/// no snap at midpoint, no snap at commit, no top/bottom safe-area lag.
 ///
-/// Three bindings:
+/// One binding:
 /// - `selection` — current page index (0…pageCount-1). Settles after
 ///   the swipe completes; updating it programmatically also flips the
 ///   page (for tap-to-switch on the view-pills row). The coordinator
@@ -17,12 +17,21 @@ import UIKit
 ///   see the post-commit values one frame earlier — without that
 ///   bump, opacity snaps from its release-moment value to the
 ///   committed value when `didFinishAnimating` fires.
-/// - `dragProgress` — magnitude 0…1 of how far the user has dragged
-///   from the current page toward an adjacent one. Always non-negative.
-/// - `signedDragProgress` — same magnitude, signed -1…+1. Positive
-///   when the user drags toward a HIGHER index (next page); negative
-///   toward a LOWER index. Lets callers compute "where is the user
-///   effectively pointing" for crossfades that need direction.
+///
+/// Drag progress is published to `PagerProgressState.shared` rather
+/// than `@Binding<CGFloat>` properties on the parent. The reason is
+/// a re-render budget one — `@Binding` writes invalidate the binding's
+/// source `@State`, which forces the owning `MainContainer` body to
+/// re-evaluate on every scroll callback (60-120 Hz). MainContainer's
+/// body is heavy enough (ZStack + computed properties + briefing
+/// canopy + chrome inset) that the re-render storm starved the main
+/// thread, dropped frames, and false-positive-tripped the
+/// `PagedSwipeResetDetector` threshold below — visible to the user
+/// as page swipes that "snap back" without committing. Routing the
+/// values through an `@Observable` singleton lets SwiftUI's
+/// Observation framework subtree-isolate the re-renders to the leaf
+/// views that actually read drag state (GlobalPhotoLayer,
+/// BriefingCanopyOverlay, the adaptive chrome wrappers).
 ///
 /// Implementation is deliberately small. `UIPageViewController` exposes
 /// its inner scroll view via `view.subviews` (the only `UIScrollView`
@@ -32,14 +41,6 @@ import UIKit
 struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
     let pageCount: Int
     @Binding var selection: Int
-    /// Magnitude 0…1.
-    @Binding var dragProgress: CGFloat
-    /// Signed -1…+1. Positive when the user drags toward a HIGHER
-    /// index (next page); negative toward a LOWER index. Lets
-    /// callers compute "where is the user effectively pointing"
-    /// for crossfades that need direction (e.g. fading the global
-    /// photo only while moving away from Today).
-    @Binding var signedDragProgress: CGFloat
     @ViewBuilder let pageBuilder: (Int) -> Page
 
     func makeUIViewController(context: Context) -> UIPageViewController {
@@ -193,12 +194,7 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
                         self.parent.selection = current.index
                     }
                 }
-                if self.parent.dragProgress != 0 {
-                    self.parent.dragProgress = 0
-                }
-                if self.parent.signedDragProgress != 0 {
-                    self.parent.signedDragProgress = 0
-                }
+                PagerProgressState.shared.reset()
             }
         }
 
@@ -274,12 +270,7 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
                     // would publish anyway, just made explicit so the
                     // consumer sees the atomic post-commit state in
                     // this tick rather than next.
-                    if self.parent.dragProgress != 0 {
-                        self.parent.dragProgress = 0
-                    }
-                    if self.parent.signedDragProgress != 0 {
-                        self.parent.signedDragProgress = 0
-                    }
+                    PagerProgressState.shared.reset()
                     prevOffsetX = currentOffset
                     return
                 }
@@ -293,12 +284,7 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
             let delta = currentOffset - pageWidth
             let signed = max(-1, min(1, delta / pageWidth))
             let magnitude = min(1, abs(delta) / pageWidth)
-            if abs(self.parent.dragProgress - magnitude) > 0.001 {
-                self.parent.dragProgress = magnitude
-            }
-            if abs(self.parent.signedDragProgress - signed) > 0.001 {
-                self.parent.signedDragProgress = signed
-            }
+            PagerProgressState.shared.publish(magnitude: magnitude, signed: signed)
         }
 
         func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
@@ -308,12 +294,7 @@ struct PagedSwipeView<Page: View>: UIViewControllerRepresentable {
             // the sources of truth for that.
             prevOffsetX = nil
             DispatchQueue.main.async {
-                if self.parent.dragProgress != 0 {
-                    self.parent.dragProgress = 0
-                }
-                if self.parent.signedDragProgress != 0 {
-                    self.parent.signedDragProgress = 0
-                }
+                PagerProgressState.shared.reset()
             }
         }
     }

--- a/apps/ios/Brett/Views/Shared/PagerProgressState.swift
+++ b/apps/ios/Brett/Views/Shared/PagerProgressState.swift
@@ -1,0 +1,137 @@
+import Observation
+import SwiftUI
+
+/// Shared live pager-drag progress published by `PagedSwipeView` so the
+/// calm-hero crossfades (global photo, briefing canopy, omnibar
+/// background opacity, view-pills visibility) can read drag-state
+/// without forcing the top-level `MainContainer` body to re-render on
+/// every scroll-view callback.
+///
+/// ### Why a shared @Observable instead of @Binding into MainContainer
+///
+/// `PagedSwipeView`'s inner UIScrollView fires `scrollViewDidScroll`
+/// every frame during a drag *and* during the post-release settle
+/// (60-120 Hz on ProMotion). Earlier, the coordinator wrote these
+/// values to two `@Binding<CGFloat>` properties bound to MainContainer
+/// `@State`. Each write invalidated MainContainer's body — which
+/// reads the values via `photoOpacity` / `pillsVisibility` /
+/// `omnibarBackgroundOpacity` computed properties — so MainContainer
+/// re-evaluated its entire ZStack on every scroll frame.
+///
+/// SwiftUI's Observation framework registers reads on
+/// `@Observable` instances during a view's body evaluation and
+/// invalidates *only* the views that performed those reads. By
+/// moving drag progress onto a singleton @Observable and routing
+/// the reads through small leaf views (GlobalPhotoLayer,
+/// BriefingCanopyOverlay, the adaptive omnibar / pills wrappers in
+/// `MainContainer.swift`), MainContainer's body no longer
+/// subscribes to per-frame drag updates. Only the leaves re-render.
+///
+/// This is the same shape as `HeroScrollState` — both are
+/// high-frequency publishers that the chrome reads from many places,
+/// and both benefit from the subtree-isolated re-render behaviour the
+/// Observation framework provides.
+///
+/// ### Lifecycle
+///
+/// Singleton, main-actor isolated. Mutations happen exclusively from
+/// `PagedSwipeView.Coordinator` callbacks (which run on the main
+/// actor by way of the UIScrollViewDelegate contract). Reads happen
+/// from any SwiftUI view that needs adaptive chrome.
+///
+/// Both properties are reset to 0 at the end of a swipe gesture —
+/// once UIPageViewController's `didFinishAnimating` or
+/// `scrollViewDidEndDecelerating` fires. The reset is what causes the
+/// post-commit crossfades to settle on their final values.
+@MainActor
+@Observable
+final class PagerProgressState {
+    static let shared = PagerProgressState()
+
+    /// Magnitude 0…1 of how far the user has dragged from the
+    /// current page toward an adjacent one. Always non-negative.
+    /// Resets to 0 between swipes.
+    private(set) var dragProgress: CGFloat = 0
+
+    /// Signed -1…+1. Positive when the user drags toward a HIGHER
+    /// index (next page); negative toward a LOWER index. Lets
+    /// callers compute "where is the user effectively pointing" for
+    /// crossfades that need direction (e.g. fading the global photo
+    /// only while moving away from Today). Resets to 0 between
+    /// swipes.
+    private(set) var signedDragProgress: CGFloat = 0
+
+    private init() {}
+
+    /// Publish a new drag progress pair. Mirrors the prior
+    /// `if abs(x - new) > 0.001 { x = new }` guards from
+    /// PagedSwipeView so consumers don't re-render on numerically
+    /// negligible deltas — the threshold is well below visual
+    /// perceptibility, and skipping no-op writes keeps the
+    /// Observation framework from invalidating subscribers
+    /// unnecessarily.
+    func publish(magnitude: CGFloat, signed: CGFloat) {
+        if abs(dragProgress - magnitude) > 0.001 {
+            dragProgress = magnitude
+        }
+        if abs(signedDragProgress - signed) > 0.001 {
+            signedDragProgress = signed
+        }
+    }
+
+    /// Reset both values to 0. Called when a swipe ends (commit or
+    /// cancel) so the crossfades settle on their post-gesture
+    /// values. Idempotent.
+    func reset() {
+        if dragProgress != 0 { dragProgress = 0 }
+        if signedDragProgress != 0 { signedDragProgress = 0 }
+    }
+}
+
+// MARK: - Adaptive-chrome opacity
+
+/// Pure function: given the current page index, live signed drag
+/// progress, and live hero scroll offset, return the photo / canopy
+/// opacity for the calm-hero crossfades.
+///
+/// Extracted so `GlobalPhotoLayer` and `BriefingCanopyOverlay` share
+/// the EXACT same opacity curve — any divergence would produce a
+/// visible mismatch where the photo and canopy fade out of sync. By
+/// routing both through one function, "match the photo's fade" is
+/// enforced by construction.
+///
+/// The "effective page" is `currentPage + signedDragProgress` —
+/// i.e., where the user is effectively pointing during a swipe, not
+/// just where the last commit landed them. How close that is to
+/// Today's index (2) is the photo's visibility. Multiplied by the
+/// Today vertical-scroll factor so scrolling past the hero also
+/// fades the photo out.
+///
+/// Pure, not isolated to `@MainActor`, so unit tests can call it
+/// directly with synthetic inputs.
+enum AdaptiveChromeOpacity {
+    /// The Today page's index in the pager. Defined here (and read
+    /// here only) so the math is self-contained — `MainContainer`
+    /// already documents the ordering at `currentPage`.
+    static let todayIndex: Double = 2
+
+    /// Distance (in points) over which the photo fades out as the
+    /// user scrolls Today's hero downward. Matches the value in
+    /// `MainContainer.heroFadeDistance`; kept as a parameter rather
+    /// than a constant so callers can supply the same source of
+    /// truth.
+    static func compute(
+        currentPage: Int,
+        signedDragProgress: CGFloat,
+        heroScrollOffset: CGFloat,
+        heroFadeDistance: CGFloat
+    ) -> Double {
+        let effectivePage = Double(currentPage) + Double(signedDragProgress)
+        let distanceFromToday = abs(effectivePage - Self.todayIndex)
+        let proximityToToday = max(0, 1 - distanceFromToday)
+        let scrollFactor: Double = currentPage == Int(Self.todayIndex)
+            ? 1 - min(max(Double(heroScrollOffset / heroFadeDistance), 0), 1)
+            : 1.0
+        return proximityToToday * scrollFactor
+    }
+}

--- a/apps/ios/BrettTests/Views/BackgroundServiceRendererTests.swift
+++ b/apps/ios/BrettTests/Views/BackgroundServiceRendererTests.swift
@@ -219,4 +219,71 @@ struct BackgroundServiceRendererTests {
         // displayedKey of `solid:#0040DD` (not `solid:0040DD`).
         #expect(svc.displayedKey == "solid:#0040DD")
     }
+
+    // MARK: - storageBaseUrl persistence
+    //
+    // The bug class these tests guard against: on cold launch with
+    // `/config` unreachable, the in-memory `storageBaseUrl` is nil,
+    // `currentImageURL(...)` returns nil for every URL request, and
+    // BackgroundView renders only the wash bed — so the user sees a
+    // dark solid wash where their wallpaper photo should be, even
+    // though the manifest cache + AsyncImage URLCache could otherwise
+    // have served the same image they saw last session.
+    //
+    // Persisting the env-level base URL across launches closes that
+    // gap. Per-user data (`currentRemoteURL`, pinned photo selection)
+    // is deliberately NOT persisted — that was the cross-user leak the
+    // 2026-05-17 rewrite removed and it must stay removed. The tests
+    // below pin that distinction explicitly.
+
+    /// Each test uses its own UserDefaults suite so the round-trip
+    /// doesn't touch `.standard` (which would persist across test
+    /// runs and bleed state between tests).
+    private func isolatedDefaults(_ suiteName: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func persistedStorageBaseUrlReturnsNilWhenUnset() {
+        let defaults = isolatedDefaults("BackgroundServiceTests.unset")
+        #expect(BackgroundService.persistedStorageBaseUrl(defaults: defaults) == nil)
+    }
+
+    @Test func storageBaseUrlPersistRoundTrip() {
+        let defaults = isolatedDefaults("BackgroundServiceTests.roundtrip")
+        let original = URL(string: "https://storage.example.com/public")!
+
+        BackgroundService.persistStorageBaseUrl(original, defaults: defaults)
+        let restored = BackgroundService.persistedStorageBaseUrl(defaults: defaults)
+
+        #expect(restored == original)
+    }
+
+    @Test func persistedStorageBaseUrlIgnoresEmptyString() {
+        // Defensive: a wider rewrite that ever stores an empty string
+        // (e.g. via a future migration) must not return an
+        // `URL(string: "")` to callers — `currentImageURL(...)` would
+        // then build malformed URLs. Empty string → nil keeps the
+        // wash-only fallback predictable.
+        let defaults = isolatedDefaults("BackgroundServiceTests.empty")
+        defaults.set("", forKey: BackgroundService.storageBaseUrlDefaultsKey)
+        #expect(BackgroundService.persistedStorageBaseUrl(defaults: defaults) == nil)
+    }
+
+    @Test func persistStorageBaseUrlOverwritesPriorValue() {
+        // The persisted base URL must follow the latest network value,
+        // not the first. Env shifts (dev ↔ prod, prod URL migration)
+        // need to win over a stale UserDefaults entry — otherwise a
+        // device that ran against the old base URL once would resolve
+        // images from the wrong host forever.
+        let defaults = isolatedDefaults("BackgroundServiceTests.overwrite")
+        let oldURL = URL(string: "https://old.example.com/public")!
+        let newURL = URL(string: "https://new.example.com/public")!
+
+        BackgroundService.persistStorageBaseUrl(oldURL, defaults: defaults)
+        BackgroundService.persistStorageBaseUrl(newURL, defaults: defaults)
+
+        #expect(BackgroundService.persistedStorageBaseUrl(defaults: defaults) == newURL)
+    }
 }

--- a/apps/ios/BrettTests/Views/PagerProgressStateTests.swift
+++ b/apps/ios/BrettTests/Views/PagerProgressStateTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Coverage for `PagerProgressState` (the @Observable singleton that
+/// replaces the old `@Binding<CGFloat>` pair on `PagedSwipeView`) and
+/// `AdaptiveChromeOpacity.compute` (the pure opacity curve that both
+/// `GlobalPhotoLayer` and `BriefingCanopyOverlay` route through).
+///
+/// The singleton itself is tiny — its job is to threshold no-op
+/// writes (so subscribers don't re-render on numerically negligible
+/// deltas) and to provide a reset that subscribers see atomically at
+/// gesture end. The opacity helper is the calm-hero curve, exercised
+/// here without a UIScrollView harness so the behaviour the user
+/// notices (smooth crossfade, no pop-in, no flash during cancelled
+/// swipes) is regression-guarded as a pure-function contract.
+@Suite("PagerProgressState + adaptive chrome")
+@MainActor
+struct PagerProgressStateTests {
+
+    // MARK: - Singleton thresholding
+
+    /// `publish` is the hot path — fires 60-120 times per second
+    /// during a swipe. A no-op write (value identical to the current
+    /// one) still notifies SwiftUI's Observation framework, so the
+    /// thresholding guard is what keeps the leaf views from
+    /// re-rendering on truly negligible per-frame deltas. Guard the
+    /// threshold so it can't be tightened without anyone noticing.
+    @Test func publishSkipsWritesUnderThreshold() {
+        let state = PagerProgressState.shared
+        state.reset()
+
+        // Establish a baseline.
+        state.publish(magnitude: 0.5, signed: 0.5)
+        #expect(state.dragProgress == 0.5)
+        #expect(state.signedDragProgress == 0.5)
+
+        // Sub-threshold delta (< 0.001) should NOT update. The
+        // dragProgress field stays exactly at the previous value.
+        state.publish(magnitude: 0.5005, signed: 0.5005)
+        #expect(state.dragProgress == 0.5)
+        #expect(state.signedDragProgress == 0.5)
+    }
+
+    /// Anything above the 0.001 threshold IS published. This is the
+    /// happy path — most per-frame deltas during a real swipe are
+    /// well above this floor.
+    @Test func publishApplyWritesAboveThreshold() {
+        let state = PagerProgressState.shared
+        state.reset()
+
+        state.publish(magnitude: 0.3, signed: 0.3)
+        #expect(state.dragProgress == 0.3)
+        #expect(state.signedDragProgress == 0.3)
+
+        // 0.0011 > 0.001 — write applies.
+        state.publish(magnitude: 0.3011, signed: 0.3011)
+        #expect(state.dragProgress == 0.3011)
+        #expect(state.signedDragProgress == 0.3011)
+    }
+
+    /// `reset` returns both fields to zero. Called from
+    /// `didFinishAnimating`, `scrollViewDidEndDecelerating`, and
+    /// the in-scroll page-commit bump — all the places where the
+    /// post-gesture crossfade needs to settle on a clean baseline.
+    @Test func resetClearsBothFields() {
+        let state = PagerProgressState.shared
+        state.publish(magnitude: 0.8, signed: -0.8)
+        #expect(state.dragProgress == 0.8)
+        #expect(state.signedDragProgress == -0.8)
+
+        state.reset()
+        #expect(state.dragProgress == 0)
+        #expect(state.signedDragProgress == 0)
+    }
+
+    /// `reset` from zero is a no-op (no spurious notification). The
+    /// guard inside `reset` ensures multiple consumers don't see a
+    /// 0 → 0 "change" that would invalidate them anyway.
+    @Test func resetFromZeroIsIdempotent() {
+        let state = PagerProgressState.shared
+        state.reset()
+        #expect(state.dragProgress == 0)
+        #expect(state.signedDragProgress == 0)
+
+        // Second reset — must be safe to call repeatedly. We can't
+        // directly observe "notification didn't fire" in a unit
+        // test, but exercising the path proves the guard branch is
+        // reached.
+        state.reset()
+        #expect(state.dragProgress == 0)
+        #expect(state.signedDragProgress == 0)
+    }
+
+    // MARK: - Adaptive-chrome opacity curve
+
+    /// On Today (index 2) with no scroll and no drag, the photo +
+    /// canopy are at full opacity — the calm-hero direction is "the
+    /// photo IS the wallpaper of Today."
+    @Test func opacityAtTodayRestStateIsOne() {
+        let opacity = AdaptiveChromeOpacity.compute(
+            currentPage: 2,
+            signedDragProgress: 0,
+            heroScrollOffset: 0,
+            heroFadeDistance: 140
+        )
+        #expect(opacity == 1.0)
+    }
+
+    /// On the inbox (index 1), settled (no drag), the photo is
+    /// invisible. `distanceFromToday = 1`, `proximityToToday = 0`.
+    /// This is the pre-refactor behaviour — pages that aren't Today
+    /// don't get the photo treatment.
+    @Test func opacityOnNonTodayPageAtRestIsZero() {
+        for page in [0, 1, 3] {
+            let opacity = AdaptiveChromeOpacity.compute(
+                currentPage: page,
+                signedDragProgress: 0,
+                heroScrollOffset: 0,
+                heroFadeDistance: 140
+            )
+            #expect(opacity == 0.0, "Page \(page) at rest should be 0")
+        }
+    }
+
+    /// Mid-swipe from Inbox (1) toward Today (2): `signedDragProgress`
+    /// is positive (moving to higher index). At drag = 0.5, the
+    /// effective page is 1.5, distance from Today is 0.5, proximity
+    /// is 0.5 — the photo crossfades IN smoothly. This is the behaviour
+    /// the user explicitly asked us to preserve.
+    @Test func opacityRampsInDuringSwipeTowardToday() {
+        let drag: [(progress: CGFloat, expected: Double)] = [
+            (0.0, 0.0),
+            (0.25, 0.25),
+            (0.5, 0.5),
+            (0.75, 0.75),
+            (1.0, 1.0),
+        ]
+        for (progress, expected) in drag {
+            let opacity = AdaptiveChromeOpacity.compute(
+                currentPage: 1,
+                signedDragProgress: progress,
+                heroScrollOffset: 0,
+                heroFadeDistance: 140
+            )
+            #expect(abs(opacity - expected) < 0.001, "drag \(progress): got \(opacity)")
+        }
+    }
+
+    /// Mid-swipe from Today (2) toward Inbox (1): drag is negative.
+    /// Photo fades OUT in lockstep — same curve, opposite direction.
+    /// Without this symmetry the swipe-away would look different
+    /// from the swipe-toward.
+    @Test func opacityRampsOutDuringSwipeAwayFromToday() {
+        let drag: [(progress: CGFloat, expected: Double)] = [
+            (0.0, 1.0),
+            (-0.25, 0.75),
+            (-0.5, 0.5),
+            (-0.75, 0.25),
+            (-1.0, 0.0),
+        ]
+        for (progress, expected) in drag {
+            let opacity = AdaptiveChromeOpacity.compute(
+                currentPage: 2,
+                signedDragProgress: progress,
+                heroScrollOffset: 0,
+                heroFadeDistance: 140
+            )
+            #expect(abs(opacity - expected) < 0.001, "drag \(progress): got \(opacity)")
+        }
+    }
+
+    /// Scrolling Today's hero downward fades the photo out — the
+    /// chrome transitions to the "work" mode. Hero offset > the
+    /// fade distance pegs the photo at 0.
+    @Test func verticalScrollOnTodayFadesPhotoOut() {
+        let cases: [(offset: CGFloat, expected: Double)] = [
+            (0,   1.0),
+            (35,  0.75),
+            (70,  0.5),
+            (105, 0.25),
+            (140, 0.0),
+            (200, 0.0),  // clamped — beyond fade distance stays at 0
+        ]
+        for (offset, expected) in cases {
+            let opacity = AdaptiveChromeOpacity.compute(
+                currentPage: 2,
+                signedDragProgress: 0,
+                heroScrollOffset: offset,
+                heroFadeDistance: 140
+            )
+            #expect(abs(opacity - expected) < 0.001, "offset \(offset): got \(opacity)")
+        }
+    }
+
+    /// On non-Today pages, vertical scroll on Today is IRRELEVANT —
+    /// the photo opacity is 0 regardless of `heroScrollOffset`. Guards
+    /// the `scrollFactor: Double = currentPage == todayIndex ? ... : 1.0`
+    /// branch so a future "let's use scrollFactor everywhere" refactor
+    /// can't sneak in and wash the photo to wash on every page.
+    @Test func nonTodayPageIgnoresHeroScroll() {
+        for page in [0, 1, 3] {
+            for offset: CGFloat in [0, 70, 200] {
+                let opacity = AdaptiveChromeOpacity.compute(
+                    currentPage: page,
+                    signedDragProgress: 0,
+                    heroScrollOffset: offset,
+                    heroFadeDistance: 140
+                )
+                #expect(opacity == 0.0, "Page \(page) offset \(offset)")
+            }
+        }
+    }
+
+    /// Effective page more than 1 unit away from Today produces 0
+    /// opacity — `1 - distanceFromToday` clamps via `max(0, ...)`.
+    /// Covers: settled-on-Lists (page 0), settled-on-Calendar
+    /// (page 3), and pathological overshoot from rubber-band
+    /// overscroll that lands an effective page past the end of
+    /// the page range.
+    @Test func opacityClampsAtZeroBeyondOneUnitFromToday() {
+        // Settled on Lists (page 0). Distance = 2. Clamped to 0.
+        let onLists = AdaptiveChromeOpacity.compute(
+            currentPage: 0,
+            signedDragProgress: 0,
+            heroScrollOffset: 0,
+            heroFadeDistance: 140
+        )
+        #expect(onLists == 0.0)
+
+        // Pathological overshoot — should still produce a sane,
+        // clamped value rather than a negative opacity.
+        let overshoot = AdaptiveChromeOpacity.compute(
+            currentPage: 0,
+            signedDragProgress: -2,
+            heroScrollOffset: 0,
+            heroFadeDistance: 140
+        )
+        // effectivePage = -2, distance from Today (2) = 4,
+        // 1 - 4 = -3, max(0, -3) = 0.
+        #expect(overshoot == 0.0)
+    }
+}


### PR DESCRIPTION
## Summary
- **fix(desktop):** keep Today list visible across day rollover, plus three multi-user/rollover follow-ups from PR review (#189, #190)
- **fix(ios):** persist storage base URL so wallpapers survive cold-launch when API is unreachable (#185, #186)
- **perf(ios):** eliminate MainContainer re-render storm on swipe + vertical scroll

## Test plan
- [ ] Watch the Railway deploy run to green via the release.yml workflow
- [ ] Confirm `/health` returns 200 once deploy finishes
- [ ] Cut desktop build locally (`scripts/release.sh desktop`) — verify autoupdater manifest updates
- [ ] Cut iOS build locally (`scripts/release.sh ios`) — verify TestFlight upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)