### PR TITLE
fix(ios): make NotesEditor tap target fill the full card (#193)

### DIFF
--- a/apps/ios/Brett/Views/Detail/NotesEditor.swift
+++ b/apps/ios/Brett/Views/Detail/NotesEditor.swift
@@ -67,13 +67,14 @@ struct NotesEditor: View {
                             scheduleSave(newValue)
                         }
                 } else {
+                    // Frame's minHeight matches the parent's so the tap target fills the card even when Text is empty/short.
                     Text(markdownRendered)
                         .font(BrettTypography.body)
                         .foregroundStyle(BrettColors.textBody)
                         .lineSpacing(4)
-                        .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.vertical, 8)
                         .padding(.horizontal, 4)
+                        .frame(maxWidth: .infinity, minHeight: 100, alignment: .topLeading)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             isFocused = true


### PR DESCRIPTION
Closes #193

## Root cause

Inside `NotesEditor` (`apps/ios/Brett/Views/Detail/NotesEditor.swift`), when the field is **not focused**, we render `Text(markdownRendered)` over the "Add notes…" placeholder. The unfocused branch carries the `.contentShape(Rectangle()) + .onTapGesture` that switches into edit mode.

When the notes string is empty (or short), that `Text` collapses to its intrinsic height. The padded `Text` ends up ~16pt tall even though the parent ZStack reserves a 100pt-tall card. `contentShape(Rectangle())` only covers the Text's own frame, so the bottom ~84pt of the visible card has no hit target — tapping in there does nothing, which is exactly what the bug report describes. The placeholder itself has `allowsHitTesting(false)`, so it doesn't help.

## Approach

Three options considered:

1. **Move the tap gesture to the outer ZStack and condition it on `!isFocused`.** Cleanest semantically, but it widens the tap surface to include the section header row and the parent layout, and risks interfering with `TextEditor`'s internal tap handling when focused.
2. **Wrap the unfocused branch in a `Color.clear`-backed shape that sizes to the parent's minHeight.** Works but adds a sibling view and an extra layer just to fix sizing.
3. **(picked)** Apply `frame(maxWidth: .infinity, minHeight: 100, alignment: .topLeading)` *after* padding on the unfocused `Text`, matching the parent ZStack's `minHeight: 100`. One-line change, surgical, preserves visual position (topLeading), keeps gesture scoped to the unfocused branch, and lets `Text` grow naturally above 100pt for long notes.

## Tests

UI-only layout/hit-testing change — no test added. Reason: this is a SwiftUI modifier ordering / frame-sizing issue. A meaningful test would need to render the view in a real simulator and synthesise a tap at a coordinate to assert focus state — well beyond the existing iOS test surface (which is XCTest models + a thin smoke test) and likely flaky for what is essentially a layout invariant. Verify visually via TestFlight: open any task with an empty notes field, tap anywhere inside the "Add notes…" card, and confirm the keyboard appears and the field becomes editable.

## Self-review

- Confirmed the parent `ZStack { … }.frame(minHeight: 100, alignment: .topLeading)` already reserves the card height, so matching `minHeight: 100` on the inner frame is intentional duplication for the hit area, not a layout change.
- Confirmed long-text behaviour: `minHeight` is a floor, so notes that render taller than 100pt still grow.
- Confirmed focused-state behaviour is unchanged — the `TextEditor` branch (which already has its own `frame(minHeight: 100)`) is unaffected.
- Confirmed the placeholder still sits at top-leading and the visible padded text position is unchanged.

## Commands

- `pnpm typecheck` fails on pre-existing TypeScript errors in `@brett/api-core/src/prisma.ts` that exist on `main` (verified by checking out `main` and re-running). This Swift-only change does not affect the TS workspace.
- `pnpm test` not run — requires Postgres + is irrelevant to an iOS view change.
- Xcode build not available in this CI environment.

## Risks / follow-ups

- Low risk. Change is constrained to one branch of one view and matches an already-existing minHeight on the parent ZStack.
- Visual verification pending — `gh pr checkout <n>` and run the iOS app, or wait for the next TestFlight build.

---
_Generated by [Claude Code](https://claude.ai/code/session_0124pTN2s1MfwG5YWRQCKjwu)_