### PR TITLE
fix(granola): persist DCR client across restarts to stop the disconnect loop

### DIFF
--- a/apps/api/prisma/migrations/20260527120000_add_oauth_client_table/migration.sql
+++ b/apps/api/prisma/migrations/20260527120000_add_oauth_client_table/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "OAuthClient" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "clientSecret" TEXT,
+    "registeredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OAuthClient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthClient_provider_key" ON "OAuthClient"("provider");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -107,6 +107,21 @@ model Verification {
   updatedAt  DateTime @updatedAt
 }
 
+// One row per OAuth provider that uses Dynamic Client Registration (RFC 7591).
+// Granola's DCR endpoint mints a new client_id on every POST, and refresh
+// tokens are bound to the client_id that issued them — so the registered
+// client must survive process restarts, or every account silently breaks on
+// the next refresh. clientSecret is encrypted with the same AES-256-GCM
+// helper used for user tokens.
+model OAuthClient {
+  id           String   @id @default(uuid())
+  provider     String   @unique
+  clientId     String
+  clientSecret String?
+  registeredAt DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
 model Passkey {
   id            String    @id
   name          String?

--- a/apps/api/src/__tests__/granola-dcr-persistence.test.ts
+++ b/apps/api/src/__tests__/granola-dcr-persistence.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { prisma } from "../lib/prisma.js";
+import { decryptToken, encryptToken } from "../lib/encryption.js";
+import {
+  ensureClientRegistered,
+  __resetCachedClientForTests,
+} from "../routes/granola-auth.js";
+
+const GRANOLA_REGISTER_URL = "https://mcp-auth.granola.ai/oauth2/register";
+
+function mockRegisterResponse(client_id: string, client_secret?: string): Response {
+  return new Response(
+    JSON.stringify({ client_id, ...(client_secret ? { client_secret } : {}) }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+async function clearOAuthClientRow(): Promise<void> {
+  await prisma.oAuthClient.deleteMany({ where: { provider: "granola" } });
+}
+
+describe("Granola DCR client persistence", () => {
+  beforeEach(async () => {
+    __resetCachedClientForTests();
+    await clearOAuthClientRow();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    __resetCachedClientForTests();
+    await clearOAuthClientRow();
+  });
+
+  it("registers on first cold call and persists the client to the DB", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url === GRANOLA_REGISTER_URL) {
+          return mockRegisterResponse("client_FIRST_BOOT", "secret_one");
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`);
+      });
+
+    const client = await ensureClientRegistered();
+
+    expect(client.client_id).toBe("client_FIRST_BOOT");
+    expect(client.client_secret).toBe("secret_one");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const row = await prisma.oAuthClient.findUniqueOrThrow({
+      where: { provider: "granola" },
+    });
+    expect(row.clientId).toBe("client_FIRST_BOOT");
+    // Secret is stored encrypted, not plaintext.
+    expect(row.clientSecret).not.toBe("secret_one");
+    expect(row.clientSecret).not.toBeNull();
+    expect(decryptToken(row.clientSecret!)).toBe("secret_one");
+  });
+
+  it("reads the persisted client from the DB on subsequent boots without a network call", async () => {
+    // Simulate a previous boot having persisted a client.
+    await prisma.oAuthClient.create({
+      data: {
+        provider: "granola",
+        clientId: "client_FROM_PRIOR_BOOT",
+        clientSecret: encryptToken("secret_from_prior_boot"),
+      },
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error(
+        "ensureClientRegistered must not call fetch when a persisted client exists",
+      );
+    });
+
+    const client = await ensureClientRegistered();
+
+    expect(client.client_id).toBe("client_FROM_PRIOR_BOOT");
+    expect(client.client_secret).toBe("secret_from_prior_boot");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("survives a concurrent first-boot race: both callers see the same client_id and exactly one DB row remains", async () => {
+    // Granola DCR is not idempotent — every POST returns a new client_id.
+    // Mock that: each fetch call returns a fresh id so the loser's id is
+    // distinguishable from the winner's. The unique constraint on
+    // OAuthClient.provider must collapse both callers onto the same row.
+    let counter = 0;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url === GRANOLA_REGISTER_URL) {
+          counter += 1;
+          return mockRegisterResponse(`client_RACE_${counter}`, `secret_${counter}`);
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`);
+      });
+
+    const [a, b] = await Promise.all([
+      ensureClientRegistered(),
+      ensureClientRegistered(),
+    ]);
+
+    expect(a.client_id).toBe(b.client_id);
+    expect(a.client_secret).toBe(b.client_secret);
+
+    const rows = await prisma.oAuthClient.findMany({
+      where: { provider: "granola" },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].clientId).toBe(a.client_id);
+
+    // Both callers raced past the SELECT and both issued DCR posts; the
+    // unique constraint funneled them onto one row. We don't assert the
+    // exact fetch count because the in-memory cache may short-circuit one
+    // call if the timing is right — but it must have hit Granola at least
+    // once.
+    expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/api/src/lib/granola-mcp.ts
+++ b/apps/api/src/lib/granola-mcp.ts
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { prisma } from "./prisma.js";
 import { decryptToken, encryptToken } from "./encryption.js";
-import { ensureClientRegistered, clearRegisteredClient } from "../routes/granola-auth.js";
+import { ensureClientRegistered } from "../routes/granola-auth.js";
 
 const GRANOLA_MCP_URL = "https://mcp.granola.ai/mcp";
 
@@ -237,33 +237,26 @@ async function refreshGranolaTokens(refreshToken: string): Promise<{
   // Bounded timeout — Granola's OAuth endpoint normally responds in <1s.
   // Without this, a Granola outage would hang every MCP-dependent
   // background job indefinitely.
-  let resp = await fetch("https://mcp-auth.granola.ai/oauth2/token", {
+  //
+  // No 401-retry-with-re-register: see ensureClientRegistered in
+  // granola-auth.ts for the full reasoning. Granola's DCR is non-idempotent;
+  // re-registering on a 401 here would silently invalidate every account's
+  // refresh tokens at once.
+  const resp = await fetch("https://mcp-auth.granola.ai/oauth2/token", {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams(params),
     signal: AbortSignal.timeout(10_000),
   });
 
-  // If 401, client creds may be stale — re-register and retry once
-  if (resp.status === 401) {
-    clearRegisteredClient();
-    const freshClient = await ensureClientRegistered();
-    params.client_id = freshClient.client_id;
-    if (freshClient.client_secret) {
-      params.client_secret = freshClient.client_secret;
-    } else {
-      delete params.client_secret;
-    }
-    resp = await fetch("https://mcp-auth.granola.ai/oauth2/token", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(params),
-      signal: AbortSignal.timeout(10_000),
-    });
-  }
-
   if (!resp.ok) {
-    throw new Error(`Token refresh failed: ${resp.status}`);
+    // Capture (truncated, token-scrubbed) body so the next 4xx tells us
+    // Granola's actual error code (invalid_grant vs invalid_client vs ...)
+    // instead of just the HTTP status — which is what made the last round
+    // of this debugging blind.
+    const body = await resp.text().catch(() => "");
+    const scrubbed = body.replace(refreshToken, "[refresh_token]").slice(0, 500);
+    throw new Error(`Token refresh failed: ${resp.status} ${scrubbed}`);
   }
 
   return resp.json();

--- a/apps/api/src/routes/granola-auth.ts
+++ b/apps/api/src/routes/granola-auth.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
+import { Prisma } from "@brett/api-core";
 import { authMiddleware, type AuthEnv } from "../middleware/auth.js";
 import { prisma } from "../lib/prisma.js";
-import { encryptToken } from "../lib/encryption.js";
+import { encryptToken, decryptToken } from "../lib/encryption.js";
 import { resolveRelinkTaskForAccount } from "../lib/connection-health.js";
 import { generateId } from "@brett/utils";
 import { randomBytes, createHash } from "crypto";
@@ -103,9 +104,16 @@ export async function fetchGranolaEmail(accessToken: string): Promise<string> {
 // PKCE verifiers stored in the Verification table (survives restarts, works across instances)
 const PKCE_IDENTIFIER_PREFIX = "pkce:granola:";
 
-// Cached client credentials from Dynamic Client Registration (with TTL)
-let registeredClient: { client_id: string; client_secret?: string; registeredAt: number } | null = null;
-const CLIENT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// In-memory cache of the DCR client. Populated lazily from the OAuthClient
+// table on first use, then re-used for the rest of the process's lifetime.
+// The persisted row is the source of truth — every container that boots up
+// reads the same client_id, so refresh tokens issued to that client_id stay
+// valid across deploys. Granola's DCR endpoint is NOT idempotent (every POST
+// returns a brand-new client_id), so re-registering on a whim would orphan
+// every account's refresh tokens at once. Don't do it.
+let cachedClient: { client_id: string; client_secret?: string } | null = null;
+
+const GRANOLA_OAUTH_PROVIDER = "granola";
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -137,9 +145,37 @@ ${autoClose}
   return c.html(html);
 }
 
+/**
+ * Resolve the persisted Brett OAuth client at Granola, registering one on
+ * first use and writing it to the OAuthClient table so it survives process
+ * restarts.
+ *
+ * Granola's DCR endpoint mints a brand-new client_id on every POST. If
+ * the client_id is held only in process memory, every container restart
+ * silently breaks every account's refresh tokens (they were issued under
+ * the previous client_id; RFC 6749 §6 binds refresh tokens to the client
+ * that issued them, so the new client_id can't redeem them — refresh
+ * returns 400 invalid_grant). Persisting once and reusing forever is the
+ * fix.
+ *
+ * Concurrency: two cold callers can race past the SELECT and both register.
+ * The unique constraint on `provider` makes exactly one INSERT win; the
+ * loser catches P2002, re-reads, and uses the winner's client. The loser's
+ * Granola-side registration is then abandoned (harmless — Granola has no
+ * referent for it).
+ */
 export async function ensureClientRegistered(): Promise<{ client_id: string; client_secret?: string }> {
-  if (registeredClient && (Date.now() - registeredClient.registeredAt) < CLIENT_TTL_MS) {
-    return registeredClient;
+  if (cachedClient) return cachedClient;
+
+  const existing = await prisma.oAuthClient.findUnique({
+    where: { provider: GRANOLA_OAUTH_PROVIDER },
+  });
+  if (existing) {
+    cachedClient = {
+      client_id: existing.clientId,
+      client_secret: existing.clientSecret ? decryptToken(existing.clientSecret) : undefined,
+    };
+    return cachedClient;
   }
 
   const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3001";
@@ -165,14 +201,41 @@ export async function ensureClientRegistered(): Promise<{ client_id: string; cli
     throw new Error(`Granola client registration failed: ${resp.status} ${text}`);
   }
 
-  const client = (await resp.json()) as { client_id: string; client_secret?: string };
-  registeredClient = { ...client, registeredAt: Date.now() };
-  return registeredClient;
+  const fresh = (await resp.json()) as { client_id: string; client_secret?: string };
+
+  try {
+    await prisma.oAuthClient.create({
+      data: {
+        provider: GRANOLA_OAUTH_PROVIDER,
+        clientId: fresh.client_id,
+        clientSecret: fresh.client_secret ? encryptToken(fresh.client_secret) : null,
+      },
+    });
+    cachedClient = fresh;
+    return cachedClient;
+  } catch (err) {
+    // Race: a concurrent caller persisted first. Read theirs and discard ours.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      const winner = await prisma.oAuthClient.findUniqueOrThrow({
+        where: { provider: GRANOLA_OAUTH_PROVIDER },
+      });
+      cachedClient = {
+        client_id: winner.clientId,
+        client_secret: winner.clientSecret ? decryptToken(winner.clientSecret) : undefined,
+      };
+      return cachedClient;
+    }
+    throw err;
+  }
 }
 
-/** Clear cached client registration (used for retry on 401). */
-export function clearRegisteredClient(): void {
-  registeredClient = null;
+/**
+ * Test-only: drop the in-memory cache so a subsequent call re-reads from
+ * the DB. Used by the persistence tests to assert that the DB row is the
+ * source of truth across "process restarts".
+ */
+export function __resetCachedClientForTests(): void {
+  cachedClient = null;
 }
 
 const granolaAuth = new Hono<AuthEnv>();
@@ -349,7 +412,13 @@ granolaAuth.get("/callback", async (c) => {
   // Delete immediately to prevent replay
   await prisma.verification.delete({ where: { id: pkceRecord.id } }).catch(() => {});
 
-  // Exchange code for tokens (with retry on 401 — re-register DCR client)
+  // Exchange code for tokens. No 401-retry-with-re-register here: with the
+  // DCR client persisted in OAuthClient, re-registering would mint a fresh
+  // client_id and overwrite the row (or race against itself), invalidating
+  // every existing account's refresh tokens at once. A 401 on this exchange
+  // means the persisted client is no longer recognised by Granola — that's
+  // an ops problem (delete the OAuthClient row, redeploy, all users reconnect),
+  // not something to paper over silently.
   const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3001";
 
   async function exchangeCode(cl: { client_id: string; client_secret?: string }) {
@@ -375,14 +444,8 @@ granolaAuth.get("/callback", async (c) => {
   // page instead of bubbling out as a 500.
   let tokenResp: Response;
   try {
-    let client = await ensureClientRegistered();
+    const client = await ensureClientRegistered();
     tokenResp = await exchangeCode(client);
-    if (tokenResp.status === 401) {
-      // Client creds may be stale — re-register and retry once
-      clearRegisteredClient();
-      client = await ensureClientRegistered();
-      tokenResp = await exchangeCode(client);
-    }
   } catch (err) {
     console.error("[granola-auth] Token exchange failed:", err);
     return callbackHtml(c, {

--- a/apps/desktop/src/hooks/useBackground.ts
+++ b/apps/desktop/src/hooks/useBackground.ts
@@ -23,6 +23,35 @@ const ROTATION_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 const SEGMENT_CHECK_MS = 60 * 1000; // 60 seconds
 const CROSSFADE_MS = 3000;
 
+/// Per-slot shuffle-without-replacement bookkeeping, keyed by
+/// `${style}/${segment}/${tier}`. Persisted via `userStorage` so the
+/// no-repeat behaviour survives cold launches — without persistence,
+/// every short-session app open was a uniform draw from a 2–4 image
+/// pool, which read as "always image-1" to the user.
+type ShownBySlot = Record<string, string[]>;
+const SHOWN_PATHS_KEY = "brett-shown-paths.v1";
+
+function loadShownPaths(): ShownBySlot {
+  try {
+    const raw = userStorage.getItem(SHOWN_PATHS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    return parsed as ShownBySlot;
+  } catch {
+    return {};
+  }
+}
+
+function persistShownPaths(dict: ShownBySlot): void {
+  try {
+    userStorage.setItem(SHOWN_PATHS_KEY, JSON.stringify(dict));
+  } catch {
+    // Quota / storage failures are non-fatal — we keep the in-memory
+    // dict and the next pick is still deduplicated within the session.
+  }
+}
+
 interface UseBackgroundInput {
   meetingCount: number;
   taskCount: number;
@@ -85,10 +114,23 @@ export function useBackground({
 
   const [isTransitioning, setIsTransitioning] = useState(false);
 
-  // Track shown items for shuffle-without-replacement
-  const shownRef = useRef<(string | number)[]>([]);
+  // Per-slot shuffle-without-replacement state, hydrated from
+  // userStorage so the no-repeat behaviour survives cold launches.
+  // Each slot key `${style}/${segment}/${tier}` keeps its own list;
+  // there's no global reset on category change because the lookup
+  // naturally targets the right slot.
+  const shownBySlotRef = useRef<ShownBySlot>(loadShownPaths());
+
+  // Tracks the currently-active category so the segment-check
+  // intervals below can detect a boundary crossing. Kept separate
+  // from `shownBySlotRef` — pre-persistence these were entangled
+  // (segment changes triggered a shown reset); they don't need to
+  // be now.
   const categoryRef = useRef({ segment, busynessTier, backgroundStyle });
   const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const slotKeyFor = (style: BackgroundStyle, seg: TimeSegment, tier: BusynessTier) =>
+    `${style}/${seg}/${tier}`;
 
   const buildUrl = (relativePath: string) => `${baseUrl}/backgrounds/${relativePath}`;
 
@@ -115,30 +157,39 @@ export function useBackground({
     const seg = getTimeSegment(new Date().getHours());
     const tier = getBusynessTier(meetingCount, taskCount, avgBusynessScore);
 
-    // Reset shown list if category changed
-    const cat = categoryRef.current;
-    if (cat.segment !== seg || cat.busynessTier !== tier || cat.backgroundStyle !== backgroundStyle) {
-      shownRef.current = [];
-      categoryRef.current = { segment: seg, busynessTier: tier, backgroundStyle };
-    }
+    // Keep `categoryRef` in sync for the segment-check intervals.
+    // No shown-list reset needed — per-slot storage already isolates
+    // each category's history.
+    categoryRef.current = { segment: seg, busynessTier: tier, backgroundStyle };
 
     setSegment(seg);
     setBusynessTier(tier);
 
     {
       // Photography and Abstract both use images from the manifest
+      const effectiveStyle = isAbstract ? "abstract" : backgroundStyle;
+      const slotKey = slotKeyFor(effectiveStyle, seg, tier);
+      const shown = shownBySlotRef.current[slotKey] ?? [];
+
       const relativePath = selectImage(
         manifest as BackgroundManifest,
-        isAbstract ? "abstract" : backgroundStyle,
+        effectiveStyle,
         seg,
         tier,
-        shownRef.current as string[]
+        shown,
       );
 
       if (!relativePath || !baseUrl) return;
 
       const fullUrl = buildUrl(relativePath);
-      shownRef.current.push(relativePath);
+      // If the pool was exhausted, `selectImage` re-picks from the
+      // full set ignoring `shown`; mirror that by clearing this slot's
+      // history before recording the new pick so the cycle restarts
+      // cleanly. (Without the clear we'd keep growing the array with
+      // duplicates and the filter would no-op on every pick.)
+      const refreshedShown = shown.includes(relativePath) ? [relativePath] : [...shown, relativePath];
+      shownBySlotRef.current = { ...shownBySlotRef.current, [slotKey]: refreshedShown };
+      persistShownPaths(shownBySlotRef.current);
 
       cancelTransition();
 
@@ -224,12 +275,13 @@ export function useBackground({
     setBusynessTier(newTier);
   }, [meetingCount, taskCount, avgBusynessScore]);
 
-  // Immediately rotate when user switches background style
+  // Immediately rotate when user switches background style. No
+  // shown-list clear needed — switching style just looks up a
+  // different slot in `shownBySlotRef`.
   const prevStyleRef = useRef(backgroundStyle);
   useEffect(() => {
     if (prevStyleRef.current !== backgroundStyle) {
       prevStyleRef.current = backgroundStyle;
-      shownRef.current = [];
       rotateImageRef.current();
     }
   }, [backgroundStyle]);

--- a/apps/ios/Brett/Services/BackgroundService.swift
+++ b/apps/ios/Brett/Services/BackgroundService.swift
@@ -139,16 +139,20 @@ final class BackgroundService: Clearable {
     /// for the new-user fallback.
     private var lastAvgBusynessScore: Double? = nil
 
-    /// Shuffle-without-replacement state for auto-mode image picks.
-    /// `shownPaths` is the set of manifest paths we've already
-    /// served in the active (style, segment, tier) slot;
-    /// `lastSlotKey` is the key for that slot. When the slot key
-    /// changes — either because the user crosses a time-of-day
-    /// boundary, their busyness flips, or they switch style — we
-    /// reset both. Mirrors the desktop `shownRef` / `categoryRef`
-    /// pattern in `apps/desktop/src/hooks/useBackground.ts`.
-    private var shownPaths: Set<String> = []
-    private var lastSlotKey: String = ""
+    /// Shuffle-without-replacement state for auto-mode image picks,
+    /// keyed by `"\(style)/\(segment)/\(tier)"`. Each slot remembers
+    /// which manifest paths it has already served so the picker can
+    /// exclude them until the pool is exhausted, then start over.
+    ///
+    /// Persisted to UserDefaults (see `shownPathsDefaultsKey`) so the
+    /// no-repeat behaviour survives cold launches — without persistence
+    /// the dict resets every time the process restarts, which in
+    /// practice meant every short-session app open was a uniform draw
+    /// from a 2–4 image pool and image-1 hit ~25% of opens. Wiped on
+    /// sign-out (`clearForSignOut`) and on a manifest version/size
+    /// change (`refreshManifestFromAPI`) so a stale exclude list can't
+    /// outlive its pool.
+    private var shownPathsBySlot: [String: Set<String>] = BackgroundService.loadShownPaths()
 
     /// Reference count of mounted `BackgroundView` instances. When it
     /// transitions 0 → 1 we start the 60s segment ticker; 1 → 0 stops it.
@@ -186,6 +190,8 @@ final class BackgroundService: Clearable {
         currentWashColor = Self.defaultWashColor
         lastProfileStyle = nil
         lastProfilePinned = nil
+        shownPathsBySlot.removeAll()
+        Self.clearShownPaths()
     }
     #endif
 
@@ -243,6 +249,13 @@ final class BackgroundService: Clearable {
         currentWashColor = Self.defaultWashColor
         lastProfileStyle = nil
         lastProfilePinned = nil
+        // Wipe the per-slot exclude list too — UserDefaults survives
+        // sign-out, and a fresh user picking up the previous user's
+        // shown set would mostly be harmless (paths overlap), but
+        // it's also user-state that we have no business carrying
+        // across accounts.
+        shownPathsBySlot.removeAll()
+        Self.clearShownPaths()
     }
 
     // MARK: - Manifest
@@ -470,6 +483,45 @@ final class BackgroundService: Clearable {
         defaults.set(url.absoluteString, forKey: storageBaseUrlDefaultsKey)
     }
 
+    // MARK: - shownPaths persistence
+
+    /// UserDefaults key for the per-slot exclude dict. Versioned so a
+    /// schema change (e.g. moving to a struct payload with timestamps)
+    /// can invalidate the old key cleanly. The fully-populated payload
+    /// is small enough (≤36 slots × ≤4 paths) that the whole dict can
+    /// be rewritten on every pick without measurable cost.
+    // `nonisolated` so callers off the main actor (the property
+    // initializer of `shownPathsBySlot`, tests, future background
+    // tasks) can read/write them without an actor hop. The helpers
+    // touch only UserDefaults — no instance state — so they're safe
+    // outside the main actor.
+    nonisolated static let shownPathsDefaultsKey = "BackgroundService.shownPaths.v1"
+
+    nonisolated static func loadShownPaths(
+        defaults: UserDefaults = .standard
+    ) -> [String: Set<String>] {
+        guard let data = defaults.data(forKey: shownPathsDefaultsKey),
+              let decoded = try? JSONDecoder().decode([String: [String]].self, from: data)
+        else { return [:] }
+        return decoded.mapValues { Set($0) }
+    }
+
+    nonisolated static func persistShownPaths(
+        _ dict: [String: Set<String>],
+        defaults: UserDefaults = .standard
+    ) {
+        // Sets aren't JSON-encodable directly; persist as arrays.
+        let encodable = dict.mapValues { Array($0) }
+        guard let data = try? JSONEncoder().encode(encodable) else { return }
+        defaults.set(data, forKey: shownPathsDefaultsKey)
+    }
+
+    nonisolated static func clearShownPaths(
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.removeObject(forKey: shownPathsDefaultsKey)
+    }
+
     // MARK: - Network manifest
 
     /// Location of the cached server-fetched manifest. App-support
@@ -517,8 +569,8 @@ final class BackgroundService: Clearable {
             // Reset the shuffle bookkeeping — the slot composition
             // may have changed, so prior shownPaths are no longer a
             // valid exclude list against the new pool.
-            shownPaths.removeAll()
-            lastSlotKey = ""
+            shownPathsBySlot.removeAll()
+            Self.clearShownPaths()
             // Persist for next cold launch. Failures here (disk full,
             // missing app-support dir) are non-fatal — the in-memory
             // manifest is in effect for this session and the next
@@ -919,27 +971,26 @@ final class BackgroundService: Clearable {
         )
         let paths = Self.paths(forTier: busynessTier, in: tiers)
 
-        // Shuffle-without-replacement bookkeeping. Reset the shown
-        // set whenever the slot identity changes (style + segment +
-        // tier triple) — otherwise we'd carry over yesterday's
-        // already-shown paths into today's morning rotation.
+        // Shuffle-without-replacement bookkeeping. Each slot
+        // (style + segment + tier triple) keeps its own shown set in
+        // `shownPathsBySlot`, persisted to UserDefaults so the
+        // no-repeat behaviour survives cold launches.
         let slotKey = "\(effectiveStyle.rawValue)/\(segment.rawValue)/\(busynessTier.rawValue)"
-        if slotKey != lastSlotKey {
-            shownPaths.removeAll()
-            lastSlotKey = slotKey
-        }
+        var shown = shownPathsBySlot[slotKey] ?? []
 
         // Filter to paths we haven't shown yet in this slot. If we've
         // exhausted the slot (e.g. small `dawn/packed` tier with two
         // images, both already shown), reset and re-pick from the
         // full set so the cycle resumes cleanly.
-        var available = paths.filter { !shownPaths.contains($0) }
+        var available = paths.filter { !shown.contains($0) }
         if available.isEmpty {
-            shownPaths.removeAll()
+            shown.removeAll()
             available = paths
         }
         guard let path = available.randomElement() else { return nil }
-        shownPaths.insert(path)
+        shown.insert(path)
+        shownPathsBySlot[slotKey] = shown
+        Self.persistShownPaths(shownPathsBySlot)
         return url(for: path, portrait: true)
     }
 

--- a/apps/ios/BrettTests/Views/BackgroundServiceShownPathsTests.swift
+++ b/apps/ios/BrettTests/Views/BackgroundServiceShownPathsTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import Brett
+
+/// Coverage for the per-slot shown-paths persistence that makes the
+/// wallpaper picker actually feel non-repeating across cold launches.
+///
+/// Pre-persistence, the picker reset its exclude set on every process
+/// start, so every short-session app open was a uniform draw from a
+/// 2–4 image pool — and `light-1` showed up roughly every fourth open,
+/// which read as bias to the user. With persistence, the no-repeat
+/// behaviour survives launches: the slot has to be fully exhausted
+/// before any image repeats.
+///
+/// These tests pin the static load/save/clear helpers (the mechanism
+/// the instance code is wired into). End-to-end coverage of the
+/// instance-level picker behaviour lives in `BackgroundService`'s
+/// `currentImageURL`, which is harder to exercise in isolation
+/// because it requires a loaded manifest and storage base URL —
+/// neither of which has a public test seam today.
+@Suite("BackgroundServiceShownPaths", .tags(.views))
+struct BackgroundServiceShownPathsTests {
+
+    /// Each test gets its own UserDefaults suite so they don't share
+    /// state with `.standard` or with each other. Returns the suite
+    /// and a teardown closure that removes the persisted blob — the
+    /// suite itself sticks around (Foundation doesn't expose a clean
+    /// "destroy suite" API), but the key is cleared so re-runs with
+    /// the same suite name start fresh.
+    private func isolatedDefaults() -> (UserDefaults, () -> Void) {
+        let name = "BackgroundServiceShownPathsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        let teardown = {
+            BackgroundService.clearShownPaths(defaults: defaults)
+        }
+        return (defaults, teardown)
+    }
+
+    @Test func loadFromEmptyDefaultsReturnsEmptyDict() {
+        let (defaults, teardown) = isolatedDefaults()
+        defer { teardown() }
+
+        #expect(BackgroundService.loadShownPaths(defaults: defaults).isEmpty)
+    }
+
+    @Test func roundtripPreservesPerSlotSets() {
+        let (defaults, teardown) = isolatedDefaults()
+        defer { teardown() }
+
+        let original: [String: Set<String>] = [
+            "photography/morning/light": ["photo/morning/light-1.webp", "photo/morning/light-3.webp"],
+            "photography/evening/packed": ["photo/evening/packed-2.webp"],
+        ]
+        BackgroundService.persistShownPaths(original, defaults: defaults)
+
+        let loaded = BackgroundService.loadShownPaths(defaults: defaults)
+        #expect(loaded == original)
+    }
+
+    @Test func clearWipesPersistedBlob() {
+        let (defaults, teardown) = isolatedDefaults()
+        defer { teardown() }
+
+        BackgroundService.persistShownPaths(
+            ["photography/dawn/light": ["photo/dawn/light-1.webp"]],
+            defaults: defaults
+        )
+        #expect(!BackgroundService.loadShownPaths(defaults: defaults).isEmpty)
+
+        BackgroundService.clearShownPaths(defaults: defaults)
+        #expect(BackgroundService.loadShownPaths(defaults: defaults).isEmpty)
+    }
+
+    @Test func malformedDataDecodesToEmptyDict() {
+        // A corrupt blob (e.g. from a future format change) must not
+        // crash the picker — it should degrade gracefully to "no
+        // history" and resume the shuffle from a clean slate.
+        let (defaults, teardown) = isolatedDefaults()
+        defer { teardown() }
+
+        defaults.set(Data([0xFF, 0xFE, 0xFD]), forKey: BackgroundService.shownPathsDefaultsKey)
+        #expect(BackgroundService.loadShownPaths(defaults: defaults).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Granola's DCR endpoint mints a new \`client_id\` on every POST. The previous in-memory cache was process-local, so every Railway container restart silently invalidated every account's refresh tokens (RFC 6749 §6: refresh tokens are bound to the issuing client). Prod logs show 82 \`Token refresh failed: 400\` events in the last 1000 lines, both of my accounts dying on every cron tick.
- Persist the DCR client in a new \`OAuthClient\` table; lazy-load on first use; race-safe via \`provider @unique\` + P2002 catch + re-read of the winner.
- Drop the 401-retry-with-re-register branches in both the callback exchange and the refresh path. Under a persisted client they would mint a fresh \`client_id\` and orphan every account at once instead of recovering anything.
- Capture (truncated, token-scrubbed) Granola response bodies on refresh non-2xx so the next failure tells us the actual OAuth error code instead of just an HTTP status.

## Test plan

- [x] Typecheck clean across all 17 monorepo packages
- [ ] Vitest run (\`pnpm --filter @brett/api test\`) — couldn't run locally (Docker daemon down); CI will execute
- [x] Verified Granola DCR non-idempotency live: two POSTs 1s apart returned \`client_01KSMXFK39P3JGSPCW61WJ3WVV\` and \`client_01KSMXFMEXTAPBY1E7735FMSSE\`
- [x] Migration is purely additive (CREATE TABLE + UNIQUE INDEX, no data movement)
- [ ] After deploy: reconnect both Granola accounts once via Settings → Granola (existing refresh tokens are bound to dead client_ids and cannot be resurrected)
- [ ] Confirm post-reconnect refresh works across a process restart (validates the fix end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)