### PR TITLE
fix: anchor calendar today pill on user's local day, not UTC (#200)

### DIFF
--- a/packages/ui/src/__tests__/quickPicker/ScrollableCalendar.test.tsx
+++ b/packages/ui/src/__tests__/quickPicker/ScrollableCalendar.test.tsx
@@ -2,10 +2,32 @@ import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { ScrollableCalendar } from "../../quickPicker/ScrollableCalendar";
+import {
+  ScrollableCalendar,
+  localDayUtcMidnight,
+} from "../../quickPicker/ScrollableCalendar";
 
 const MAY_7 = new Date(Date.UTC(2026, 4, 7));
 const MAY_15 = new Date(Date.UTC(2026, 4, 15));
+
+/**
+ * Construct a Date whose local components and UTC components disagree —
+ * the runtime shape of a real `new Date()` when the user is at, say,
+ * 11:30 PM MT on May 31 (local) which is 5:30 AM UTC on June 1 (UTC).
+ * Lets us assert the fix is TZ-independent — the unit test must catch
+ * the bug even when the test runner is in UTC (CI default).
+ */
+function dateWithLocalAndUtc(
+  local: { y: number; m: number; d: number },
+  utc: { y: number; m: number; d: number; h: number; min: number },
+): Date {
+  const real = new Date(Date.UTC(utc.y, utc.m, utc.d, utc.h, utc.min));
+  return Object.assign(real, {
+    getFullYear: () => local.y,
+    getMonth: () => local.m,
+    getDate: () => local.d,
+  });
+}
 
 describe("ScrollableCalendar", () => {
   it("renders the weekday header above the scroll region", () => {
@@ -84,6 +106,28 @@ describe("ScrollableCalendar", () => {
     expect(passed.toISOString().slice(0, 10)).toBe("2026-05-09");
   });
 
+  it("marks today using the user's LOCAL calendar day, not UTC's", () => {
+    // 11:30 PM MT on May 31, 2026 — UTC has already rolled to June 1.
+    const localMay31 = dateWithLocalAndUtc(
+      { y: 2026, m: 4, d: 31 },
+      { y: 2026, m: 5, d: 1, h: 5, min: 30 },
+    );
+    render(
+      <ScrollableCalendar
+        anchorDate={MAY_15}
+        highlightedDate={MAY_15}
+        selectedDate={null}
+        onHighlight={vi.fn()}
+        onCommit={vi.fn()}
+        monthsBefore={0}
+        monthsAfter={1}
+        now={localMay31}
+      />,
+    );
+    expect(screen.getByTestId("day-2026-05-31").dataset.today).toBe("true");
+    expect(screen.getByTestId("day-2026-06-01").dataset.today).toBe("false");
+  });
+
   it("fires onHighlight when a day cell is hovered", () => {
     const onHighlight = vi.fn();
     render(
@@ -102,5 +146,29 @@ describe("ScrollableCalendar", () => {
     expect(onHighlight).toHaveBeenCalled();
     const last = onHighlight.mock.calls.at(-1)![0] as Date;
     expect(last.toISOString().slice(0, 10)).toBe("2026-05-12");
+  });
+});
+
+describe("localDayUtcMidnight", () => {
+  it("returns UTC midnight of the user's LOCAL calendar day", () => {
+    // 11:30 PM MT on May 31 (local) = 5:30 AM UTC on June 1 (UTC).
+    const evening = dateWithLocalAndUtc(
+      { y: 2026, m: 4, d: 31 },
+      { y: 2026, m: 5, d: 1, h: 5, min: 30 },
+    );
+    expect(localDayUtcMidnight(evening).toISOString()).toBe(
+      "2026-05-31T00:00:00.000Z",
+    );
+  });
+
+  it("returns UTC midnight when local and UTC days agree", () => {
+    const utcMay7 = new Date(Date.UTC(2026, 4, 7, 12));
+    // For a UTC-constructed Date in the (typically UTC) test runner, local
+    // components match UTC components, so the result is May 7 UTC midnight.
+    // This guards against an accidental "always shift by N hours" regression.
+    const result = localDayUtcMidnight(utcMay7);
+    expect(result.getUTCHours()).toBe(0);
+    expect(result.getUTCMinutes()).toBe(0);
+    expect(result.getUTCSeconds()).toBe(0);
   });
 });

--- a/packages/ui/src/quickPicker/QuickDatePicker.tsx
+++ b/packages/ui/src/quickPicker/QuickDatePicker.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom";
 import { computeTriageResult, type TriageDatePreset } from "@brett/business";
 import type { DueDatePrecision } from "@brett/types";
-import { ScrollableCalendar } from "./ScrollableCalendar";
+import { localDayUtcMidnight, ScrollableCalendar } from "./ScrollableCalendar";
 import { useAnchoredPosition } from "./useAnchoredPosition";
 import {
   DATE_LETTER_TO_PRESET,
@@ -63,9 +63,6 @@ function addDays(d: Date, n: number): Date {
   return copy;
 }
 
-function startOfDayUTC(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-}
 
 export function QuickDatePicker({
   anchorEl,
@@ -77,7 +74,7 @@ export function QuickDatePicker({
   now,
   visible = true,
 }: QuickDatePickerProps) {
-  const today = useMemo(() => startOfDayUTC(now ?? new Date()), [now]);
+  const today = useMemo(() => localDayUtcMidnight(now ?? new Date()), [now]);
   const popoverRef = useRef<HTMLDivElement>(null);
   // Bumping `version` when `visible` flips forces useAnchoredPosition to
   // re-measure once popoverRef.current has actually been attached to the DOM

--- a/packages/ui/src/quickPicker/ScrollableCalendar.tsx
+++ b/packages/ui/src/quickPicker/ScrollableCalendar.tsx
@@ -51,6 +51,17 @@ const MONTH_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
+/**
+ * UTC midnight of the user's LOCAL calendar day. Day cells in the grid are
+ * UTC-midnight Dates, and `isoDay` compares via `toISOString()` (UTC). Using
+ * `new Date()` (or any local-time Date) directly leaks the UTC-offset hours
+ * into the comparison — for any user whose local day differs from UTC's day
+ * the today pill lands on the wrong cell.
+ */
+export function localDayUtcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+}
+
 export function ScrollableCalendar({
   anchorDate,
   highlightedDate,
@@ -61,7 +72,7 @@ export function ScrollableCalendar({
   monthsAfter = 24,
   now,
 }: ScrollableCalendarProps) {
-  const today = useMemo(() => now ?? new Date(), [now]);
+  const today = useMemo(() => localDayUtcMidnight(now ?? new Date()), [now]);
   const months = useMemo(
     () => buildMonths(anchorDate, monthsBefore, monthsAfter),
     [anchorDate, monthsBefore, monthsAfter],


### PR DESCRIPTION
Closes #200

## Root cause

The "today pill" the bug refers to is the gold ring inside `ScrollableCalendar.tsx` — the calendar popup that opens when you set a date on a task (e.g. from the Today view's triage flow). The breadcrumb class `button.text-[10px].rounded-[3px]` in the bug report matches `ScrollableCalendar.tsx:173` exactly.

Inside that component, day cells are constructed as `new Date(Date.UTC(year, month, day))` — UTC midnight — and `sameDay` compares them via `isoDay`, which calls `toISOString().slice(0, 10)` (also UTC). But `today` was just `now ?? new Date()` — a raw local-time Date. When the user is at 6:31 PM MT (May 31), `new Date().toISOString()` returns `2026-06-01T00:31:00.000Z`, so `isoDay(today)` is `"2026-06-01"`. The pill ends up on June 1 (tomorrow in MT) instead of May 31.

The same bug shape exists in `QuickDatePicker.tsx`'s `startOfDayUTC`, which used `getUTCFullYear() / getUTCMonth() / getUTCDate()` — UTC components of a local-time Date — and seeded the `highlighted` calendar state with the off-by-one date. Initial-highlight selection therefore opened on the wrong day too.

This is the same category of TZ-confusion bug as #197 (Today-section urgency anchored on UTC). Different surface, same root cause: comparing a local-time Date to a UTC-anchored Date.

## Approach

Three options considered:

1. **Change `isoDay` to use local components.** Would require also changing `daysInMonth` to construct local-time Dates instead of UTC-midnight ones, since otherwise `getDate()` returns the wrong day for a UTC-midnight Date in any TZ west of UTC. Touches the `onCommit(d)` and `onHighlight(d)` callback contract — downstream callers (and the storage convention for `dueDate`) expect UTC-midnight. Out of scope.
2. **Accept an explicit `timezone` prop and use `Intl.DateTimeFormat` to compute the user's calendar day.** More correct in edge cases (server-rendered scenarios where system TZ ≠ user TZ), but Brett's desktop client always runs in the user's system TZ, so this is over-engineering for a pure-client surface.
3. **(picked)** Normalize `today` to UTC-midnight of the user's **local** calendar day via `localDayUtcMidnight(d) = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))`. Minimal, scoped, matches the existing `isoDay`-via-UTC convention used everywhere else in the component. Helper is exported from `ScrollableCalendar.tsx` and reused by `QuickDatePicker.tsx` so both call sites share the same anchor.

Note: `QuickDatePicker.tsx:184-187` already had a comment acknowledging this exact TZ trap for `ChipColumn` ("preset sublabels reflect the user's local calendar day"). The same lesson now applies to the calendar grid and the initial-highlighted-date seed.

## Tests

- `packages/ui/src/__tests__/quickPicker/ScrollableCalendar.test.tsx` — added three tests:
  - `marks today using the user's LOCAL calendar day, not UTC's` — renders `ScrollableCalendar` with a `now` whose local components are May 31 and UTC components are June 1 (simulating 11:30 PM MT on May 31). Asserts `day-2026-05-31` has `data-today="true"` and `day-2026-06-01` has `data-today="false"`.
  - `localDayUtcMidnight returns UTC midnight of the user's LOCAL calendar day` — same mock-Date setup, asserts the returned `toISOString()` is `2026-05-31T00:00:00.000Z`. Catches a regression where a future refactor swaps the local component getters back to UTC ones.
  - `localDayUtcMidnight returns UTC midnight when local and UTC days agree` — guards against an accidental "always shift N hours" regression.
- Helper `dateWithLocalAndUtc(local, utc)` in the test file constructs a Date whose local and UTC components disagree by overriding `getFullYear/getMonth/getDate`. Lets the assertion catch the bug regardless of the test runner's TZ — without this, CI's UTC TZ would hide the failure.

The fix category caught: comparing a local-time Date to a UTC-anchored Date inside calendar / date-bucket logic. A future regression that swaps `localDayUtcMidnight` back to `now ?? new Date()` fails the integration test; one that uses UTC-component getters fails the first helper test.

UI-styling-only changes weren't added — the bug is logic, not pixels, so logic tests are appropriate.

## Self-review

- All three call sites for "what's today's calendar day in the user's TZ" inside `quickPicker/` now route through `localDayUtcMidnight`. Verified via grep — no stale `new Date()`-direct comparisons remain in this surface.
- Confirmed the keyboard navigation in `QuickDatePicker` (`addDays(d, 7)` etc.) still works: `addDays` uses `setUTCDate`, `d` is UTC-midnight, so adding N UTC days is the same as N local days regardless of TZ. No behavioral change there.
- Confirmed `daysInMonth` still constructs UTC-midnight Dates — the `onCommit(d, "day", false)` callback contract is unchanged, so downstream `dueDate` storage (the `T00:00:00Z` convention) is preserved.
- Confirmed the existing `marks the selected date with the selected attr and today with the today attr` test still passes — it passes `MAY_7 = new Date(Date.UTC(2026, 4, 7))` as `now`. In UTC CI, `MAY_7.getFullYear()/getMonth()/getDate()` returns 2026/4/7, and `Date.UTC(2026, 4, 7)` round-trips to the same instant. In a non-UTC test runner, the existing test was already TZ-dependent (would have broken pre-fix in west-of-UTC TZs too); the fix doesn't worsen that. CI is UTC, so the test stays green.
- Confirmed `CalendarMonthView` / `CalendarWeekView` / `CalendarDayView` are NOT affected — they compare via `getFullYear/getMonth/getDate` (local components) on both sides of `isSameDay`, so they were already TZ-correct. Verified by re-reading each.
- Searched for other consumers of `startOfDayUTC` — only `QuickDatePicker.tsx`. Function is deleted cleanly.
- No backwards-compat concerns: this is a pure-renderer fix. iOS has its own date picker and isn't affected.

## Commands

- `pnpm --filter @brett/ui test` — passes (142 tests, 8 in `ScrollableCalendar.test.tsx` including the 3 new ones).
- `pnpm --filter @brett/ui typecheck` — passes after building `@brett/types`, `@brett/business`, `@brett/utils` (TS6305 errors on raw `@brett/ui` typecheck are pre-existing on `main` and disappear once project-reference deps are built).
- `pnpm --filter @brett/desktop typecheck` — passes (both renderer and electron-process tsconfigs).
- `pnpm typecheck` at the root fails on a pre-existing `@brett/api-core/src/prisma.ts` Prisma client-generation error that exists on `main` and is unrelated to this PR (verified by reproducing on `main`).

## Risks / follow-ups

- Low risk. Pure rendering / comparison fix. Existing storage convention (UTC-midnight `dueDate`) unchanged.
- Visual verification pending — `gh pr checkout 200` in the Electron build, open any task's date picker after 6 PM MT or before 6 AM MT, and confirm the gold ring is on today's cell (not tomorrow's). Also confirm the initial keyboard cursor opens on today.
- Related but out of scope: the same category of bug was fixed for the Today-section urgency anchoring in PR #198. The "fix locally, not UTC" pattern likely applies to other surfaces too (AI skills `list-today.ts`, badge count) — that's the follow-up scope #198 already called out.

---
_Generated by [Claude Code](https://claude.ai/code/session_017K9twDw41kkLPDV7Wjpd1g)_