### PR TITLE
fix: defer crossfade opacity flip so bg-return actually fades (#199)

### DIFF
--- a/apps/desktop/src/hooks/useBackground.ts
+++ b/apps/desktop/src/hooks/useBackground.ts
@@ -128,6 +128,7 @@ export function useBackground({
   // be now.
   const categoryRef = useRef({ segment, busynessTier, backgroundStyle });
   const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRafRef = useRef<number | null>(null);
 
   const slotKeyFor = (style: BackgroundStyle, seg: TimeSegment, tier: BusynessTier) =>
     `${style}/${seg}/${tier}`;
@@ -140,17 +141,33 @@ export function useBackground({
       clearTimeout(transitionTimeoutRef.current);
       transitionTimeoutRef.current = null;
     }
+    if (pendingRafRef.current !== null) {
+      cancelAnimationFrame(pendingRafRef.current);
+      pendingRafRef.current = null;
+    }
   };
 
-  // Finalize a crossfade after CROSSFADE_MS
+  // Finalize a crossfade after CROSSFADE_MS. Two-step state update: paint
+  // Layer B with the new image at opacity 0 first (set by the caller via
+  // setNextImage), then flip opacity to 1 in a second frame. Without the
+  // double rAF the src change and the opacity change land in the same paint
+  // and the browser skips the CSS transition — visible as a flash instead
+  // of a fade, especially on visibilitychange-triggered rotations where the
+  // next image is already in the browser cache and onload fires in the
+  // same task as the visibility flip.
   const startCrossfade = (onComplete: () => void) => {
     cancelTransition();
-    setIsTransitioning(true);
-    transitionTimeoutRef.current = setTimeout(() => {
-      onComplete();
-      setIsTransitioning(false);
-      transitionTimeoutRef.current = null;
-    }, CROSSFADE_MS);
+    pendingRafRef.current = requestAnimationFrame(() => {
+      pendingRafRef.current = requestAnimationFrame(() => {
+        pendingRafRef.current = null;
+        setIsTransitioning(true);
+        transitionTimeoutRef.current = setTimeout(() => {
+          onComplete();
+          setIsTransitioning(false);
+          transitionTimeoutRef.current = null;
+        }, CROSSFADE_MS);
+      });
+    });
   };
 
   const rotateImage = () => {


### PR DESCRIPTION
Closes #199

## Root cause

The dual-layer crossfade in `apps/desktop/src/hooks/useBackground.ts` runs the swap inside `img.onload`:

```ts
img.onload = () => {
  …
  setNextImage(fullUrl);
  startCrossfade(() => {
    setCurrentImage(fullUrl);
    setNextImage(null);
  });
};
```

`setNextImage(fullUrl)` re-renders Layer B with the new image, and `startCrossfade` immediately calls `setIsTransitioning(true)`. React 19 batches both updates into a single commit. The browser sees Layer B's style go from `{src=OLD, opacity=0}` to `{src=NEW, opacity=1}` in one paint — the CSS opacity transition (3000ms ease-in-out) is then skipped and Layer B flashes in instantly.

The bug is most reproducible on returning from a backgrounded window because:
1. The `visibilitychange → "visible"` handler fires `checkSegment()` synchronously.
2. If the segment changed while hidden, `rotateImage()` runs immediately.
3. The browser cache already has the next-segment image (preloaded via the boundary preloader effect), so `img.onload` fires in the same microtask.
4. React commits the batched updates before the renderer has a chance to paint Layer B at opacity 0 with the new src — the "from" state of the fade is never visible.

The user reported: "I opened brett after being backgrounded. It just flashed to a new one, it didn't crossfade. Always crossfade in every scenario of a bg changing." This is exactly the above path.

## Approach

Three options considered:

1. **Use `flushSync` to force the `setNextImage` commit first.** Forces React's commit but doesn't guarantee a browser PAINT before the next state update. Browsers can still combine paints; transition can still be skipped.
2. **Add `requestAnimationFrame` inside the `visibilitychange` handler** so rotation kicks off in the next frame after the page becomes visible. Targeted to the reported scenario but doesn't fix the same race on `style-change → rotateImage` or `devNext` — the user's "Always crossfade in every scenario" implies a general fix.
3. **(picked)** Defer `setIsTransitioning(true)` inside `startCrossfade` itself by two `requestAnimationFrame` hops. After `setNextImage` commits, Layer B paints at opacity 0 with the new src. The first rAF schedules the second; the second rAF runs after the browser has painted that "before" frame; then `setIsTransitioning(true)` runs and the browser sees a clean opacity 0 → 1 transition. Double rAF is the canonical CSS-transition kickoff pattern — single rAF can race against React's commit because rAF callbacks fire before the next paint, not after. Centralizing the fix in `startCrossfade` automatically covers `devNext` too, and any future caller.

I also added rAF tracking + cancellation in `cancelTransition` so a new rotation (or any other caller that needs to preempt) cleanly cancels a pending one — without this, a rapid back-to-back rotation could leave an orphan rAF that flips `isTransitioning` mid-flight.

## Tests

UI / timing change — no automated test added. Reason: a meaningful test would either mock `requestAnimationFrame` and assert `setIsTransitioning` is deferred by two frames (which just mirrors the implementation) or render the component and snapshot opacity changes over time (flaky, mocks half the renderer, and `useBackground` has no existing test scaffolding — would mean mocking config / manifest / `useVisibilityAwareInterval` / `userStorage`). The user-facing behavior — "Layer B actually fades in over 3 seconds instead of flashing" — is a visual invariant best verified in the running app.

Could a pragmatic test have caught the original bug? Not really — the race is between React's commit cycle and the browser's paint cycle, which JSDOM doesn't simulate. The CSS transition skip-on-batched-commit behavior only manifests in a real browser. Documenting this in the PR body so the next agent doesn't add a fake test.

Verify visually via `gh pr checkout 199` and either:
- Background the window during one wallpaper segment, wait long enough to cross a segment boundary, return — confirm fade.
- Or trigger a rotation via the dev `devNext()` from the wallpaper control to see the same crossfade path.

## Self-review

- All callers of `startCrossfade` (`rotateImage` and `devNext`) benefit from the fix — the deferral is internal to `startCrossfade`, so no caller had to change. Verified via grep.
- The first-load atomic-swap branch (`!hasLoadedImageRef.current → setCurrentImage` then early-return) is unaffected — it never calls `startCrossfade`, so the Ken Burns reveal still runs without an extra fade stomping on it.
- `cancelTransition` now cancels both the timeout AND the pending rAF, so a rotation interrupting another rotation cleanly preempts. Without the rAF cancel, an orphan rAF from the previous rotation would still flip `isTransitioning` after the new rotation already committed its own state.
- The user is reading state from `categoryRef.current.segment` at the moment of the rotation, not via a stale closure. The rAF deferral doesn't introduce a stale-closure bug because `setIsTransitioning`/`setCurrentImage` close over the current `setState` setters (which are stable refs from React) and the URL is captured in `fullUrl` from `rotateImage`'s scope.
- Pinned background path (`pinnedBackground != null` early return at line 372–401) still bypasses crossfade entirely — that's a separate UX gap (changing pin = instant swap) that is out of scope and would require shape-shifting the pinned return value to carry a `nextImageUrl`. Worth a follow-up issue if pinned-background-change flashes also bother the user.
- No new dependencies. `requestAnimationFrame` / `cancelAnimationFrame` are browser-native. The fix is renderer-only — no Electron main-process change.
- No backwards-compat risk. Behavioral change is "transition takes ~32 ms longer to START" (two rAF hops); user-imperceptible.
- iOS is unaffected — it has its own `BackgroundService` with explicit pause/resume on `scenePhase` change (see `apps/ios/Brett/Views/MainContainer.swift:318-336`).

## Commands

- `pnpm --filter @brett/desktop typecheck` — passes (both renderer and `tsconfig.electron.json`).
- `pnpm --filter @brett/desktop test` — passes (220 tests, no regressions).
- `pnpm typecheck` at the root fails on a pre-existing `@brett/api-core/src/prisma.ts` Prisma client-generation error that exists on `main` and is unrelated to this PR.

## Risks / follow-ups

- Low risk. Pure timing change in one hook, one function.
- The pinned-background path (`pinnedBackground != null`) still does an instant swap with no fade because it short-circuits the dual-layer state. If `Always crossfade in every scenario` is meant literally, follow-up is to shape the pinned return value to carry `nextImageUrl` and route through the same dual-layer rendering. Out of scope for this bug — would touch `pinnedBackground` plumbing in `LivingBackground`, `useAppConfig`, and the settings UI.
- The first-image atomic swap (line 218–223) intentionally bypasses the fade so the App-level Ken Burns reveal isn't stomped. Documented in-line, not changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_017K9twDw41kkLPDV7Wjpd1g)_