### PR TITLE
fix: anchor Today urgency on user's timezone, not server UTC (#197)

### DIFF
--- a/apps/api/src/__tests__/things.test.ts
+++ b/apps/api/src/__tests__/things.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { createTestUser, authRequest } from "./helpers.js";
 import { app } from "../app.js";
 import { DEFAULT_LIST_NAME } from "@brett/business";
@@ -520,6 +520,69 @@ describe("GET /things?dueAfter", () => {
     expect(body.length).toBe(2);
     const titles = body.map((t: any) => t.title).sort();
     expect(titles).toEqual(["Past", "Today"]);
+  });
+});
+
+/**
+ * Regression test for issue #197 — at 18:31 MDT (= 00:31 UTC next day), a
+ * task due tomorrow MT was bucketed as `today` because the route handler
+ * called `itemToThing(item)` with no `timezone` argument. `computeUrgency`
+ * then fell back to the server-process clock (UTC on Railway), so it
+ * treated UTC's "today" as the user's "today".
+ *
+ * Fix: route handlers fetch `User.timezone` and thread it through every
+ * `itemToThing` / `itemToThingDetail` call.
+ *
+ * Assumes the test runner's TZ is UTC (the CI default). On a non-UTC dev
+ * box the assertion still holds with the fix in place; the regression-
+ * detection power is what depends on the runtime TZ.
+ */
+describe("GET /things — urgency anchors on the user's stored timezone", () => {
+  let token: string;
+  let userId: string;
+  let itemId: string;
+
+  beforeAll(async () => {
+    const u = await createTestUser("TZ Urgency User");
+    token = u.token;
+    userId = u.userId;
+    await prisma.user.update({
+      where: { id: userId },
+      data: { timezone: "America/Denver" },
+    });
+    // Create the item directly so signup/auth aren't running under fake
+    // timers — better-auth uses Date.now() for tokens and we don't want
+    // to introduce timer interactions across the unrelated setup steps.
+    const item = await prisma.item.create({
+      data: {
+        type: "task",
+        title: "TZ Urgency: tomorrow MT",
+        status: "active",
+        userId,
+        dueDate: new Date("2026-06-01T00:00:00Z"),
+        dueDatePrecision: "day",
+        source: "Brett",
+      },
+    });
+    itemId = item.id;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not bucket a Jun 1 MT task as 'today' at 18:31 MDT May 31 (= 00:31 UTC Jun 1)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true, toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-01T00:31:00Z"));
+
+    const res = await authRequest("/things?status=active", token);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ id: string; urgency: string }>;
+    const t = body.find((row) => row.id === itemId);
+    expect(t).toBeDefined();
+    // Pre-fix: server-clock anchored "today" => bucket = "today".
+    // Post-fix: MT anchored "today" (May 31, Sun) => Jun 1 Mon = "this_week".
+    expect(t!.urgency).not.toBe("today");
   });
 });
 

--- a/apps/api/src/routes/things.ts
+++ b/apps/api/src/routes/things.ts
@@ -14,6 +14,25 @@ import { getBrokenConnections } from "../lib/connection-health.js";
 
 const things = new Hono<AuthEnv>();
 
+/** Fallback timezone for users whose row was created before the User.timezone
+ *  field existed (defensive — the schema default is the same value). */
+const DEFAULT_TIMEZONE = "America/Los_Angeles";
+
+/**
+ * Fetch the authenticated user's IANA timezone. Threaded into every
+ * `itemToThing` / `itemToThingDetail` call so `computeUrgency` anchors on the
+ * user's local "today", not the server's UTC clock. Without this, items due
+ * tomorrow MT show up in the Today bucket once UTC rolls past midnight — see
+ * issue #197.
+ */
+async function getUserTimezone(userId: string): Promise<string> {
+  const u = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { timezone: true },
+  });
+  return u?.timezone ?? DEFAULT_TIMEZONE;
+}
+
 /** Enrich items with scout names for items where source === "scout" */
 async function enrichWithScoutNames<T extends { source: string; sourceId: string | null }>(items: T[]): Promise<(T & { scoutName?: string })[]> {
   const scoutIds = [...new Set(items.filter((i) => i.source === "scout" && i.sourceId).map((i) => i.sourceId!))];
@@ -29,7 +48,11 @@ async function enrichWithScoutNames<T extends { source: string; sourceId: string
   }));
 }
 
-async function itemToThingDetail(item: any): Promise<ThingDetail> {
+async function itemToThingDetail(
+  item: any,
+  now: Date = new Date(),
+  timezone?: string,
+): Promise<ThingDetail> {
   // Enrich scout-originated items with scout name + finding feedback (parallelized)
   let scoutFindingId: string | undefined;
   let scoutFeedbackUseful: boolean | null | undefined;
@@ -50,7 +73,7 @@ async function itemToThingDetail(item: any): Promise<ThingDetail> {
     }
   }
 
-  const thing = itemToThing(item);
+  const thing = itemToThing(item, now, timezone);
 
   const attachments: AttachmentType[] = await Promise.all(
     (item.attachments || []).map(async (a: any) => ({
@@ -272,7 +295,9 @@ things.get("/", async (c) => {
       });
 
   const enriched = await enrichWithScoutNames(items);
-  const thingsList = enriched.map((item) => itemToThing(item as any));
+  const timezone = await getUserTimezone(user.id);
+  const now = new Date();
+  const thingsList = enriched.map((item) => itemToThing(item as any, now, timezone));
   return c.json(thingsList);
 });
 
@@ -350,8 +375,10 @@ things.get("/inbox", async (c) => {
   });
 
   const enriched = await enrichWithScoutNames(items);
+  const timezone = await getUserTimezone(user.id);
+  const nowDate = new Date();
   return c.json({
-    visible: enriched.map((item) => itemToThing(item as any)),
+    visible: enriched.map((item) => itemToThing(item as any, nowDate, timezone)),
   });
 });
 
@@ -370,7 +397,8 @@ things.get("/:id", async (c) => {
   });
 
   if (!item) return c.json({ error: "Not found" }, 404);
-  return c.json(await itemToThingDetail(item));
+  const timezone = await getUserTimezone(user.id);
+  return c.json(await itemToThingDetail(item, new Date(), timezone));
 });
 
 // POST /things — create
@@ -409,7 +437,8 @@ things.post("/", async (c) => {
     include: { list: { select: { name: true } }, meetingNote: { select: { title: true, calendarEventId: true } } },
   });
 
-  const thing = itemToThing(item as any);
+  const timezone = await getUserTimezone(user.id);
+  const thing = itemToThing(item as any, new Date(), timezone);
 
   // Inline embedding + duplicate detection
   let duplicateCandidates: Array<{ id: string; title: string; similarity: number }> | undefined;
@@ -629,7 +658,8 @@ things.patch("/:id", async (c) => {
     await spawnNextRecurrence(item, item.linksFrom);
   }
 
-  return c.json(itemToThing(item as any));
+  const timezone = await getUserTimezone(user.id);
+  return c.json(itemToThing(item as any, new Date(), timezone));
 });
 
 // PATCH /things/:id/toggle — toggle completion
@@ -656,7 +686,8 @@ things.patch("/:id/toggle", async (c) => {
     await spawnNextRecurrence(existing, existing.linksFrom);
   }
 
-  return c.json(itemToThing(item as any));
+  const timezone = await getUserTimezone(user.id);
+  return c.json(itemToThing(item as any, new Date(), timezone));
 });
 
 // DELETE /things/:id

--- a/apps/desktop/src/hooks/__tests__/useTodayKey.test.tsx
+++ b/apps/desktop/src/hooks/__tests__/useTodayKey.test.tsx
@@ -19,7 +19,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useTodayKey } from "../useTodayKey";
+import { useTodayKey, todayKeyToBounds } from "../useTodayKey";
 
 describe("useTodayKey", () => {
   beforeEach(() => {
@@ -80,5 +80,69 @@ describe("useTodayKey", () => {
 
     expect(result.current).not.toBe(dayBefore);
     expect(result.current).toContain("2026-05-07");
+  });
+});
+
+/**
+ * Regression tests for issue #197 — Today view showed tomorrow tasks as
+ * today at 6:31pm MT. Pre-fix, the view derived its `dueBefore` /
+ * `completedAfter` / new-task `dueDate` from `getTodayUTC()` / `getEndOfWeekUTC()`,
+ * which anchor on the server-process UTC day. Replacing the anchor with
+ * `todayKeyToBounds` (local-key-derived) is the desktop side of the fix.
+ */
+describe("todayKeyToBounds", () => {
+  it("encodes the user's local calendar day as UTC midnight for storage", () => {
+    // Storage convention: dueDate is UTC midnight of the user's intended
+    // calendar date, regardless of the runtime timezone.
+    expect(todayKeyToBounds("2026-05-31").todayDueDateISO).toBe(
+      "2026-05-31T00:00:00.000Z",
+    );
+    expect(todayKeyToBounds("2026-01-01").todayDueDateISO).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("todayStartISO round-trips back to the same local calendar date", () => {
+    // `new Date(todayStartISO)` parsed back as local time must agree with
+    // the parts we constructed it from. Catches a stale "UTC midnight"
+    // anchor that would shift the calendar day for non-UTC runtimes.
+    const r = todayKeyToBounds("2026-05-31");
+    const d = new Date(r.todayStartISO);
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(4); // May (0-indexed)
+    expect(d.getDate()).toBe(31);
+  });
+
+  it("endOfWeekISO lands on the upcoming local Sunday for every weekday", () => {
+    // Walk a full week and assert the endOfWeek always reads as Sunday in
+    // local time. Independent of the runtime timezone — the helper computes
+    // the day-of-week locally, so the resulting Date's local getDay() === 0.
+    const days = [
+      "2026-05-25", // Mon
+      "2026-05-26", // Tue
+      "2026-05-27", // Wed
+      "2026-05-28", // Thu
+      "2026-05-29", // Fri
+      "2026-05-30", // Sat
+      "2026-05-31", // Sun
+    ];
+    for (const key of days) {
+      const dow = new Date(todayKeyToBounds(key).endOfWeekISO).getDay();
+      expect(dow).toBe(0);
+    }
+  });
+
+  it("Sunday's endOfWeek is the next Sunday (a full week out, not today)", () => {
+    // Without `dow === 0 ? 7 : 7 - dow`, Sunday would resolve to "0 days
+    // out" — i.e. dueBefore == today, hiding everything later in the week.
+    const r = todayKeyToBounds("2026-05-31"); // Sun
+    expect(r.endOfWeekISO).not.toBe(r.todayStartISO);
+    // Both anchors are local midnights, so the difference resolves to a
+    // multiple of 24h (modulo DST, which doesn't apply between May 31 and
+    // Jun 7). 7 days is the expected gap.
+    const startDate = new Date(r.todayStartISO);
+    const endDate = new Date(r.endOfWeekISO);
+    const days = Math.round((endDate.getTime() - startDate.getTime()) / 86_400_000);
+    expect(days).toBe(7);
   });
 });

--- a/apps/desktop/src/hooks/useTodayKey.ts
+++ b/apps/desktop/src/hooks/useTodayKey.ts
@@ -1,6 +1,40 @@
 import { useEffect, useState } from "react";
 import { useNow } from "@brett/ui";
 
+/**
+ * Date instants and storage-shape dueDate derived from a `useTodayKey`
+ * string. Colocated with the hook so every date-driven view (Today, Upcoming,
+ * the dock badge) reads bounds from one place and anchors on the user's local
+ * day rather than UTC.
+ *
+ * Returned values:
+ *   - `todayStartISO`   instant of local midnight TODAY — for filters like
+ *                       `completedAfter` that span from "now in this calendar
+ *                       day" forward.
+ *   - `endOfWeekISO`    instant of local midnight on the upcoming Sunday —
+ *                       for `dueBefore` on the Today view (this-week window).
+ *   - `todayDueDateISO` UTC midnight of the user's local calendar date —
+ *                       matches the storage convention for `Item.dueDate`
+ *                       (every dueDate is UTC midnight of the user's
+ *                       intended day). Use when creating a "today" task.
+ */
+export function todayKeyToBounds(todayKey: string): {
+  todayStartISO: string;
+  endOfWeekISO: string;
+  todayDueDateISO: string;
+} {
+  const [y, m, d] = todayKey.split("-").map(Number);
+  const todayStart = new Date(y, m - 1, d);
+  const dow = todayStart.getDay();
+  const daysUntilSunday = dow === 0 ? 7 : 7 - dow;
+  const endOfWeek = new Date(y, m - 1, d + daysUntilSunday);
+  return {
+    todayStartISO: todayStart.toISOString(),
+    endOfWeekISO: endOfWeek.toISOString(),
+    todayDueDateISO: new Date(Date.UTC(y, m - 1, d)).toISOString(),
+  };
+}
+
 /** Local-day identity in YYYY-MM-DD form, derived from the supplied Date. */
 function getLocalDayKey(d: Date = new Date()): string {
   const y = d.getFullYear();

--- a/apps/desktop/src/views/TodayView.tsx
+++ b/apps/desktop/src/views/TodayView.tsx
@@ -13,7 +13,6 @@ import {
 } from "@brett/ui";
 import type { OmnibarProps, NextUpTimerState } from "@brett/ui";
 import type { Thing, CalendarEventDisplay, NavList, FilterType } from "@brett/types";
-import { getTodayUTC, getEndOfWeekUTC } from "@brett/business";
 import {
   useActiveThings,
   useDoneThings,
@@ -23,7 +22,7 @@ import {
 import { useBriefing, useBriefingSummary } from "../api/briefing";
 import { usePreference } from "../api/preferences";
 import { useAutoUpdate } from "../hooks/useAutoUpdate";
-import { useTodayKey } from "../hooks/useTodayKey";
+import { useTodayKey, todayKeyToBounds } from "../hooks/useTodayKey";
 import { useLocalStorageBoolean } from "../lib/useLocalStorageBoolean";
 import { useTonightExpansion } from "../lib/useTonightAutoExpand";
 
@@ -73,18 +72,18 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
 
   // Date boundaries — recomputed when the user's LOCAL day rolls over so
   // tasks coming due today become visible without requiring an app reload.
-  // todayKey is just the rollover trigger; the actual UTC ISO bounds come
-  // straight from `getTodayUTC()` / `getEndOfWeekUTC()` so they stay correct
-  // independent of the key's string format.
+  // Bounds are derived from `todayKey` (YYYY-MM-DD in the user's local
+  // timezone) — UTC anchoring would mis-bucket items near the user's local
+  // midnight (see issue #197: 6:31pm MT showed tomorrow tasks as today).
   const todayKey = useTodayKey();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const dueBefore = useMemo(() => getEndOfWeekUTC(new Date()).toISOString(), [todayKey]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const completedAfter = useMemo(() => getTodayUTC().toISOString(), [todayKey]);
+  const { todayStartISO, endOfWeekISO, todayDueDateISO } = useMemo(
+    () => todayKeyToBounds(todayKey),
+    [todayKey],
+  );
 
   // Two explicit queries: active items due this week or earlier, done items from today
-  const { data: activeThings = [], isLoading: activeLoading } = useActiveThings(dueBefore);
-  const { data: doneThings = [], isLoading: doneLoading } = useDoneThings(completedAfter);
+  const { data: activeThings = [], isLoading: activeLoading } = useActiveThings(endOfWeekISO);
+  const { data: doneThings = [], isLoading: doneLoading } = useDoneThings(todayStartISO);
   const things = [...activeThings, ...doneThings];
   const thingsLoading = activeLoading || doneLoading;
 
@@ -97,7 +96,7 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
 
   const handleAddTask = (title: string, listId: string | null) => {
     createThing.mutate(
-      { type: "task", title, listId: listId ?? undefined, dueDate: getTodayUTC().toISOString(), dueDatePrecision: "day" },
+      { type: "task", title, listId: listId ?? undefined, dueDate: todayDueDateISO, dueDatePrecision: "day" },
       { onError: (err) => console.error("Failed to create thing:", err) }
     );
   };
@@ -111,7 +110,7 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
 
   const handleQuickAddContent = (url: string) => {
     createThing.mutate(
-      { type: "content", title: url, sourceUrl: url, dueDate: getTodayUTC().toISOString(), dueDatePrecision: "day" as const },
+      { type: "content", title: url, sourceUrl: url, dueDate: todayDueDateISO, dueDatePrecision: "day" as const },
       { onError: (err) => console.error("Failed to create thing:", err) }
     );
   };
@@ -149,7 +148,11 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
   }, [filteredThings]);
 
   const sections = useMemo(() => {
-    const dow = new Date().getUTCDay();
+    // Local day-of-week so the weekend/weekday ordering matches the user's
+    // wall clock, not UTC's. (UTC's day flips hours before/after a user's
+    // local midnight outside Greenwich.)
+    const [y, m, d] = todayKey.split("-").map(Number);
+    const dow = new Date(y, m - 1, d).getDay();
     const isWeekendNow = dow === 0 || dow === 6;
     const list: Array<{ key: string; title: string; count: number }> = [];
     if (grouped.overdue.length > 0) list.push({ key: "overdue", title: "Overdue", count: grouped.overdue.length });
@@ -172,7 +175,7 @@ export function TodayView({ lists, onItemClick, onTriageOpen, onFocusChange, omn
     }
     if (grouped.done.length > 0) list.push({ key: "done-today", title: "Done Today", count: grouped.done.length });
     return list;
-  }, [grouped]);
+  }, [grouped, todayKey]);
 
   // Per-section collapsed state. Persisted per-user via localStorage so
   // toggling a section, navigating away, and coming back retains the choice.


### PR DESCRIPTION
Closes #197

## Root cause

The Today section shows items whose `urgency === "today"`. `urgency` is computed server-side via `itemToThing(item)` → `computeUrgency(dueDate, completedAt, now, timezone?)`. **Every call site in `apps/api/src/routes/things.ts` was omitting the `timezone` argument**, so `computeUrgency` fell back to the server-process clock for "today" — which on Railway is UTC.

At 18:31 MDT (May 31) it is already 00:31 UTC (June 1). A task scheduled by the user for "tomorrow" (June 1 MT, stored as `2026-06-01T00:00:00Z` per the storage convention) matches UTC's "today" exactly and buckets as `today`. The detail-pane date picker reads the raw `dueDate` field and correctly displays "Tomorrow", which is why the user noticed the inconsistency — the same item rendered as both depending on whether the surface used `urgency` or `dueDate`.

The desktop client had a parallel bug: `TodayView` derived `dueBefore` / `completedAfter` / new-task `dueDate` from `getTodayUTC()` / `getEndOfWeekUTC()`, which are anchored on UTC the same way. Pre-existing `useUpcomingThings` already solved this with a `useTodayKey`-derived local pattern — this PR mirrors that.

## Approach

Three options considered:

1. **Make `timezone` a required param on `itemToThing` / `computeUrgency`.** Forces every caller to thread it. Catches the bug at compile time. Downside: blows up scope to AI skills (`packages/ai/src/skills/list-{today,upcoming,inbox,...}.ts`), which also forget to pass it — out of scope for one bug.
2. **Compute urgency client-side, ignore the server's value.** Big architectural shift; mobile (iOS) computes urgency in Swift already, so the server field is mostly desktop's concern. Still requires plumbing user TZ to the desktop urgency computation.
3. **(picked)** Thread `User.timezone` into all `itemToThing` calls in `apps/api/src/routes/things.ts`. Surgical, follows the existing `prisma.user.findUnique({ select: { timezone: true } })` pattern used in `routes/weather.ts`, `routes/calendar.ts`, `routes/users.ts`. Adds one Prisma roundtrip per request — same cost shape as those endpoints. The desktop client also stops UTC-anchoring its own `dueBefore` / `completedAfter` / new-task `dueDate` so freshly-created "today" tasks don't end up in the wrong bucket post-fix.

The desktop fix factors a tiny pure `todayKeyToBounds(todayKey)` helper alongside `useTodayKey` (since it's a pure function of that string), returning:
- `todayStartISO` — local midnight TODAY (for `completedAfter`)
- `endOfWeekISO` — local midnight upcoming Sunday (for `dueBefore`)
- `todayDueDateISO` — UTC midnight of user's calendar date, matching the storage convention (for new task `dueDate`)

Weekend ordering in `sections` also moved from `new Date().getUTCDay()` → local day-of-week, since UTC's weekday flips at the wrong hour for non-UK users.

## Tests

- `apps/api/src/__tests__/things.test.ts` — added a regression test that pins user TZ to `America/Denver`, fakes the system clock to `2026-06-01T00:31:00Z` (= 18:31 MDT May 31), creates a task due June 1 UTC midnight, and asserts the `GET /things` response does NOT bucket it as `today`. Catches the category of "route handler forgets to thread timezone into urgency computation". Assumes CI is UTC (the default) — on a non-UTC dev box the assertion still holds with the fix but loses regression-detection power.
- `apps/desktop/src/hooks/__tests__/useTodayKey.test.tsx` — added four tests for `todayKeyToBounds`: storage-convention `dueDate` shape, `todayStartISO` calendar-day round-trip, `endOfWeekISO` always-Sunday across all weekdays, and Sunday → next Sunday (not today). Timezone-agnostic — assertions hold regardless of runtime TZ.

The fix category caught by these tests: dates derived from UTC-anchored helpers when the user's local day differs from UTC's day. A future regression that swaps `todayKeyToBounds` back for `getTodayUTC` would fail every `todayKeyToBounds` assertion plus the API integration test.

## Self-review

- All six `itemToThing` / `itemToThingDetail` call sites in `routes/things.ts` updated. Verified via grep — no stale callers.
- `itemToThingDetail` accepts `now` and `timezone` defaults so any future caller continues to compile if they omit them, while every current caller now passes both.
- Desktop fix scoped to `TodayView`. `App.tsx:508`'s `getEndOfWeekUTC(new Date(todayKey))` was reviewed and is actually correct — `new Date(todayKey)` parses as UTC midnight of the local calendar day, so its weekday matches the user's. Left as-is.
- `provisionalThing` in `apps/desktop/src/api/things.ts:110` still calls `computeUrgency` without TZ for the optimistic insert. The server invalidation in `onSettled` overwrites it within one round-trip — not the reported bug, deliberate scope cut.
- AI skills (`packages/ai/src/skills/list-today.ts`, etc.) also call `itemToThing(item, now)` without TZ. Lower-priority surface (AI chat) and broader change — deliberate scope cut, callable as a follow-up.
- Sync route (`routes/sync.ts`) ships raw item rows to iOS which computes urgency in Swift — not affected.
- API changes are additive (more correct `urgency` values in existing response shapes). No breaking change for older desktop / iOS clients.

## Risks / follow-ups

- **Badge count has the same conceptual bug.** `apps/desktop/src/lib/badgeCount.ts` uses `now.getUTC*()` to compute end-of-today. At 18:31 MDT the badge over-counts by the tomorrow-MT items in the response. The file's comment requires iOS parity (`apps/ios/Brett/Views/Today/TodaySections.swift` `badgeCount`), so fixing it requires a synchronized Swift change. Deliberately left out of this PR. Worth a follow-up issue.
- **DB roundtrip per /things request** to fetch timezone. Same pattern as `/weather` and `/calendar`. If profiling flags it, the right move is request-scoped caching via middleware — broader refactor.

## Commands

- `pnpm typecheck` — passes (all 17 packages, full force run).
- `pnpm test` from `apps/desktop/` — 224 tests pass, including the four new `todayKeyToBounds` tests.
- `pnpm test` from `packages/business/` — 261 tests pass (no `itemToThing` / `computeUrgency` regressions).
- `apps/api/` tests require Postgres which isn't available in this sandbox; the new API regression test will run on CI.

Visual verification pending — `gh pr checkout 197` and exercise Today after 6pm MT in the Electron build.

---
_Generated by [Claude Code](https://claude.ai/code/session_017K9twDw41kkLPDV7Wjpd1g)_