### PR TITLE
fix(calendar): restore Google webhook + incremental sync

### DIFF
--- a/apps/api/src/jobs/cron.ts
+++ b/apps/api/src/jobs/cron.ts
@@ -65,6 +65,12 @@ export function startCronJobs(): void {
         return;
       }
 
+      const webhookBaseUrl = process.env.GOOGLE_WEBHOOK_BASE_URL;
+      if (!webhookBaseUrl) {
+        console.warn("[cron] GOOGLE_WEBHOOK_BASE_URL not set, skipping webhook renewal");
+        return;
+      }
+
       for (const cal of expiring) {
         try {
           const client = await getCalendarClient(cal.googleAccountId);
@@ -84,7 +90,7 @@ export function startCronJobs(): void {
             .update(channelId)
             .digest("hex");
 
-          const channel = await watchCalendar(client, cal.googleCalendarId, channelId, token);
+          const channel = await watchCalendar(client, cal.googleCalendarId, channelId, token, webhookBaseUrl);
 
           await prisma.calendarList.update({
             where: { id: cal.id },

--- a/apps/api/src/lib/google-calendar.ts
+++ b/apps/api/src/lib/google-calendar.ts
@@ -200,11 +200,19 @@ export async function fetchEvents(
   let nextSyncToken: string | null | undefined;
 
   do {
+    // NOTE: do NOT set `orderBy` here. Google's events.list omits
+    // `nextSyncToken` from the response whenever `orderBy` is set (it's on
+    // the syncToken-incompatible param list, alongside `q`, `timeMin`,
+    // etc.). Without `nextSyncToken` we can never transition from full
+    // fetch to incremental sync, which means deletions never propagate
+    // (Google only returns cancelled events through syncToken-based
+    // incremental sync, never through time-windowed full fetch). The
+    // upsert path doesn't depend on event ordering — callers that need
+    // ordered events sort client-side.
     const params: calendar_v3.Params$Resource$Events$List = {
       calendarId,
       maxResults: options.maxResults ?? 250,
       singleEvents: true,
-      orderBy: "startTime",
       pageToken,
     };
 
@@ -266,20 +274,26 @@ export async function updateRsvp(
   return res.data;
 }
 
-/** Register webhook watch on a calendar */
+/** Register webhook watch on a calendar.
+ *  `webhookBaseUrl` is the public origin where Google should POST notifications
+ *  (e.g. `https://api.brett.brentbarkman.com` in prod, an ngrok URL in dev).
+ *  Caller is responsible for verifying it's set — see `GOOGLE_WEBHOOK_BASE_URL`
+ *  reads in calendar-sync.ts and jobs/cron.ts. */
 export async function watchCalendar(
   calendarClient: calendar_v3.Calendar,
   calendarId: string,
   channelId: string,
   token: string,
+  webhookBaseUrl: string,
 ): Promise<calendar_v3.Schema$Channel> {
   await googleThrottle();
+  const address = new URL("/webhooks/google-calendar", webhookBaseUrl).toString();
   const res = await calendarClient.events.watch({
     calendarId,
     requestBody: {
       id: channelId,
       type: "web_hook",
-      address: `${process.env.BETTER_AUTH_URL}/calendar/webhook`,
+      address,
       token,
     },
   });

--- a/apps/api/src/services/calendar-sync.ts
+++ b/apps/api/src/services/calendar-sync.ts
@@ -708,7 +708,7 @@ async function registerWebhook(
       .update(channelId)
       .digest("hex");
 
-    const channel = await watchCalendar(client, googleCalendarId, channelId, token);
+    const channel = await watchCalendar(client, googleCalendarId, channelId, token, webhookBaseUrl);
 
     await prisma.calendarList.update({
       where: { id: calendarListId },

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,6 +72,29 @@ fi
 release_desktop() {
   echo "=== Desktop release ==="
 
+  # Node version guard — Prisma 7's WebAssembly bindings need Node 18.18+,
+  # and `.nvmrc` pins Node 20. Background/non-interactive shells inherit the
+  # system Node (often 16) instead of nvm's. Auto-source nvm and switch.
+  local REQUIRED_NODE_MAJOR CURRENT_NODE_MAJOR
+  REQUIRED_NODE_MAJOR=$(cut -d. -f1 "$ROOT_DIR/.nvmrc" 2>/dev/null || echo 20)
+  CURRENT_NODE_MAJOR=$(node --version 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')
+  if [[ "$CURRENT_NODE_MAJOR" != "$REQUIRED_NODE_MAJOR" ]]; then
+    if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+      # nvm.sh references unset vars; relax nounset just for the source.
+      set +u
+      # shellcheck source=/dev/null
+      source "$HOME/.nvm/nvm.sh"
+      nvm use --silent >/dev/null 2>&1 || nvm use "$REQUIRED_NODE_MAJOR" --silent >/dev/null 2>&1 || true
+      set -u
+      CURRENT_NODE_MAJOR=$(node --version 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')
+    fi
+    if [[ "$CURRENT_NODE_MAJOR" != "$REQUIRED_NODE_MAJOR" ]]; then
+      echo "Error: Node $REQUIRED_NODE_MAJOR required (.nvmrc); found $(node --version 2>/dev/null || echo 'no node on PATH')." >&2
+      echo "Install nvm (https://github.com/nvm-sh/nvm) and run: nvm install $REQUIRED_NODE_MAJOR" >&2
+      exit 1
+    fi
+  fi
+
   # Auto-bump version using the same formula CI used: base major.minor from
   # package.json + commit count as patch. Mutates package.json in place but
   # we do NOT commit it — the version is ephemeral, pinned by the build.


### PR DESCRIPTION
## Summary

Two compounding bugs broke Google Calendar push notifications and deletion-detection since launch. The 4h reconciliation cron has been masking the symptom by full-fetching — but full fetches don't return cancelled events, so deletions inside the sync window stayed visible in Brett forever.

- **Webhook URL pointed at a 404.** `registerWebhook` gave Google `${BETTER_AUTH_URL}/calendar/webhook`, but the actual handler is mounted at `/webhooks/google-calendar`. Google's sync ping on `events.watch()` got a 404, the watch was rejected, the error was swallowed non-fatally, and `watchChannelId` stayed NULL across every CalendarList row (verified in prod: 9/9 NULL). Realigned with the original spec — `watchCalendar` now takes `webhookBaseUrl` as a parameter, callers pass `GOOGLE_WEBHOOK_BASE_URL` (which was already being read as a feature flag but never used as the URL base), and the URL is built with `new URL()` per the auth security checklist.
- **`orderBy: "startTime"` in `fetchEvents` is on Google's syncToken-incompatible param list.** Google omits `nextSyncToken` from the response whenever `orderBy` is set, so the initial fetch never returned a token to save — `syncToken` stayed NULL across every CalendarList row (verified in prod: 9/9 NULL after weeks of reconciliation runs). That kept us permanently in the full-fetch fallback, and full fetches don't surface cancellations. Dropped `orderBy`; the upsert path doesn't depend on event ordering.

Also includes a release-script ergonomics fix (`ae36071`) auto-switching to Node 20 via nvm.

## Test plan

- [x] `pnpm typecheck` passes (API)
- [x] No tests reference the changed `watchCalendar` signature (grep'd `__tests__`)
- [ ] After merge + Railway deploy: reconnect Google in Settings → Calendar on one account, verify `CalendarList.watchChannelId` and `CalendarList.syncToken` are populated
- [ ] Verify a fresh deletion in Google Calendar propagates to Brett within ~10s (webhook debounce window)
- [ ] Verify the stuck deleted invite from yesterday clears once incremental sync runs (event is <30d old, so it's still in Google's change feed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)